### PR TITLE
fix: show contextual notices for non-online public orders

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -21,6 +21,7 @@ import {
   getCheckoutPollingErrorNotice,
   getCheckoutStepTitle,
   getCheckoutNoticeFromResult,
+  getCreatedPublicOrderNotice,
   getContinueFlowTarget,
   getHalfFlavorOptions,
   getOrderStepState,
@@ -435,6 +436,12 @@ export default function MenuClient({
       setPublicOrderStatus(nextState.publicOrderStatus)
       setCheckoutStep(nextState.checkoutStep)
       setCart(nextState.cart)
+      setCheckoutNotice(
+        getCreatedPublicOrderNotice(
+          order.payment_status ?? nextState.publicOrderStatus.payment_status,
+          order.payment_method ?? nextState.publicOrderStatus.payment_method ?? (paymentMethod as PublicOrderStatus['payment_method'])
+        )
+      )
     } catch (e: unknown) {
       alert(getPublicOrderPlacementErrorMessage(e))
     }

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -230,6 +230,25 @@ export function getCheckoutConvertedNotice() {
   return 'Pagamento confirmado. Pedido enviado para o estabelecimento.'
 }
 
+export function getCreatedPublicOrderNotice(
+  paymentStatus?: PublicOrderStatus['payment_status'] | null,
+  paymentMethod?: PublicOrderStatus['payment_method'] | null
+) {
+  if (paymentStatus === 'paid') {
+    return getCheckoutConvertedNotice()
+  }
+
+  if (paymentMethod === 'delivery') {
+    return 'Pedido enviado para o estabelecimento. O pagamento será realizado na entrega.'
+  }
+
+  if (paymentMethod === 'counter' || paymentMethod === 'table') {
+    return 'Pedido enviado para o estabelecimento. O pagamento será realizado no local.'
+  }
+
+  return 'Pedido enviado para o estabelecimento.'
+}
+
 export function getCheckoutPollingErrorNotice() {
   return 'Nao foi possivel consultar o status do pagamento agora.'
 }

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -1661,6 +1661,9 @@ describe('MenuClient component', () => {
     )
     expect(stateSetters[17]).toHaveBeenCalledWith('order-created')
     expect(stateSetters[16]).toHaveBeenCalledWith(77)
+    expect(stateSetters[21]).toHaveBeenCalledWith(
+      'Pedido enviado para o estabelecimento. O pagamento será realizado na entrega.'
+    )
     expect(stateSetters[2]).toHaveBeenCalledWith('done')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -24,6 +24,7 @@ import {
   getCartItemLineTotal,
   getCancelledOrderMessage,
   getCartTotals,
+  getCreatedPublicOrderNotice,
   getCheckoutConvertedNotice,
   getCheckoutPollingErrorNotice,
   getCheckoutStepTitle,
@@ -535,6 +536,15 @@ describe('public menu helpers', () => {
     expect(getPublicCheckoutProcessingState(true, false)).toBe(true)
     expect(getPublicCheckoutProcessingState(false, true)).toBe(true)
     expect(getPublicCheckoutProcessingState(false, false)).toBe(false)
+    expect(getCreatedPublicOrderNotice('pending', 'delivery')).toBe(
+      'Pedido enviado para o estabelecimento. O pagamento será realizado na entrega.'
+    )
+    expect(getCreatedPublicOrderNotice('pending', 'counter')).toBe(
+      'Pedido enviado para o estabelecimento. O pagamento será realizado no local.'
+    )
+    expect(getCreatedPublicOrderNotice('paid', 'online')).toBe(
+      'Pagamento confirmado. Pedido enviado para o estabelecimento.'
+    )
   })
 
   it('monta steps do pedido conforme contexto de mesa', () => {


### PR DESCRIPTION
## Resumo
Este PR ajusta os avisos exibidos ao cliente quando um pedido público é criado sem pagamento online, evitando mensagens genéricas ou inconsistentes com o método de pagamento escolhido.

## O que foi ajustado
- adiciona o helper `getCreatedPublicOrderNotice`
- exibe aviso contextual no `MenuClient` após criação do pedido:
  - pagamento na entrega
  - pagamento no local
  - pagamento online já aprovado
- usa fallback com o estado local quando a resposta do backend não retorna `payment_method`

## Impacto esperado
- pedidos com `pagar na entrega` deixam de ficar sem feedback ou com texto ambíguo
- pedidos de mesa/caixa ficam com mensagem mais coerente para o consumidor
- o fluxo online permanece inalterado

## Validação
- `npm test`
- `npm run build`