### PR TITLE
fix: enforce plan-based access for tables across sidebar, guards, and api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,10 @@ jobs:
         run: npm ci --omit=dev
 
       - name: Audit production dependencies
-        run: npm run audit:prod
+        run: |
+          trap 'mv package-lock.ci.backup package-lock.json' EXIT
+          mv package-lock.json package-lock.ci.backup
+          npm run audit:prod
 
   secrets-scan:
     name: Secrets Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
   dependency-audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -88,13 +87,12 @@ jobs:
   filesystem-scan:
     name: Filesystem Vulnerability Scan
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,11 @@ jobs:
 
       - name: Audit production dependencies
         run: |
-          trap 'mv package-lock.ci.backup package-lock.json' EXIT
-          mv package-lock.json package-lock.ci.backup
-          npm run audit:prod
+          mkdir audit-prod
+          node -e "const fs=require('fs'); const pkg=require('./package.json'); const prodPkg={name:pkg.name, version:pkg.version, private:true, dependencies:pkg.dependencies ?? {}}; fs.writeFileSync('audit-prod/package.json', JSON.stringify(prodPkg, null, 2));"
+          cd audit-prod
+          npm install --package-lock-only
+          npm audit --omit=dev
 
   secrets-scan:
     name: Secrets Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install production dependencies
+        run: npm ci --omit=dev
+
       - name: Install Trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | \
             sh -s -- -b /usr/local/bin
 
       - name: Run Trivy filesystem scan
-        run: trivy fs --format table --exit-code 1 --ignore-unfixed --severity CRITICAL,HIGH .
+        run: trivy fs --format table --exit-code 1 --ignore-unfixed --severity CRITICAL,HIGH node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --omit=dev
 
       - name: Audit production dependencies
         run: npm run audit:prod
@@ -91,12 +91,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | \
+            sh -s -- -b /usr/local/bin
+
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.28.0
-        with:
-          scan-type: fs
-          scan-ref: .
-          format: table
-          exit-code: 1
-          ignore-unfixed: true
-          severity: CRITICAL,HIGH
+        run: trivy fs --format table --exit-code 1 --ignore-unfixed --severity CRITICAL,HIGH .

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import Link from 'next/link'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import Link from 'next/link'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'

--- a/app/(dashboard)/usuarios/page.tsx
+++ b/app/(dashboard)/usuarios/page.tsx
@@ -1,15 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import PaginationControls from '@/components/shared/PaginationControls'
 import { useUser } from '@/features/auth/hooks/useUser'
 import {
   useCreateUser,
@@ -19,11 +10,7 @@ import {
   type TeamUser,
 } from '@/features/users/hooks/useUsers'
 import { UsersPageContent } from '@/features/users/UsersPageContent'
-import {
-  type EstablishmentRole,
-  formatRoleLabel,
-  ROLE_LABELS,
-} from '@/lib/rbac'
+import { type EstablishmentRole } from '@/lib/rbac'
 import { toast } from 'sonner'
 import {
   canManageTeamUser,

--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from 'react'
 import { useCreateOrder } from '@/features/orders/hooks/useOrders'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import type { CartItem, CustomerAddress } from '@/features/orders/types'
 import { toast } from 'sonner'
 import {

--- a/app/admin/tenants/page.tsx
+++ b/app/admin/tenants/page.tsx
@@ -1,8 +1,6 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import Link from 'next/link'
-import { Button } from '@/components/ui/button'
 import {
   buildAdminTenantFilterSummary,
   buildAdminTenantCards,

--- a/app/api/tables/[id]/route.ts
+++ b/app/api/tables/[id]/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server'
+import { requireTenantFeature } from '@/lib/auth-guards'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -13,7 +13,9 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const supabase = await createClient()
+    const auth = await requireTenantFeature('tables', ['owner', 'manager', 'cashier'])
+    if (!auth.ok) return auth.response
+    const { supabase } = auth
     const { id } = await params
     const body = await request.json()
     const parsed = updateSchema.safeParse(body)
@@ -54,7 +56,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const supabase = await createClient()
+    const auth = await requireTenantFeature('tables', ['owner', 'manager', 'cashier'])
+    if (!auth.ok) return auth.response
+    const { supabase } = auth
     const { id } = await params
 
     // Verifica se tem sessão aberta

--- a/app/api/tables/route.ts
+++ b/app/api/tables/route.ts
@@ -1,4 +1,4 @@
-import { requireTenantRoles } from '@/lib/auth-guards'
+import { requireTenantFeature } from '@/lib/auth-guards'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
@@ -10,7 +10,7 @@ const tableSchema = z.object({
 
 export async function GET() {
   try {
-    const auth = await requireTenantRoles(['owner', 'manager', 'cashier'])
+    const auth = await requireTenantFeature('tables', ['owner', 'manager', 'cashier'])
     if (!auth.ok) return auth.response
     const { supabase, profile } = auth
 
@@ -58,7 +58,7 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
-    const auth = await requireTenantRoles(['owner', 'manager', 'cashier'])
+    const auth = await requireTenantFeature('tables', ['owner', 'manager', 'cashier'])
     if (!auth.ok) return auth.response
     const { supabase, profile } = auth
     const body = await request.json()

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "shadcn/tailwind.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/features/auth/components/DashboardAccessGuard.tsx
+++ b/features/auth/components/DashboardAccessGuard.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useUser } from '@/features/auth/hooks/useUser'
 import { canAccessDashboardPath } from '@/lib/rbac'
+import type { Plan } from '@/features/plans/types'
 
 export default function DashboardAccessGuard({
   children,
@@ -13,8 +14,9 @@ export default function DashboardAccessGuard({
   const pathname = usePathname()
   const router = useRouter()
   const { user, loading } = useUser()
+  const plan = (user?.profile.tenant?.plan as Plan | null | undefined) ?? null
 
-  const canAccess = canAccessDashboardPath(user?.profile.role, pathname)
+  const canAccess = canAccessDashboardPath(user?.profile.role, pathname, plan)
 
   useEffect(() => {
     if (!loading && !canAccess) {

--- a/features/auth/components/Sidebar.tsx
+++ b/features/auth/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { usePlan } from '@/features/plans/hooks/usePlan'
-import { PLAN_LABELS } from '@/features/plans/types'
+import { hasPlanFeature, PLAN_LABELS, type PlanFeature } from '@/features/plans/types'
 import {
   LayoutDashboard, Package, ArrowLeftRight,
   UtensilsCrossed, ClipboardList, BarChart2,
@@ -14,19 +14,19 @@ import {
 
 const navItems = [
   { href: '/dashboard',   label: 'Início',      icon: LayoutDashboard, roles: ['owner', 'manager', 'cashier'] },
-  { href: '/categorias',  label: 'Categorias',  icon: Tag,             roles: ['owner', 'manager'] },
-  { href: '/produtos',    label: 'Produtos',    icon: Package,         roles: ['owner', 'manager'] },
-  { href: '/estoque',     label: 'Estoque',     icon: ArrowLeftRight,  roles: ['owner', 'manager'] },
-  { href: '/cardapio',    label: 'Cardápio',    icon: UtensilsCrossed, roles: ['owner', 'manager'] },
-  { href: '/extras',      label: 'Adicionais',  icon: Settings,        roles: ['owner', 'manager'] },
-  { href: '/pedidos',     label: 'Pedidos',     icon: ClipboardList,   roles: ['owner', 'manager', 'cashier', 'kitchen'] },
-  { href: '/entregadores',label: 'Entregadores',icon: Bike,            roles: ['owner', 'manager', 'cashier'] },
-  { href: '/comandas',    label: 'Comandas',    icon: ReceiptText,     roles: ['owner', 'manager', 'cashier'] },
-  { href: '/mesas',       label: 'Mesas',       icon: LayoutGrid,      roles: ['owner', 'manager', 'cashier'] },
-  { href: '/kds',         label: 'Cozinha',     icon: MonitorCheck,    roles: ['owner', 'manager', 'kitchen'] },
-  { href: '/vendas',      label: 'Vendas',      icon: BarChart2,       roles: ['owner', 'manager'] },
-  { href: '/integracoes', label: 'Integrações', icon: PlugZap,         roles: ['owner'] },
-  { href: '/usuarios',    label: 'Usuários',    icon: Users,           roles: ['owner'] },
+  { href: '/categorias',  label: 'Categorias',  icon: Tag,             roles: ['owner', 'manager'], feature: 'menu' as PlanFeature },
+  { href: '/produtos',    label: 'Produtos',    icon: Package,         roles: ['owner', 'manager'], feature: 'menu' as PlanFeature },
+  { href: '/estoque',     label: 'Estoque',     icon: ArrowLeftRight,  roles: ['owner', 'manager'], feature: 'stock' as PlanFeature },
+  { href: '/cardapio',    label: 'Cardápio',    icon: UtensilsCrossed, roles: ['owner', 'manager'], feature: 'menu' as PlanFeature },
+  { href: '/extras',      label: 'Adicionais',  icon: Settings,        roles: ['owner', 'manager'], feature: 'menu' as PlanFeature },
+  { href: '/pedidos',     label: 'Pedidos',     icon: ClipboardList,   roles: ['owner', 'manager', 'cashier', 'kitchen'], feature: 'orders' as PlanFeature },
+  { href: '/entregadores',label: 'Entregadores',icon: Bike,            roles: ['owner', 'manager', 'cashier'], feature: 'orders' as PlanFeature },
+  { href: '/comandas',    label: 'Comandas',    icon: ReceiptText,     roles: ['owner', 'manager', 'cashier'], feature: 'tables' as PlanFeature },
+  { href: '/mesas',       label: 'Mesas',       icon: LayoutGrid,      roles: ['owner', 'manager', 'cashier'], feature: 'tables' as PlanFeature },
+  { href: '/kds',         label: 'Cozinha',     icon: MonitorCheck,    roles: ['owner', 'manager', 'kitchen'], feature: 'kds' as PlanFeature },
+  { href: '/vendas',      label: 'Vendas',      icon: BarChart2,       roles: ['owner', 'manager'], feature: 'sales' as PlanFeature },
+  { href: '/integracoes', label: 'Integrações', icon: PlugZap,         roles: ['owner'], feature: 'payments' as PlanFeature },
+  { href: '/usuarios',    label: 'Usuários',    icon: Users,           roles: ['owner'], feature: 'team' as PlanFeature },
   { href: '/planos',      label: 'Planos',      icon: CreditCard,      roles: ['owner'] },
 ]
 
@@ -48,7 +48,10 @@ export default function Sidebar({ profile }: Props) {
   const pathname = usePathname()
   const { data: plan } = usePlan()
   const allowedNavItems = navItems.filter((item) =>
-    profile?.role ? item.roles.includes(profile.role) : false
+    profile?.role
+      ? item.roles.includes(profile.role) &&
+        (!item.feature || !plan?.plan || hasPlanFeature(plan.plan, item.feature))
+      : false
   )
 
   return (

--- a/features/menu/MenuDashboardPageContent.tsx
+++ b/features/menu/MenuDashboardPageContent.tsx
@@ -7,7 +7,6 @@ import { MenuDashboardFilters } from '@/features/menu/MenuDashboardFilters'
 import { MenuDashboardEmptyState } from '@/features/menu/MenuDashboardEmptyState'
 import { MenuDashboardTable } from '@/features/menu/MenuDashboardTable'
 import { MenuItemDialog } from '@/features/menu/MenuItemDialog'
-import type { MenuItemIngredient } from '@/features/menu/dashboard-menu-page'
 
 type Props = {
   availableCount: number

--- a/features/menu/PublicMenuPageShell.tsx
+++ b/features/menu/PublicMenuPageShell.tsx
@@ -1,4 +1,3 @@
-import type { CartItem } from '@/features/orders/types'
 import type {
   MenuExtra,
   PublicMenuItem,

--- a/features/orders/OrderCard.tsx
+++ b/features/orders/OrderCard.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import type { DeliveryStatus, Order } from '@/features/orders/types'
 import {

--- a/features/orders/OrdersListSection.tsx
+++ b/features/orders/OrdersListSection.tsx
@@ -2,7 +2,7 @@ import PaginationControls from '@/components/shared/PaginationControls'
 import { OrdersEmptyState } from '@/features/orders/OrdersEmptyState'
 import { OrderCard } from '@/features/orders/OrderCard'
 import { getOrdersTotalPages, orderStatusConfig } from '@/features/orders/orders-page'
-import type { DeliveryStatus, Order } from '@/features/orders/types'
+import type { Order } from '@/features/orders/types'
 
 export function OrdersListSection({
   isLoading,

--- a/features/plans/types.ts
+++ b/features/plans/types.ts
@@ -77,7 +77,7 @@ export const PLAN_FEATURES: Record<Plan, string[]> = {
 }
 
 export const PLAN_INCLUDED_FEATURES: Record<Plan, PlanFeature[]> = {
-  free: ['orders', 'menu', 'tables', 'payments', 'team'],
+  free: ['orders', 'menu', 'payments', 'team'],
   basic: ['orders', 'menu', 'tables', 'kds', 'stock', 'stock_automation', 'sales', 'payments', 'whatsapp_notifications', 'team'],
   pro: ['orders', 'menu', 'tables', 'kds', 'stock', 'stock_automation', 'sales', 'payments', 'whatsapp_notifications', 'team', 'reports', 'white_label'],
 }

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -1,4 +1,4 @@
-import type { Plan } from '@/features/plans/types'
+import { hasPlanFeature, type Plan, type PlanFeature } from '@/features/plans/types'
 
 export type EstablishmentRole = 'owner' | 'manager' | 'cashier' | 'kitchen'
 
@@ -41,19 +41,19 @@ export const PLAN_MAX_USERS: Record<Plan, number> = {
 
 export const DASHBOARD_ROUTE_ROLES = [
   { path: '/dashboard', roles: ['owner', 'manager', 'cashier'] as EstablishmentRole[] },
-  { path: '/categorias', roles: ['owner', 'manager'] as EstablishmentRole[] },
-  { path: '/produtos', roles: ['owner', 'manager'] as EstablishmentRole[] },
-  { path: '/estoque', roles: ['owner', 'manager'] as EstablishmentRole[] },
-  { path: '/cardapio', roles: ['owner', 'manager'] as EstablishmentRole[] },
-  { path: '/extras', roles: ['owner', 'manager'] as EstablishmentRole[] },
-  { path: '/pedidos', roles: ['owner', 'manager', 'cashier', 'kitchen'] as EstablishmentRole[] },
-  { path: '/entregadores', roles: ['owner', 'manager', 'cashier'] as EstablishmentRole[] },
-  { path: '/comandas', roles: ['owner', 'manager', 'cashier'] as EstablishmentRole[] },
-  { path: '/mesas', roles: ['owner', 'manager', 'cashier'] as EstablishmentRole[] },
-  { path: '/kds', roles: ['owner', 'manager', 'kitchen'] as EstablishmentRole[] },
-  { path: '/vendas', roles: ['owner', 'manager'] as EstablishmentRole[] },
-  { path: '/integracoes', roles: ['owner'] as EstablishmentRole[] },
-  { path: '/usuarios', roles: ['owner'] as EstablishmentRole[] },
+  { path: '/categorias', roles: ['owner', 'manager'] as EstablishmentRole[], feature: 'menu' as PlanFeature },
+  { path: '/produtos', roles: ['owner', 'manager'] as EstablishmentRole[], feature: 'menu' as PlanFeature },
+  { path: '/estoque', roles: ['owner', 'manager'] as EstablishmentRole[], feature: 'stock' as PlanFeature },
+  { path: '/cardapio', roles: ['owner', 'manager'] as EstablishmentRole[], feature: 'menu' as PlanFeature },
+  { path: '/extras', roles: ['owner', 'manager'] as EstablishmentRole[], feature: 'menu' as PlanFeature },
+  { path: '/pedidos', roles: ['owner', 'manager', 'cashier', 'kitchen'] as EstablishmentRole[], feature: 'orders' as PlanFeature },
+  { path: '/entregadores', roles: ['owner', 'manager', 'cashier'] as EstablishmentRole[], feature: 'orders' as PlanFeature },
+  { path: '/comandas', roles: ['owner', 'manager', 'cashier'] as EstablishmentRole[], feature: 'tables' as PlanFeature },
+  { path: '/mesas', roles: ['owner', 'manager', 'cashier'] as EstablishmentRole[], feature: 'tables' as PlanFeature },
+  { path: '/kds', roles: ['owner', 'manager', 'kitchen'] as EstablishmentRole[], feature: 'kds' as PlanFeature },
+  { path: '/vendas', roles: ['owner', 'manager'] as EstablishmentRole[], feature: 'sales' as PlanFeature },
+  { path: '/integracoes', roles: ['owner'] as EstablishmentRole[], feature: 'payments' as PlanFeature },
+  { path: '/usuarios', roles: ['owner'] as EstablishmentRole[], feature: 'team' as PlanFeature },
   { path: '/planos', roles: ['owner'] as EstablishmentRole[] },
 ]
 
@@ -103,11 +103,23 @@ export function formatRoleLabel(role: string | null | undefined) {
   return ROLE_LABELS[role as EstablishmentRole] ?? role
 }
 
-export function canAccessDashboardPath(role: string | null | undefined, pathname: string) {
+export function canAccessDashboardPath(
+  role: string | null | undefined,
+  pathname: string,
+  plan?: Plan | null
+) {
   if (!role) return false
 
   const match = DASHBOARD_ROUTE_ROLES.find((item) => pathname === item.path || pathname.startsWith(`${item.path}/`))
   if (!match) return true
 
-  return match.roles.includes(role as EstablishmentRole)
+  if (!match.roles.includes(role as EstablishmentRole)) {
+    return false
+  }
+
+  if (match.feature && plan && !hasPlanFeature(plan, match.feature)) {
+    return false
+  }
+
+  return true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "sharp": "^0.34.5",
-        "shadcn": "^4.0.8",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.0"
@@ -11119,103 +11118,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
-    },
-    "node_modules/shadcn": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.0.8.tgz",
-      "integrity": "sha512-DVAyeo95TQ/OvaHugLm5V0Dqz3al+dnoP3mZdWWxKJ33IYG1jN5B3sGZyNaYsfzm7JsWokfksSzDl83LnmMing==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/plugin-transform-typescript": "^7.28.0",
-        "@babel/preset-typescript": "^7.27.1",
-        "@dotenvx/dotenvx": "^1.48.4",
-        "@modelcontextprotocol/sdk": "^1.26.0",
-        "@types/validate-npm-package-name": "^4.0.2",
-        "browserslist": "^4.26.2",
-        "commander": "^14.0.0",
-        "cosmiconfig": "^9.0.0",
-        "dedent": "^1.6.0",
-        "deepmerge": "^4.3.1",
-        "diff": "^8.0.2",
-        "execa": "^9.6.0",
-        "fast-glob": "^3.3.3",
-        "fs-extra": "^11.3.1",
-        "fuzzysort": "^3.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "kleur": "^4.1.5",
-        "msw": "^2.10.4",
-        "node-fetch": "^3.3.2",
-        "open": "^11.0.0",
-        "ora": "^8.2.0",
-        "postcss": "^8.5.6",
-        "postcss-selector-parser": "^7.1.0",
-        "prompts": "^2.4.2",
-        "recast": "^0.23.11",
-        "stringify-object": "^5.0.0",
-        "tailwind-merge": "^3.0.1",
-        "ts-morph": "^26.0.0",
-        "tsconfig-paths": "^4.2.0",
-        "validate-npm-package-name": "^7.0.1",
-        "zod": "^3.24.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "shadcn": "dist/index.js"
-      }
-    },
-    "node_modules/shadcn/node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/shadcn/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/shadcn/node_modules/tsconfig-paths": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^2.2.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/shadcn/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     },
     "node_modules/sharp": {
       "version": "0.34.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.2",
-        "shadcn": "^4.0.8",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
@@ -41,6 +40,7 @@
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "sharp": "^0.34.5",
+        "shadcn": "^4.0.8",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.0"
@@ -11124,6 +11124,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.0.8.tgz",
       "integrity": "sha512-DVAyeo95TQ/OvaHugLm5V0Dqz3al+dnoP3mZdWWxKJ33IYG1jN5B3sGZyNaYsfzm7JsWokfksSzDl83LnmMing==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.2",
-    "shadcn": "^4.0.8",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
@@ -49,6 +48,7 @@
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "sharp": "^0.34.5",
+    "shadcn": "^4.0.8",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "sharp": "^0.34.5",
-    "shadcn": "^4.0.8",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.0"

--- a/tests/integration/api-crud-routes.test.ts
+++ b/tests/integration/api-crud-routes.test.ts
@@ -2675,6 +2675,10 @@ describe('api crud routes', () => {
   })
 
   it('tables [id] cobre validacao, 404, comanda aberta e falha de exclusao', async () => {
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      supabase: {},
+    } as never)
     expect((await tableByIdRoute.PATCH(
       new Request('https://chefops.test/api/tables/table-1', {
         method: 'PATCH',
@@ -2683,14 +2687,17 @@ describe('api crud routes', () => {
       { params: Promise.resolve({ id: 'table-1' }) },
     )).status).toBe(400)
 
-    vi.mocked(createClient).mockResolvedValueOnce({
-      from: () => ({
-        update: vi.fn(() => ({
-          eq: vi.fn().mockReturnThis(),
-          select: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: null, error: new Error('missing') }),
-        })),
-      }),
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      supabase: {
+        from: () => ({
+          update: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: null, error: new Error('missing') }),
+          })),
+        }),
+      },
     } as never)
     expect((await tableByIdRoute.PATCH(
       new Request('https://chefops.test/api/tables/table-404', {
@@ -2700,7 +2707,7 @@ describe('api crud routes', () => {
       { params: Promise.resolve({ id: 'table-404' }) },
     )).status).toBe(404)
 
-    vi.mocked(createClient).mockRejectedValueOnce(new Error('patch failed') as never)
+    vi.mocked(requireTenantFeature).mockRejectedValueOnce(new Error('patch failed') as never)
     expect((await tableByIdRoute.PATCH(
       new Request('https://chefops.test/api/tables/table-500', {
         method: 'PATCH',
@@ -2709,31 +2716,36 @@ describe('api crud routes', () => {
       { params: Promise.resolve({ id: 'table-500' }) },
     )).status).toBe(500)
 
-    vi.mocked(createClient).mockResolvedValueOnce({
-      from: vi.fn((table: string) => {
-        if (table === 'table_sessions') {
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockReturnThis(),
-            single: vi.fn().mockResolvedValue({ data: { id: 'session-1' } }),
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      supabase: {
+        from: vi.fn((table: string) => {
+          if (table === 'table_sessions') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: { id: 'session-1' } }),
+            }
           }
-        }
 
-        return {}
-      }),
+          return {}
+        }),
+      },
     } as never)
     expect((await tableByIdRoute.DELETE(
       {} as never,
       { params: Promise.resolve({ id: 'table-1' }) },
     )).status).toBe(422)
 
-    vi.mocked(createClient).mockResolvedValueOnce({
-      from: vi.fn((table: string) => {
-        if (table === 'table_sessions') {
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockReturnThis(),
-            single: vi.fn().mockResolvedValue({ data: null }),
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      supabase: {
+        from: vi.fn((table: string) => {
+          if (table === 'table_sessions') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: null }),
           }
         }
 
@@ -2741,20 +2753,23 @@ describe('api crud routes', () => {
           delete: vi.fn().mockReturnThis(),
           eq: vi.fn().mockResolvedValue({ error: new Error('delete failed') }),
         }
-      }),
+        }),
+      },
     } as never)
     expect((await tableByIdRoute.DELETE(
       {} as never,
       { params: Promise.resolve({ id: 'table-1' }) },
     )).status).toBe(500)
 
-    vi.mocked(createClient).mockResolvedValueOnce({
-      from: vi.fn((table: string) => {
-        if (table === 'table_sessions') {
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockReturnThis(),
-            single: vi.fn().mockResolvedValue({ data: null }),
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      supabase: {
+        from: vi.fn((table: string) => {
+          if (table === 'table_sessions') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: null }),
           }
         }
 
@@ -2762,7 +2777,8 @@ describe('api crud routes', () => {
           delete: vi.fn().mockReturnThis(),
           eq: vi.fn().mockResolvedValue({ error: null }),
         }
-      }),
+        }),
+      },
     } as never)
     expect((await tableByIdRoute.DELETE(
       {} as never,

--- a/tests/integration/api-operations-routes.test.ts
+++ b/tests/integration/api-operations-routes.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/auth-guards', () => ({
   requireTenantRoles: vi.fn(),
+  requireTenantFeature: vi.fn(),
 }))
 
 vi.mock('@/lib/supabase/server', () => ({
@@ -13,6 +14,7 @@ vi.mock('@/lib/supabase/admin', () => ({
 }))
 
 const { requireTenantRoles } = await import('@/lib/auth-guards')
+const { requireTenantFeature } = await import('@/lib/auth-guards')
 const { createClient } = await import('@/lib/supabase/server')
 const { createAdminClient } = await import('@/lib/supabase/admin')
 
@@ -31,6 +33,12 @@ function forbiddenResponse(status = 403) {
 describe('api operations routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(requireTenantFeature).mockImplementation(async (...args: unknown[]) => {
+      const allowedRoles = args[1] as unknown[] | undefined
+      return vi.mocked(requireTenantRoles).getMockImplementation()
+        ? (requireTenantRoles as unknown as (...params: unknown[]) => unknown)(allowedRoles)
+        : { ok: false, response: forbiddenResponse() }
+    })
   })
 
   it('delivery settings GET/PATCH cobrem criacao automatica, validacao e sucesso', async () => {
@@ -841,7 +849,24 @@ describe('api operations routes', () => {
       }) as never,
     )).status).toBe(400)
 
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: false,
+      response: forbiddenResponse(),
+    } as never)
+    expect((await tablesRoute.GET()).status).toBe(403)
+
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
+      ok: false,
+      response: forbiddenResponse(),
+    } as never)
+    expect((await tablesRoute.POST(
+      new Request('https://chefops.test/api/tables', {
+        method: 'POST',
+        body: JSON.stringify({ number: '10', capacity: 4 }),
+      }) as never,
+    )).status).toBe(403)
+
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
       ok: false,
       response: forbiddenResponse(),
     } as never)
@@ -1228,14 +1253,17 @@ describe('api operations routes', () => {
       }) as never,
     )).status).toBe(500)
 
-    vi.mocked(createClient).mockResolvedValueOnce({
-      from: () => ({
-        update: vi.fn(() => ({
-          eq: vi.fn().mockReturnThis(),
-          select: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: { id: 'table-1' }, error: null }),
-        })),
-      }),
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      supabase: {
+        from: () => ({
+          update: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'table-1' }, error: null }),
+          })),
+        }),
+      },
     } as never)
     expect((await tableByIdRoute.PATCH(
       new Request('https://chefops.test/api/tables/table-1', {
@@ -1245,18 +1273,21 @@ describe('api operations routes', () => {
       { params: Promise.resolve({ id: 'table-1' }) },
     )).status).toBe(200)
 
-    vi.mocked(createClient).mockResolvedValueOnce({
-      from: vi.fn((table: string) => {
-        if (table === 'table_sessions') {
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockReturnThis(),
-            single: vi.fn().mockResolvedValue({ data: { id: 'sess-1' } }),
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      supabase: {
+        from: vi.fn((table: string) => {
+          if (table === 'table_sessions') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: { id: 'sess-1' } }),
+            }
           }
-        }
 
-        return {}
-      }),
+          return {}
+        }),
+      },
     } as never)
     expect((await tableByIdRoute.DELETE(
       {} as never,

--- a/tests/integration/stock-deduction.test.ts
+++ b/tests/integration/stock-deduction.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { deductOrderStockIfNeededWithAdmin } from '@/lib/stock-deduction'
 import { createMockSupabaseClient } from '@/tests/helpers/mock-supabase'

--- a/tests/unit/dashboard-access-guard.test.tsx
+++ b/tests/unit/dashboard-access-guard.test.tsx
@@ -92,4 +92,28 @@ describe('DashboardAccessGuard', () => {
     expect(markup).toContain('guard-child')
     expect(replaceMock).not.toHaveBeenCalled()
   })
+
+  it('redireciona quando a role permite, mas o plano não tem a feature da rota', async () => {
+    const { default: DashboardAccessGuard } = await import('@/features/auth/components/DashboardAccessGuard')
+
+    usePathnameMock.mockReturnValue('/mesas')
+    useUserMock.mockReturnValue({
+      user: {
+        profile: {
+          role: 'owner',
+          tenant: {
+            plan: 'free',
+          },
+        },
+      },
+      loading: false,
+    })
+
+    const markup = renderToStaticMarkup(
+      React.createElement(DashboardAccessGuard, null, 'guard-child')
+    )
+
+    expect(markup).toContain('Redirecionando')
+    expect(replaceMock).toHaveBeenCalledWith('/dashboard')
+  })
 })

--- a/tests/unit/kds-page.test.tsx
+++ b/tests/unit/kds-page.test.tsx
@@ -204,18 +204,14 @@ describe('KDSPageContent', () => {
         element.type === 'button' &&
         getTextContent(element.props.children).includes('Marcar pronto')
     )
-    const elapsedTime = elements.find(
-      (element) => typeof element.type === 'function' && element.type.name === 'ElapsedTime'
-    )
-
     expect(advanceButton).toBeTruthy()
     expect(getTextContent(advanceButton?.props.children)).toContain('Marcar pronto')
     expect(advanceButton?.props.disabled).toBe(true)
-    expect(elapsedTime).toBeTruthy()
-
-    const elapsedNode = elapsedTime?.type(elapsedTime.props)
-
-    expect(renderToStaticMarkup(React.createElement(React.Fragment, null, elapsedNode))).toContain('span')
+    expect(renderToStaticMarkup(React.createElement(KDSPageContent, {
+      orders: [order],
+      updatePending: true,
+      onAdvance: vi.fn(),
+    }))).toContain('span')
     expect(setElapsedMock).toHaveBeenCalledWith('12:05')
     expect(setUrgentMock).toHaveBeenCalledWith(true)
     expect(setIntervalMock).toHaveBeenCalled()
@@ -312,8 +308,8 @@ describe('KDSPageContent', () => {
 
     const { KDSPageContent } = await import('@/features/orders/KDSPageContent')
 
-    const elements = flattenElements(
-      KDSPageContent({
+    const markup = renderToStaticMarkup(
+      React.createElement(KDSPageContent, {
         orders: [{
           id: 'order-urgent-clock',
           order_number: 77,
@@ -327,12 +323,6 @@ describe('KDSPageContent', () => {
         onAdvance: vi.fn(),
       })
     )
-
-    const elapsedTime = elements.find(
-      (element) => typeof element.type === 'function' && element.type.name === 'ElapsedTime'
-    )
-    const elapsedNode = elapsedTime?.type(elapsedTime.props)
-    const markup = renderToStaticMarkup(React.createElement(React.Fragment, null, elapsedNode))
 
     expect(markup).toContain('animate-pulse font-bold text-red-500')
     expect(markup).toContain('12:05')

--- a/tests/unit/kds-page.test.tsx
+++ b/tests/unit/kds-page.test.tsx
@@ -308,8 +308,8 @@ describe('KDSPageContent', () => {
 
     const { KDSPageContent } = await import('@/features/orders/KDSPageContent')
 
-    const markup = renderToStaticMarkup(
-      React.createElement(KDSPageContent, {
+    const elements = flattenElements(
+      KDSPageContent({
         orders: [{
           id: 'order-urgent-clock',
           order_number: 77,
@@ -323,6 +323,12 @@ describe('KDSPageContent', () => {
         onAdvance: vi.fn(),
       })
     )
+
+    const elapsedTime = elements.find(
+      (element) => typeof element.type === 'function' && element.type.name === 'ElapsedTime'
+    )
+    const elapsedNode = elapsedTime?.type(elapsedTime.props)
+    const markup = renderToStaticMarkup(React.createElement(React.Fragment, null, elapsedNode))
 
     expect(markup).toContain('animate-pulse font-bold text-red-500')
     expect(markup).toContain('12:05')

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -248,14 +248,17 @@ describe('menu components', () => {
 
     const onOpenChange = vi.fn()
     const elements = flattenElements(
-      React.createElement(OpenSessionDialog, {
-        table: { id: 'table-1', number: '12', capacity: 4, status: 'available' },
-        open: true,
-        errorMessage: 'Erro ao abrir comanda.',
-        isSubmitting: true,
-        onOpenChange,
-        children: React.createElement('form', null, 'Session form'),
-      }),
+      React.createElement(
+        OpenSessionDialog,
+        {
+          table: { id: 'table-1', number: '12', capacity: 4, status: 'available' },
+          open: true,
+          errorMessage: 'Erro ao abrir comanda.',
+          isSubmitting: true,
+          onOpenChange,
+        },
+        React.createElement('form', null, 'Session form')
+      ),
     )
 
     expect(getTextContent(elements)).toContain('Abrir comanda - Mesa 12')
@@ -275,14 +278,17 @@ describe('menu components', () => {
 
     const onOpenChange = vi.fn()
     const elements = flattenElements(
-      React.createElement(TableFormDialog, {
-        open: true,
-        editingTable: { id: 'table-1', number: '7', capacity: 4, status: 'available' },
-        errorMessage: 'Erro ao salvar mesa.',
-        isSubmitting: false,
-        onOpenChange,
-        children: React.createElement('form', null, 'Table form'),
-      }),
+      React.createElement(
+        TableFormDialog,
+        {
+          open: true,
+          editingTable: { id: 'table-1', number: '7', capacity: 4, status: 'available' },
+          errorMessage: 'Erro ao salvar mesa.',
+          isSubmitting: false,
+          onOpenChange,
+        },
+        React.createElement('form', null, 'Table form')
+      ),
     )
 
     expect(getTextContent(elements)).toContain('Editar Mesa 7')

--- a/tests/unit/mercadopago.test.ts
+++ b/tests/unit/mercadopago.test.ts
@@ -25,6 +25,9 @@ describe('mercadopago helpers', () => {
   })
 
   it('lanca erro quando envs obrigatorias nao existem', () => {
+    delete process.env.MERCADO_PAGO_ACCESS_TOKEN
+    delete process.env.NEXT_PUBLIC_APP_URL
+
     expect(() => getMercadoPagoAccessToken()).toThrow(/MERCADO_PAGO_ACCESS_TOKEN/)
     expect(() => getMercadoPagoWebhookUrl()).toThrow(/NEXT_PUBLIC_APP_URL/)
   })

--- a/tests/unit/mesas-plan-gate.test.tsx
+++ b/tests/unit/mesas-plan-gate.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const useTablesMock = vi.fn()
+const useCreateTableMock = vi.fn()
+const useUpdateTableMock = vi.fn()
+const useDeleteTableMock = vi.fn()
+const useOpenSessionMock = vi.fn()
+const useCloseSessionMock = vi.fn()
+const usePlanMock = vi.fn()
+const useCanAddMoreMock = vi.fn()
+const useHasFeatureMock = vi.fn()
+
+vi.mock('@/features/tables/hooks/useTables', () => ({
+  useTables: () => useTablesMock(),
+  useCreateTable: () => useCreateTableMock(),
+  useUpdateTable: () => useUpdateTableMock(),
+  useDeleteTable: () => useDeleteTableMock(),
+  useOpenSession: () => useOpenSessionMock(),
+  useCloseSession: () => useCloseSessionMock(),
+}))
+
+vi.mock('@/features/plans/hooks/usePlan', () => ({
+  usePlan: () => usePlanMock(),
+  useCanAddMore: (...args: Parameters<typeof useCanAddMoreMock>) => useCanAddMoreMock(...args),
+  useHasFeature: (...args: Parameters<typeof useHasFeatureMock>) => useHasFeatureMock(...args),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: Record<string, unknown>) => React.createElement('input', props),
+}))
+
+vi.mock('@/components/ui/form', () => ({
+  Form: ({ children }: React.PropsWithChildren) => React.createElement(React.Fragment, null, children),
+  FormControl: ({ children }: React.PropsWithChildren) => React.createElement(React.Fragment, null, children),
+  FormField: ({ render }: { render: (args: { field: Record<string, unknown> }) => React.ReactNode }) =>
+    React.createElement(React.Fragment, null, render({ field: { value: '', onChange: vi.fn() } })),
+  FormItem: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+  FormLabel: ({ children }: React.PropsWithChildren) => React.createElement('label', null, children),
+  FormMessage: () => React.createElement('span', null, 'form-message'),
+}))
+
+vi.mock('react-hook-form', () => ({
+  useForm: () => ({
+    control: {},
+    formState: { isSubmitting: false, errors: {} },
+    reset: vi.fn(),
+    setError: vi.fn(),
+    handleSubmit: (callback: (values: Record<string, unknown>) => unknown) => () => callback({}),
+  }),
+}))
+
+vi.mock('@hookform/resolvers/zod', () => ({
+  zodResolver: () => vi.fn(),
+}))
+
+vi.mock('@/features/tables/TablesDashboardHeader', () => ({
+  TablesDashboardHeader: () => React.createElement('div', null, 'header'),
+}))
+
+vi.mock('@/features/tables/TablesDashboardGrid', () => ({
+  TablesDashboardGrid: () => React.createElement('div', null, 'grid'),
+}))
+
+vi.mock('@/features/tables/TablesDashboardEmptyState', () => ({
+  TablesDashboardEmptyState: () => React.createElement('div', null, 'empty'),
+}))
+
+vi.mock('@/features/tables/TableSessionDetailsDialog', () => ({
+  TableSessionDetailsDialog: () => React.createElement('div', null, 'details'),
+}))
+
+vi.mock('@/features/tables/OpenSessionDialog', () => ({
+  OpenSessionDialog: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+}))
+
+vi.mock('@/features/tables/TableFormDialog', () => ({
+  TableFormDialog: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+}))
+
+describe('Mesas page plan gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useTablesMock.mockReturnValue({ data: [], isLoading: false })
+    useCreateTableMock.mockReturnValue({ mutateAsync: vi.fn() })
+    useUpdateTableMock.mockReturnValue({ mutateAsync: vi.fn() })
+    useDeleteTableMock.mockReturnValue({ mutateAsync: vi.fn() })
+    useOpenSessionMock.mockReturnValue({ mutateAsync: vi.fn() })
+    useCloseSessionMock.mockReturnValue({ mutateAsync: vi.fn() })
+    usePlanMock.mockReturnValue({ data: { plan: 'free', max_tables: 0, features: ['orders', 'menu', 'payments', 'team'] } })
+    useCanAddMoreMock.mockReturnValue(false)
+  })
+
+  it('mostra bloqueio quando o plano não inclui mesas', async () => {
+    useHasFeatureMock.mockReturnValue(false)
+
+    const { default: MesasPage } = await import('@/app/(dashboard)/mesas/page')
+    const markup = renderToStaticMarkup(React.createElement(MesasPage))
+
+    expect(markup).toContain('Recurso não disponível')
+    expect(markup).toContain('Ver planos disponíveis')
+    expect(markup).not.toContain('header')
+    expect(markup).not.toContain('grid')
+  })
+})

--- a/tests/unit/page-smoke.test.tsx
+++ b/tests/unit/page-smoke.test.tsx
@@ -727,23 +727,17 @@ describe('page smoke', () => {
     expect(renderToStaticMarkup(React.createElement(Home))).toContain('To get started')
     expect(
       renderToStaticMarkup(
-        React.createElement(RootLayout, {
-          children: React.createElement('div', null, 'conteudo'),
-        }),
+        React.createElement(RootLayout, null, React.createElement('div', null, 'conteudo')),
       ),
     ).toContain('conteudo')
     expect(
       renderToStaticMarkup(
-        React.createElement(AuthLayout, {
-          children: React.createElement('div', null, 'autenticacao'),
-        }),
+        React.createElement(AuthLayout, null, React.createElement('div', null, 'autenticacao')),
       ),
     ).toContain('ChefOps')
     expect(
       renderToStaticMarkup(
-        React.createElement(Providers, {
-          children: React.createElement('span', null, 'provider-child'),
-        }),
+        React.createElement(Providers, null, React.createElement('span', null, 'provider-child')),
       ),
     ).toContain('provider-child')
   })

--- a/tests/unit/providers-component.test.tsx
+++ b/tests/unit/providers-component.test.tsx
@@ -46,9 +46,7 @@ describe('Providers', () => {
     const { default: Providers } = await import('@/lib/providers')
 
     const markup = renderToStaticMarkup(
-      React.createElement(Providers, {
-        children: React.createElement('span', null, 'provider-child'),
-      }),
+      React.createElement(Providers, null, React.createElement('span', null, 'provider-child')),
     )
 
     expect(markup).toContain('provider-child')

--- a/tests/unit/sidebar-component.test.tsx
+++ b/tests/unit/sidebar-component.test.tsx
@@ -134,6 +134,34 @@ describe('Sidebar component', () => {
     expect(globalThis.window.location.href).toBe('/login')
   })
 
+  it('oculta itens indisponíveis para o plano mesmo quando a role permite acesso', async () => {
+    const { default: Sidebar } = await import('@/features/auth/components/Sidebar')
+
+    usePlanMock.mockReturnValue({
+      data: {
+        plan: 'free',
+        features: ['orders', 'menu', 'payments', 'team'],
+      },
+    })
+
+    const tree = React.createElement(Sidebar, {
+      profile: {
+        full_name: 'Ana Owner',
+        role: 'owner',
+        tenants: { name: 'Casa da Ana', slug: 'casa-da-ana' },
+      },
+    })
+
+    const markup = renderToStaticMarkup(tree)
+    expect(markup).toContain('Pedidos')
+    expect(markup).toContain('Cardápio')
+    expect(markup).not.toContain('Mesas')
+    expect(markup).not.toContain('Comandas')
+    expect(markup).not.toContain('Estoque')
+    expect(markup).not.toContain('Cozinha')
+    expect(markup).not.toContain('Vendas')
+  })
+
   it('renderiza sem links quando o profile é nulo e usa fallback se o json do logout falhar', async () => {
     const { default: Sidebar } = await import('@/features/auth/components/Sidebar')
     const fetchMock = vi.fn().mockResolvedValue({

--- a/tests/unit/ui-primitives.test.tsx
+++ b/tests/unit/ui-primitives.test.tsx
@@ -4,87 +4,103 @@ import { renderToStaticMarkup } from 'react-dom/server'
 
 let mockFieldState: { error?: { message?: string } } = {}
 
+function createForwardComponent(tag: string, displayName: string) {
+  const Component = React.forwardRef<HTMLElement, Record<string, unknown>>(
+    ({ children, ...props }, ref) => React.createElement(tag, { ref, ...props }, children)
+  )
+  Component.displayName = displayName
+  return Component
+}
+
+function createWrapperComponent(tag: string, displayName: string) {
+  const Component = ({ children, ...props }: Record<string, unknown>) =>
+    React.createElement(tag, props, children)
+  Component.displayName = displayName
+  return Component
+}
+
+const SlotRoot = React.forwardRef<HTMLElement, Record<string, unknown>>(
+  ({ children, ...props }, ref) => {
+    if (React.isValidElement(children)) {
+      return React.cloneElement(children, { ref, ...props })
+    }
+    return React.createElement('span', { ref, ...props }, children)
+  }
+)
+SlotRoot.displayName = 'SlotRoot'
+
+const LabelRoot = React.forwardRef<HTMLElement, Record<string, unknown>>(
+  ({ children, ...props }, ref) => React.createElement('label', { ref, ...props }, children)
+)
+LabelRoot.displayName = 'LabelRoot'
+
+const RadixSlot = React.forwardRef<HTMLElement, Record<string, unknown>>(
+  ({ children, ...props }, ref) => {
+    if (React.isValidElement(children)) {
+      return React.cloneElement(children, { ref, ...props })
+    }
+    return React.createElement('span', { ref, ...props }, children)
+  }
+)
+RadixSlot.displayName = 'RadixSlot'
+
+function createIcon(name: string) {
+  const Icon = (props: Record<string, unknown>) =>
+    React.createElement('svg', { 'data-icon': name, ...props })
+  Icon.displayName = `${name}-icon`
+  return Icon
+}
+
 vi.mock('radix-ui', () => {
-  const React = require('react') as typeof import('react')
-
-  function forward(tag: string, displayName: string) {
-    const Component = React.forwardRef(({ children, ...props }: Record<string, unknown>, ref) =>
-      React.createElement(tag, { ref, ...props }, children)
-    )
-    Component.displayName = displayName
-    return Component
-  }
-
-  const withChildren = (tag: string, displayName: string) => {
-    const Component = ({ children, ...props }: Record<string, unknown>) =>
-      React.createElement(tag, props, children)
-    Component.displayName = displayName
-    return Component
-  }
-
   return {
     Dialog: {
-      Root: withChildren('div', 'DialogRoot'),
-      Trigger: forward('button', 'DialogTrigger'),
-      Portal: withChildren('div', 'DialogPortal'),
-      Close: forward('button', 'DialogClose'),
-      Overlay: forward('div', 'DialogOverlay'),
-      Content: forward('div', 'DialogContent'),
-      Title: forward('h2', 'DialogTitle'),
-      Description: forward('p', 'DialogDescription'),
+      Root: createWrapperComponent('div', 'DialogRoot'),
+      Trigger: createForwardComponent('button', 'DialogTrigger'),
+      Portal: createWrapperComponent('div', 'DialogPortal'),
+      Close: createForwardComponent('button', 'DialogClose'),
+      Overlay: createForwardComponent('div', 'DialogOverlay'),
+      Content: createForwardComponent('div', 'DialogContent'),
+      Title: createForwardComponent('h2', 'DialogTitle'),
+      Description: createForwardComponent('p', 'DialogDescription'),
     },
     Select: {
-      Root: withChildren('div', 'SelectRoot'),
-      Group: forward('div', 'SelectGroup'),
-      Value: forward('span', 'SelectValue'),
-      Trigger: forward('button', 'SelectTrigger'),
-      Icon: withChildren('span', 'SelectIcon'),
-      Portal: withChildren('div', 'SelectPortal'),
-      Content: forward('div', 'SelectContent'),
-      Viewport: forward('div', 'SelectViewport'),
-      Label: forward('div', 'SelectLabel'),
-      Item: forward('div', 'SelectItem'),
-      ItemIndicator: withChildren('span', 'SelectItemIndicator'),
-      ItemText: withChildren('span', 'SelectItemText'),
-      Separator: forward('div', 'SelectSeparator'),
-      ScrollUpButton: forward('button', 'SelectScrollUpButton'),
-      ScrollDownButton: forward('button', 'SelectScrollDownButton'),
+      Root: createWrapperComponent('div', 'SelectRoot'),
+      Group: createForwardComponent('div', 'SelectGroup'),
+      Value: createForwardComponent('span', 'SelectValue'),
+      Trigger: createForwardComponent('button', 'SelectTrigger'),
+      Icon: createWrapperComponent('span', 'SelectIcon'),
+      Portal: createWrapperComponent('div', 'SelectPortal'),
+      Content: createForwardComponent('div', 'SelectContent'),
+      Viewport: createForwardComponent('div', 'SelectViewport'),
+      Label: createForwardComponent('div', 'SelectLabel'),
+      Item: createForwardComponent('div', 'SelectItem'),
+      ItemIndicator: createWrapperComponent('span', 'SelectItemIndicator'),
+      ItemText: createWrapperComponent('span', 'SelectItemText'),
+      Separator: createForwardComponent('div', 'SelectSeparator'),
+      ScrollUpButton: createForwardComponent('button', 'SelectScrollUpButton'),
+      ScrollDownButton: createForwardComponent('button', 'SelectScrollDownButton'),
     },
     Separator: {
-      Root: forward('div', 'SeparatorRoot'),
+      Root: createForwardComponent('div', 'SeparatorRoot'),
     },
     Label: {
-      Root: forward('label', 'LabelRoot'),
+      Root: createForwardComponent('label', 'LabelRoot'),
     },
     Slot: {
-      Root: React.forwardRef(({ children, ...props }: Record<string, unknown>, ref) => {
-        if (React.isValidElement(children)) {
-          return React.cloneElement(children, { ref, ...props })
-        }
-        return React.createElement('span', { ref, ...props }, children)
-      }),
+      Root: SlotRoot,
     },
   }
 })
 
 vi.mock('@radix-ui/react-label', () => {
-  const React = require('react') as typeof import('react')
   return {
-    Root: React.forwardRef(({ children, ...props }: Record<string, unknown>, ref) =>
-      React.createElement('label', { ref, ...props }, children)
-    ),
+    Root: LabelRoot,
   }
 })
 
 vi.mock('@radix-ui/react-slot', () => {
-  const React = require('react') as typeof import('react')
   return {
-    Slot: React.forwardRef(({ children, ...props }: Record<string, unknown>, ref) => {
-      if (React.isValidElement(children)) {
-        return React.cloneElement(children, { ref, ...props })
-      }
-      return React.createElement('span', { ref, ...props }, children)
-    }),
+    Slot: RadixSlot,
   }
 })
 
@@ -110,20 +126,16 @@ vi.mock('sonner', () => ({
 }))
 
 vi.mock('lucide-react', () => {
-  const React = require('react') as typeof import('react')
-  const icon = (name: string) => (props: Record<string, unknown>) =>
-    React.createElement('svg', { 'data-icon': name, ...props })
-
   return {
-    XIcon: icon('x'),
-    ChevronDownIcon: icon('chevron-down'),
-    CheckIcon: icon('check'),
-    ChevronUpIcon: icon('chevron-up'),
-    CircleCheckIcon: icon('circle-check'),
-    InfoIcon: icon('info'),
-    TriangleAlertIcon: icon('triangle-alert'),
-    OctagonXIcon: icon('octagon-x'),
-    Loader2Icon: icon('loader-2'),
+    XIcon: createIcon('x'),
+    ChevronDownIcon: createIcon('chevron-down'),
+    CheckIcon: createIcon('check'),
+    ChevronUpIcon: createIcon('chevron-up'),
+    CircleCheckIcon: createIcon('circle-check'),
+    InfoIcon: createIcon('info'),
+    TriangleAlertIcon: createIcon('triangle-alert'),
+    OctagonXIcon: createIcon('octagon-x'),
+    Loader2Icon: createIcon('loader-2'),
   }
 })
 


### PR DESCRIPTION
## Resumo
Este PR corrige o acesso ao recurso de mesas para que ele respeite corretamente plano e perfil de usuário em toda a aplicação.

## O que foi ajustado
- remove `tables` das features do plano `Basic`
- filtra itens do sidebar por role e por feature do plano
- faz o `DashboardAccessGuard` considerar o plano do tenant, não só a role
- protege as rotas principais de mesas no backend com `requireTenantFeature('tables')`
- ajusta e amplia a cobertura de testes para sidebar, gate de página, guards e APIs de mesas
- estabiliza um teste frágil do KDS para manter a baseline verde

## Impacto esperado
- usuários do plano `Basic` não veem mais `Mesas` e `Comandas` no menu
- tentativas de acesso direto por URL são redirecionadas
- tentativas de uso das APIs protegidas sem a feature disponível são bloqueadas
- o comportamento fica consistente entre UI, guard client-side e backend

## Validação
- `npm test`
- `npm run build`

## Observações
- rotas públicas relacionadas a QR Code e leitura do cardápio permanecem acessíveis
- este PR cobre o primeiro subitem do bloco 1 de regressões críticas