### PR TITLE
fix: keep public order notices in sync with tracked status updates

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -497,14 +497,23 @@ export function getPublicOrderTrackingMessage(
 
 export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus | null) {
   if (!publicOrderStatus) return null
-  if (publicOrderStatus.status === 'delivered') return 'Pedido entregue com sucesso.'
-  if (
-    publicOrderStatus.payment_method === 'delivery' &&
-    publicOrderStatus.status === 'ready' &&
-    publicOrderStatus.delivery_status === 'out_for_delivery'
-  ) {
-    return 'Seu pedido saiu para entrega.'
+  if (publicOrderStatus.status === 'confirmed') {
+    return 'Seu pedido foi confirmado pelo estabelecimento.'
   }
+  if (publicOrderStatus.status === 'preparing') {
+    return 'Seu pedido está em preparo.'
+  }
+  if (publicOrderStatus.status === 'ready') {
+    if (
+      publicOrderStatus.payment_method === 'delivery' &&
+      publicOrderStatus.delivery_status === 'out_for_delivery'
+    ) {
+      return 'Seu pedido saiu para entrega.'
+    }
+
+    return 'Seu pedido está pronto.'
+  }
+  if (publicOrderStatus.status === 'delivered') return 'Pedido entregue com sucesso.'
 
   return null
 }

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -2380,6 +2380,70 @@ describe('MenuClient component', () => {
     expect(setTimeoutMock).not.toHaveBeenCalled()
   })
 
+  it('atualiza o aviso quando o polling do pedido retorna preparo', async () => {
+    stateValues[17] = 'order-preparing'
+
+    const setTimeoutMock = vi.fn()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/orders/order-preparing/status') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            data: createPublicOrderStatus({
+              id: 'order-preparing',
+              status: 'preparing',
+              payment_status: 'pending',
+              payment_method: 'delivery',
+              delivery_status: 'waiting_dispatch',
+            }),
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: null }),
+      }
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('window', {
+      location: { href: '' },
+      prompt: vi.fn(),
+      setTimeout: setTimeoutMock,
+      localStorage: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+    })
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8 },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/public/orders/order-preparing/status')
+    expect(stateSetters[21]).toHaveBeenCalledWith('Seu pedido está em preparo.')
+    expect(setTimeoutMock).toHaveBeenCalled()
+  })
+
   it('permite confirmar o recebimento no acompanhamento do pedido', async () => {
     stateValues[16] = 123
     stateValues[17] = 'order-3'

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -614,6 +614,21 @@ describe('public menu helpers', () => {
     }, 'entregue')).toBe('Seu pedido foi entregue.')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
+      status: 'confirmed',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('Seu pedido foi confirmado pelo estabelecimento.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
+      status: 'preparing',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('Seu pedido está em preparo.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
+      status: 'ready',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('Seu pedido está pronto.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
       status: 'delivered',
       delivery_status: 'delivered',
     })).toBe('Pedido entregue com sucesso.')


### PR DESCRIPTION
## Resumo
Este PR melhora o acompanhamento público do pedido para que o aviso principal evolua junto com o status retornado pelo polling.

## O que foi ajustado
- amplia `getPublicOrderStatusNotice` para cobrir:
  - `confirmed`
  - `preparing`
  - `ready`
  - `ready + out_for_delivery`
  - `delivered`
- adiciona teste de polling no `MenuClient` validando atualização do aviso quando o pedido entra em preparo

## Impacto esperado
- o consumidor vê mensagens coerentes ao longo de toda a evolução do pedido
- o banner do topo deixa de ficar preso em aviso antigo após a criação do pedido
- o tracking público fica mais consistente sem alterar o fluxo de pagamento

## Validação
- `npm test`
- `npm run build`