### PR TITLE
feat: allow customers to confirm delivery from order tracking

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -114,6 +114,7 @@ export default function MenuClient({
   const [checkoutNotice, setCheckoutNotice] = useState<string | null>(null)
   const [publicOrderStatus, setPublicOrderStatus] = useState<PublicOrderStatus | null>(null)
   const [cancelOrderLoading, setCancelOrderLoading] = useState(false)
+  const [confirmDeliveryLoading, setConfirmDeliveryLoading] = useState(false)
   const activeOrderStorageKey = getActiveOrderStorageKey(tenant.slug, tableInfo?.id)
 
   const createOrder = useCreatePublicOrder()
@@ -479,6 +480,31 @@ export default function MenuClient({
     }
   }
 
+  async function handleConfirmDelivery() {
+    if (!orderId) return
+
+    try {
+      setConfirmDeliveryLoading(true)
+
+      const res = await fetch(`/api/public/orders/${orderId}/confirm-delivery`, {
+        method: 'POST',
+      })
+      const json = await res.json()
+
+      if (!res.ok) {
+        throw new Error(json.error)
+      }
+
+      setPublicOrderStatus(json.data)
+      setCheckoutNotice('Pedido entregue com sucesso.')
+      toast.success('Entrega confirmada com sucesso.')
+    } catch (error) {
+      alert(getPublicOrderPlacementErrorMessage(error))
+    } finally {
+      setConfirmDeliveryLoading(false)
+    }
+  }
+
   const orderSteps = getOrderSteps(tableInfo)
   const isCheckoutProcessing = getPublicCheckoutProcessingState(
     createOrder.isPending,
@@ -599,7 +625,9 @@ export default function MenuClient({
           orderSteps,
           getStepState,
           cancelOrderLoading,
+          confirmDeliveryLoading,
           onCancelOrder: handleCancelOrder,
+          onConfirmDelivery: handleConfirmDelivery,
           onClose: () => setCartOpen(false),
         },
       }}

--- a/app/api/public/orders/[id]/confirm-delivery/route.ts
+++ b/app/api/public/orders/[id]/confirm-delivery/route.ts
@@ -1,0 +1,97 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { sendOrderWhatsappNotification } from '@/lib/order-whatsapp'
+import { NextResponse } from 'next/server'
+
+type ConfirmDeps = {
+  createAdminClient: typeof createAdminClient
+  sendOrderWhatsappNotification: typeof sendOrderWhatsappNotification
+}
+
+const defaultDeps: ConfirmDeps = {
+  createAdminClient,
+  sendOrderWhatsappNotification,
+}
+
+export async function confirmPublicOrderDelivery(
+  orderId: string,
+  deps: ConfirmDeps = defaultDeps,
+) {
+  const admin = deps.createAdminClient()
+
+  const { data: existingOrder, error: existingOrderError } = await admin
+    .from('orders')
+    .select('id, status, payment_method, delivery_status')
+    .eq('id', orderId)
+    .single()
+
+  if (existingOrderError || !existingOrder) {
+    return NextResponse.json(
+      { error: 'Pedido não encontrado.' },
+      { status: 404 }
+    )
+  }
+
+  const canConfirmDelivery =
+    existingOrder.payment_method === 'delivery' &&
+    existingOrder.delivery_status === 'out_for_delivery'
+
+  if (!canConfirmDelivery) {
+    return NextResponse.json(
+      { error: 'Este pedido ainda não pode ser confirmado como entregue.' },
+      { status: 422 }
+    )
+  }
+
+  const { error: updateError } = await admin
+    .from('orders')
+    .update({
+      status: 'delivered',
+      delivery_status: 'delivered',
+    })
+    .eq('id', orderId)
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: updateError.message },
+      { status: 500 }
+    )
+  }
+
+  const { data: updatedOrder, error: updatedOrderError } = await admin
+    .from('orders')
+    .select('id, order_number, status, payment_status, payment_method, delivery_status, cancelled_reason, refunded_at, created_at, updated_at, delivery_driver:delivery_drivers(name)')
+    .eq('id', orderId)
+    .single()
+
+  if (updatedOrderError || !updatedOrder) {
+    return NextResponse.json(
+      { error: 'Erro ao recarregar o pedido atualizado.' },
+      { status: 500 }
+    )
+  }
+
+  await deps.sendOrderWhatsappNotification({
+    orderId,
+    eventKey: 'order_delivered',
+  }).catch((error) => {
+    console.error('[public-orders:confirm-delivery:whatsapp]', error)
+  })
+
+  return NextResponse.json({ data: updatedOrder })
+}
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    return await confirmPublicOrderDelivery(id)
+  } catch (error) {
+    console.error('[public-orders:confirm-delivery]', error)
+    return NextResponse.json(
+      { error: 'Erro ao confirmar entrega do pedido.' },
+      { status: 500 }
+    )
+  }
+}

--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -17,7 +17,9 @@ export function MenuDoneStep({
   orderSteps,
   getStepState,
   cancelOrderLoading,
+  confirmDeliveryLoading,
   onCancelOrder,
+  onConfirmDelivery,
   onClose,
 }: {
   orderNumber: number | null
@@ -26,7 +28,9 @@ export function MenuDoneStep({
   orderSteps: Array<{ key: PublicOrderStatus['status']; label: string; description: string }>
   getStepState: (stepKey: PublicOrderStatus['status']) => 'done' | 'current' | 'upcoming'
   cancelOrderLoading: boolean
+  confirmDeliveryLoading: boolean
   onCancelOrder: () => void
+  onConfirmDelivery: () => void
   onClose: () => void
 }) {
   return (
@@ -108,6 +112,17 @@ export function MenuDoneStep({
               {getPaymentStatusLabel(publicOrderStatus?.payment_status, publicOrderStatus?.payment_method)}
             </span>
           </div>
+
+          {publicOrderStatus?.payment_method === 'delivery' &&
+            publicOrderStatus?.delivery_status === 'out_for_delivery' && (
+              <Button
+                className="mt-4 w-full"
+                onClick={onConfirmDelivery}
+                disabled={confirmDeliveryLoading}
+              >
+                {confirmDeliveryLoading ? 'Confirmando...' : 'Confirmar recebimento'}
+              </Button>
+            )}
 
           {shouldShowCancelOrderButton(publicOrderStatus?.status) && (
             <Button

--- a/tests/integration/public-confirm-delivery-route.test.ts
+++ b/tests/integration/public-confirm-delivery-route.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('@/lib/order-whatsapp', () => ({
+  sendOrderWhatsappNotification: vi.fn(),
+}))
+
+import * as confirmRoute from '@/app/api/public/orders/[id]/confirm-delivery/route'
+import { createMockSupabaseClient } from '@/tests/helpers/mock-supabase'
+
+describe('public confirm delivery route', () => {
+  it('rejeita confirmação quando o pedido ainda não saiu para entrega', async () => {
+    const admin = createMockSupabaseClient({
+      orders: (state) => {
+        if (state.operation === 'select' && state.columns === 'id, status, payment_method, delivery_status') {
+          return {
+            data: {
+              id: 'order-1',
+              status: 'ready',
+              payment_method: 'delivery',
+              delivery_status: 'waiting_dispatch',
+            },
+            error: null,
+          }
+        }
+
+        throw new Error('Nenhuma outra query deveria ser executada')
+      },
+    })
+
+    const response = await confirmRoute.confirmPublicOrderDelivery(
+      'order-1',
+      {
+        createAdminClient: () => admin as never,
+        sendOrderWhatsappNotification: async () => ({ sent: false }),
+      },
+    )
+
+    expect(response.status).toBe(422)
+    expect(await response.json()).toEqual({
+      error: 'Este pedido ainda não pode ser confirmado como entregue.',
+    })
+  })
+
+  it('confirma entrega pública e devolve pedido atualizado', async () => {
+    let updateValues: Record<string, unknown> | undefined
+    let notifiedOrderId: string | undefined
+    let updated = false
+
+    const admin = createMockSupabaseClient({
+      orders: (state) => {
+        if (state.operation === 'select') {
+          if (updated) {
+            return {
+              data: {
+                id: 'order-1',
+                order_number: 88,
+                status: 'delivered',
+                payment_status: 'pending',
+                payment_method: 'delivery',
+                delivery_status: 'delivered',
+                created_at: '2026-03-26T10:00:00.000Z',
+                updated_at: '2026-03-26T10:20:00.000Z',
+              },
+              error: null,
+            }
+          }
+
+          return {
+            data: {
+              id: 'order-1',
+              status: 'ready',
+              payment_method: 'delivery',
+              delivery_status: 'out_for_delivery',
+            },
+            error: null,
+          }
+        }
+
+        if (state.operation === 'update') {
+          updateValues = state.values
+          updated = true
+          return { data: null, error: null }
+        }
+
+        throw new Error('Nenhuma outra query deveria ser executada')
+      },
+    })
+
+    const response = await confirmRoute.confirmPublicOrderDelivery(
+      'order-1',
+      {
+        createAdminClient: () => admin as never,
+        sendOrderWhatsappNotification: async ({ orderId }) => {
+          notifiedOrderId = orderId
+          return { sent: true }
+        },
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateValues).toEqual({
+      status: 'delivered',
+      delivery_status: 'delivered',
+    })
+    expect(notifiedOrderId).toBe('order-1')
+    expect((await response.json()).data.status).toBe('delivered')
+  })
+})

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -2377,6 +2377,83 @@ describe('MenuClient component', () => {
     expect(setTimeoutMock).not.toHaveBeenCalled()
   })
 
+  it('permite confirmar o recebimento no acompanhamento do pedido', async () => {
+    stateValues[16] = 123
+    stateValues[17] = 'order-3'
+    stateValues[22] = createPublicOrderStatus({
+      id: 'order-3',
+      order_number: 123,
+      status: 'ready',
+      payment_status: 'pending',
+      payment_method: 'delivery',
+      delivery_status: 'out_for_delivery',
+    })
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/public/orders/order-3/confirm-delivery') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            data: createPublicOrderStatus({
+              id: 'order-3',
+              order_number: 123,
+              status: 'delivered',
+              payment_status: 'pending',
+              payment_method: 'delivery',
+              delivery_status: 'delivered',
+            }),
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: null }),
+      }
+    }))
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8 },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    const props = capturedShellProps as {
+      drawerProps: {
+        doneStepProps: {
+          onConfirmDelivery: () => Promise<void>
+        }
+      }
+    }
+
+    await props.drawerProps.doneStepProps.onConfirmDelivery()
+
+    expect(fetch).toHaveBeenCalledWith('/api/public/orders/order-3/confirm-delivery', {
+      method: 'POST',
+    })
+    expect(stateSetters[22]).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'order-3',
+        status: 'delivered',
+        delivery_status: 'delivered',
+      }),
+    )
+    expect(stateSetters[21]).toHaveBeenCalledWith('Pedido entregue com sucesso.')
+    expect(toastSuccessMock).toHaveBeenCalledWith('Entrega confirmada com sucesso.')
+  })
+
   it('executa cleanups dos pollings de checkout e pedido', async () => {
     stateValues[17] = 'order-1'
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -823,6 +823,7 @@ describe('menu components', () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 
     const onCancelOrder = vi.fn()
+    const onConfirmDelivery = vi.fn()
     const onClose = vi.fn()
     const elements = flattenElements(
       React.createElement(MenuDoneStep, {
@@ -847,7 +848,9 @@ describe('menu components', () => {
         getStepState: (key: 'pending' | 'confirmed' | 'ready') =>
           key === 'ready' ? 'current' : 'done',
         cancelOrderLoading: true,
+        confirmDeliveryLoading: false,
         onCancelOrder,
+        onConfirmDelivery,
         onClose,
       }),
     )
@@ -861,11 +864,14 @@ describe('menu components', () => {
       (element) => element.type === 'button' && typeof element.props.onClick === 'function',
     )
 
-    expect(buttons).toHaveLength(1)
-    expect(getTextContent(buttons[0])).toContain('Fechar')
+    expect(buttons).toHaveLength(2)
+    expect(getTextContent(buttons[0])).toContain('Confirmar recebimento')
+    expect(getTextContent(buttons[1])).toContain('Fechar')
 
     buttons[0].props.onClick()
+    buttons[1].props.onClick()
 
+    expect(onConfirmDelivery).toHaveBeenCalledOnce()
     expect(onClose).toHaveBeenCalledOnce()
     expect(onCancelOrder).not.toHaveBeenCalled()
   })
@@ -895,7 +901,9 @@ describe('menu components', () => {
         getStepState: (key: 'pending' | 'confirmed' | 'ready') =>
           key === 'ready' ? 'current' : 'done',
         cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
         onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
         onClose: vi.fn(),
       })
     )
@@ -933,7 +941,9 @@ describe('menu components', () => {
         getStepState: (key: 'pending' | 'confirmed' | 'ready') =>
           key === 'pending' ? 'done' : key === 'confirmed' ? 'current' : 'upcoming',
         cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
         onCancelOrder,
+        onConfirmDelivery: vi.fn(),
         onClose,
       }),
     )
@@ -972,7 +982,9 @@ describe('menu components', () => {
         orderSteps: [{ key: 'pending', label: 'Recebido', description: 'Entrou na fila.' }],
         getStepState: () => 'current',
         cancelOrderLoading: true,
+        confirmDeliveryLoading: false,
         onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
         onClose: vi.fn(),
       }),
     )
@@ -992,7 +1004,9 @@ describe('menu components', () => {
         orderSteps: [],
         getStepState: () => 'upcoming',
         cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
         onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
         onClose: vi.fn(),
       }),
     )


### PR DESCRIPTION
## Resumo
Este PR adiciona confirmação pública de entrega pelo consumidor no acompanhamento do pedido, mantendo o fluxo atual de confirmação pelo estabelecimento.

## O que foi ajustado
- cria a rota pública `POST /api/public/orders/[id]/confirm-delivery`
- valida que só pedidos de delivery em `out_for_delivery` podem ser confirmados pelo consumidor
- atualiza o pedido para `delivered` com `delivery_status = delivered`
- mantém o envio do evento de WhatsApp de pedido entregue
- adiciona botão `Confirmar recebimento` no passo final do acompanhamento do cliente
- atualiza o estado local e o aviso da tela após a confirmação

## Impacto esperado
- o cliente final pode confirmar que recebeu o pedido
- o estabelecimento continua podendo confirmar a entrega pelo painel, como fallback
- o tracking do pedido fica mais completo no fluxo de delivery

## Validação
- `npm test`
- `npm run build`