### PR TITLE
fix: align sales metrics with paid non-cancelled orders

### DIFF
--- a/app/(dashboard)/vendas/page.tsx
+++ b/app/(dashboard)/vendas/page.tsx
@@ -25,8 +25,8 @@ export default function VendasPage() {
           bg: 'bg-green-50',
         },
         {
-          label: 'Pedidos entregues',
-          value: metrics.delivered,
+          label: 'Vendas concluídas',
+          value: metrics.paid_orders,
           icon: ShoppingBag,
           color: 'text-blue-600',
           bg: 'bg-blue-50',

--- a/app/api/sales/metrics/route.ts
+++ b/app/api/sales/metrics/route.ts
@@ -48,11 +48,10 @@ export async function GET(request: NextRequest) {
     const pending = orders.filter((o) =>
       ['pending', 'confirmed', 'preparing', 'ready'].includes(o.status)
     )
-    const revenue = delivered
-      .filter((o) => o.payment_status === 'paid')
+    const paidOrders = orders.filter((o) => o.payment_status === 'paid' && o.status !== 'cancelled')
+    const revenue = paidOrders
       .reduce((sum, o) => sum + Number(o.total), 0)
-
-    const average_ticket = delivered.length > 0 ? revenue / delivered.length : 0
+    const average_ticket = paidOrders.length > 0 ? revenue / paidOrders.length : 0
 
     return NextResponse.json({
       data: {
@@ -60,6 +59,7 @@ export async function GET(request: NextRequest) {
         from,
         to,
         total_orders,
+        paid_orders: paidOrders.length,
         delivered: delivered.length,
         cancelled: cancelled.length,
         pending: pending.length,

--- a/tests/integration/api-feature-routes.test.ts
+++ b/tests/integration/api-feature-routes.test.ts
@@ -153,6 +153,7 @@ describe('api feature routes', () => {
               { id: '1', status: 'delivered', total: 30, payment_status: 'paid' },
               { id: '2', status: 'delivered', total: 50, payment_status: 'pending' },
               { id: '3', status: 'confirmed', total: 20, payment_status: 'pending' },
+              { id: '4', status: 'confirmed', total: 45, payment_status: 'paid' },
             ],
             error: null,
           }),
@@ -168,9 +169,10 @@ describe('api feature routes', () => {
     expect(response.status).toBe(200)
     expect(json.data.period).toBe('month')
     expect(json.data.delivered).toBe(2)
-    expect(json.data.pending).toBe(1)
-    expect(json.data.revenue).toBe(30)
-    expect(json.data.average_ticket).toBe(15)
+    expect(json.data.pending).toBe(2)
+    expect(json.data.paid_orders).toBe(2)
+    expect(json.data.revenue).toBe(75)
+    expect(json.data.average_ticket).toBe(37.5)
   })
 
   it('sales metrics GET cobre período custom sem from e to', async () => {

--- a/tests/unit/vendas-page-component.test.tsx
+++ b/tests/unit/vendas-page-component.test.tsx
@@ -68,6 +68,7 @@ describe('VendasPage component', () => {
     useSalesMetricsMock.mockReturnValue({
       data: {
         revenue: 1234.5,
+        paid_orders: 12,
         delivered: 12,
         average_ticket: 102.87,
         cancelled: 2,
@@ -104,7 +105,7 @@ describe('VendasPage component', () => {
 
     expect(markup).toContain('Faturamento')
     expect(markup).toContain('R$ 1234.50')
-    expect(markup).toContain('Pedidos entregues')
+    expect(markup).toContain('Vendas concluídas')
     expect(markup).toContain('12')
     expect(markup).toContain('Ticket médio')
     expect(markup).toContain('R$ 102.87')


### PR DESCRIPTION
## Resumo
Este PR corrige o cálculo de faturamento e ticket médio para refletir vendas realmente concluídas financeiramente, em vez de depender apenas de pedidos com status `delivered`.

## O que foi ajustado
- atualiza `/api/sales/metrics` para calcular:
  - `revenue` com pedidos `paid` e não cancelados
  - `average_ticket` com base nesses pedidos pagos
  - `paid_orders` como contador explícito de vendas concluídas
- mantém `delivered`, `cancelled` e `pending` como métricas operacionais separadas
- ajusta a tela de vendas para mostrar `Vendas concluídas` usando `paid_orders`

## Impacto esperado
- faturamento deixa de aparecer zerado quando há pedidos pagos ainda não marcados como `delivered`
- ticket médio fica coerente com a receita exibida
- a tela de vendas passa a comunicar melhor a quantidade real de vendas concluídas

## Validação
- `npm test`
- `npm run build`