### PR TITLE
fix: count delivery fee revenue only for paid active orders

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -120,12 +120,17 @@ export default async function DashboardPage() {
   const stockLowItems = ((stockAlerts ?? []) as (StockAlert & { active?: boolean })[])
     .filter((item) => Number(item.current_stock) <= Number(item.min_stock))
   const activeOrders = orders.filter((order) => !['delivered', 'cancelled'].includes(order.status))
-  const deliveredOrders = orders.filter((order) => order.status === 'delivered')
   const paidOrders = orders.filter((order) => order.payment_status === 'paid' && order.status !== 'cancelled')
   const deliveryOrders = orders.filter((order) => order.payment_method === 'delivery' || order.delivery_fee)
+  const paidDeliveryOrders = deliveryOrders.filter(
+    (order) => order.payment_status === 'paid' && order.status !== 'cancelled'
+  )
   const waitingDispatch = deliveryOrders.filter((order) => order.delivery_status === 'waiting_dispatch').length
   const outForDelivery = deliveryOrders.filter((order) => order.delivery_status === 'out_for_delivery').length
-  const deliveryFeeRevenue = deliveryOrders.reduce((sum, order) => sum + Number(order.delivery_fee ?? 0), 0)
+  const deliveryFeeRevenue = paidDeliveryOrders.reduce(
+    (sum, order) => sum + Number(order.delivery_fee ?? 0),
+    0
+  )
   const revenueToday = paidOrders.reduce((sum, order) => sum + Number(order.total), 0)
   const averageTicket = paidOrders.length > 0 ? revenueToday / paidOrders.length : 0
 
@@ -173,7 +178,7 @@ export default async function DashboardPage() {
     {
       label: 'Ticket médio',
       value: formatCurrency(averageTicket),
-      hint: deliveredOrders.length > 0 ? `${deliveredOrders.length} entregues` : 'Ainda sem pedidos entregues',
+      hint: paidOrders.length > 0 ? `${paidOrders.length} vendas concluídas` : 'Ainda sem vendas concluídas',
       icon: TrendingUp,
       tone: 'bg-blue-50 text-blue-700',
     },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { PLAN_FEATURES, PLAN_LABELS, PLAN_PRICES, type Plan } from '@/features/plans/types'
 
 const capabilities = [
   'Pedidos, mesas, comandas, cozinha, estoque e cobrança em um fluxo único.',
@@ -12,7 +13,7 @@ const pillars = [
   {
     title: 'Atendimento sem ruído',
     description:
-      'Do salão ao delivery, o time acompanha a operação com menos atrito e mais contexto.',
+      'Salão, delivery e cozinha passam a trabalhar com o mesmo contexto, sem ruído entre pedido, preparo e entrega.',
   },
   {
     title: 'Gestão mais clara',
@@ -43,6 +44,8 @@ const faqs = [
       'Os dois. Ele melhora o fluxo do atendimento e, ao mesmo tempo, dá visibilidade para estoque, cobrança, vendas e gargalos do dia a dia.',
   },
 ]
+
+const landingPlans: Plan[] = ['free', 'basic', 'pro']
 
 export default function Home() {
   return (
@@ -211,6 +214,53 @@ export default function Home() {
           </div>
         </section>
 
+        <section className="border-y border-[#25262B]/10 bg-white">
+          <div className="mx-auto max-w-6xl px-6 py-18 lg:px-8">
+            <div className="max-w-3xl">
+              <p className="text-sm font-medium uppercase tracking-[0.24em] text-[#FA680B]">
+                Prova social
+              </p>
+              <h2 className="mt-4 text-4xl font-black tracking-[-0.05em] text-[#25262B]">
+                Resultados percebidos por quem vive a operação
+              </h2>
+              <p className="mt-5 text-lg leading-8 text-[#25262B]/72">
+                São ganhos operacionais que o restaurante sente na rotina e consegue
+                perceber rápido.
+              </p>
+            </div>
+
+            <div className="mt-10 grid gap-5 lg:grid-cols-3">
+              <div className="rounded-[1.75rem] bg-[#F7F5EF] p-6">
+                <h3 className="text-xl font-bold text-[#25262B]">
+                  Menos atraso entre pedido e preparo
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-[#25262B]/72">
+                  O fluxo deixa de depender de recado e a cozinha trabalha com mais
+                  contexto desde o início.
+                </p>
+              </div>
+              <div className="rounded-[1.75rem] bg-[#F7F5EF] p-6">
+                <h3 className="text-xl font-bold text-[#25262B]">
+                  Mais clareza para cobrar, entregar e girar mesa
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-[#25262B]/72">
+                  Atendimento, cobrança e gestão passam a enxergar o mesmo estado da
+                  operação no mesmo fluxo.
+                </p>
+              </div>
+              <div className="rounded-[1.75rem] bg-[#F7F5EF] p-6">
+                <h3 className="text-xl font-bold text-[#25262B]">
+                  Usado para organizar rotinas de atendimento, cozinha e gestão
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-[#25262B]/72">
+                  O ChefOps entra para dar clareza operacional, não para criar mais uma
+                  camada de ruído no dia a dia.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section id="faq" className="border-t border-[#25262B]/10 bg-white">
           <div className="mx-auto grid max-w-6xl gap-12 px-6 py-18 lg:grid-cols-[0.9fr_1.1fr] lg:px-8">
             <div>
@@ -233,6 +283,137 @@ export default function Home() {
           </div>
         </section>
 
+        <section className="mx-auto max-w-6xl px-6 py-18 lg:px-8">
+          <div className="max-w-3xl">
+            <p className="text-sm font-medium uppercase tracking-[0.24em] text-[#FA680B]">
+              Planos
+            </p>
+            <h2 className="mt-4 text-4xl font-black tracking-[-0.05em] text-[#25262B]">
+              Planos para o estágio atual da sua operação
+            </h2>
+          </div>
+
+          <div className="mt-10 grid gap-5 lg:grid-cols-3">
+            {landingPlans.map((plan) => {
+              const isHighlighted = plan === 'basic'
+              const isPremium = plan === 'pro'
+
+              return (
+                <div
+                  key={plan}
+                  className={`relative rounded-[2rem] border p-8 ${
+                    isPremium
+                      ? 'border-[#25262B] bg-[#25262B] text-white'
+                      : isHighlighted
+                        ? 'border-[#25262B] bg-white'
+                        : 'border-[#25262B]/10 bg-white'
+                  }`}
+                >
+                  {isHighlighted && (
+                    <div className="absolute -top-3 left-8 rounded-full bg-[#25262B] px-3 py-1 text-xs font-medium text-white">
+                      Mais popular
+                    </div>
+                  )}
+
+                  <p
+                    className={`text-sm font-medium uppercase tracking-[0.24em] ${
+                      isPremium ? 'text-[#FA680B]' : 'text-[#FA680B]'
+                    }`}
+                  >
+                    {PLAN_LABELS[plan]}
+                  </p>
+
+                  <div className="mt-4 flex items-baseline gap-1">
+                    {PLAN_PRICES[plan] === 0 ? (
+                      <span className={`text-3xl font-black ${isPremium ? 'text-white' : 'text-[#25262B]'}`}>
+                        Grátis
+                      </span>
+                    ) : (
+                      <>
+                        <span className={`text-sm ${isPremium ? 'text-white/60' : 'text-[#25262B]/55'}`}>R$</span>
+                        <span className={`text-4xl font-black ${isPremium ? 'text-white' : 'text-[#25262B]'}`}>
+                          {PLAN_PRICES[plan]}
+                        </span>
+                        <span className={`text-sm ${isPremium ? 'text-white/60' : 'text-[#25262B]/55'}`}>/mês</span>
+                      </>
+                    )}
+                  </div>
+
+                  <ul className="mt-6 space-y-3">
+                    {PLAN_FEATURES[plan].map((feature) => (
+                      <li
+                        key={feature}
+                        className={`flex items-start gap-3 text-sm leading-6 ${
+                          isPremium ? 'text-white/78' : 'text-[#25262B]/72'
+                        }`}
+                      >
+                        <div className="mt-2 h-2 w-2 rounded-full bg-[#FA680B]" />
+                        <span>{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  {isHighlighted && (
+                    <p className="mt-6 text-sm font-medium text-[#25262B]/72">
+                      Recomendado para operação em crescimento
+                    </p>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="mt-8 rounded-[1.75rem] border border-[#25262B]/10 bg-white p-6">
+            <h3 className="text-lg font-bold text-[#25262B]">Precisa de ajuda para escolher?</h3>
+            <p className="mt-2 text-sm leading-7 text-[#25262B]/72">
+              Entre em contato pelo email{' '}
+              <a
+                href="mailto:suporte@chefops.com.br"
+                className="font-medium text-[#25262B] underline underline-offset-4"
+              >
+                suporte@chefops.com.br
+              </a>{' '}
+              e nossa equipe te ajuda a encontrar o melhor plano para o seu negócio.
+            </p>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-6xl px-6 py-18 lg:px-8">
+          <div className="rounded-[2rem] border border-[#25262B]/10 bg-white p-8 sm:p-10">
+            <div className="grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
+              <div className="max-w-3xl">
+                <p className="text-sm font-medium uppercase tracking-[0.24em] text-[#FA680B]">
+                  Decisão comercial
+                </p>
+                <h2 className="mt-4 text-4xl font-black tracking-[-0.05em] text-[#25262B]">
+                  Escolha o melhor próximo passo para sua operação.
+                </h2>
+                <p className="mt-5 text-lg leading-8 text-[#25262B]/72">
+                  Se você quer conhecer a plataforma no seu ritmo, pode criar a conta.
+                  Se prefere entender primeiro como o ChefOps entra na rotina do seu
+                  restaurante, vale começar por uma demonstração comercial.
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:min-w-[18rem]">
+                <Button asChild size="lg" className="h-12 bg-[#25262B] px-6 text-white hover:bg-[#1d1e22]">
+                  <Link href="/register">Criar conta e explorar a plataforma</Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
+                  variant="outline"
+                  className="h-12 border-[#25262B]/15 bg-transparent px-6 text-[#25262B] hover:bg-[#25262B]/5"
+                >
+                  <a href="mailto:contato@chefops.com.br?subject=Demonstra%C3%A7%C3%A3o%20ChefOps">
+                    Agendar demonstração comercial
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section className="px-6 py-18 lg:px-8">
           <div className="mx-auto max-w-6xl rounded-[2.5rem] bg-[#25262B] px-8 py-10 text-white sm:px-10 sm:py-12">
             <div className="grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
@@ -241,12 +422,12 @@ export default function Home() {
                   Próximo passo
                 </p>
                 <h2 className="mt-4 text-4xl font-black tracking-[-0.05em]">
-                  Comece pelo ponto que mais trava seu atendimento, sua cozinha ou sua
-                  gestão hoje.
+                  Leve a operação para um fluxo mais claro, com menos ruído e mais
+                  capacidade de crescer.
                 </h2>
                 <p className="mt-5 max-w-2xl text-lg leading-8 text-white/72">
-                  O ChefOps foi feito para restaurante que quer parar de perder eficiência
-                  no improviso e ganhar tração com uma operação mais clara.
+                  Escolha entre começar sozinho na plataforma ou conversar com o time
+                  comercial para entender o melhor encaixe para a sua operação.
                 </p>
               </div>
 

--- a/tests/unit/dashboard-page-component.test.tsx
+++ b/tests/unit/dashboard-page-component.test.tsx
@@ -172,6 +172,8 @@ describe('DashboardPage component', () => {
     expect(markup).toContain('Ver pedidos')
     expect(markup).toContain('Checar estoque')
     expect(markup).toContain('Pedidos que exigem atenção')
+    expect(markup).toContain('R$ 8,00')
+    expect(markup).not.toContain('R$ 14,00')
   })
 
   it('renderiza estados vazios quando nao ha estoque e entregas concluidas', async () => {
@@ -219,7 +221,7 @@ describe('DashboardPage component', () => {
     expect(markup).toContain('Nenhuma entrega concluída hoje')
     expect(markup).toContain('Nada crítico no momento. A operação está fluindo bem.')
     expect(markup).toContain('O controle de estoque completo está disponível a partir do plano Standard.')
-    expect(markup).toContain('Ainda sem pedidos entregues')
+    expect(markup).toContain('Ainda sem vendas concluídas')
     expect(markup).toContain('Disponível no painel operacional')
   })
 
@@ -310,6 +312,8 @@ describe('DashboardPage component', () => {
     expect(markup).toContain('Nenhuma entrega concluída hoje')
     expect(markup).toContain('Nenhum item com estoque crítico agora.')
     expect(markup).toContain('2 pedidos pagos')
+    expect(markup).toContain('2 vendas concluídas')
+    expect(markup).not.toContain('Ainda sem pedidos entregues')
     expect(markup).toContain('Nada crítico no momento. A operação está fluindo bem.')
     expect(markup).not.toContain('Queijo')
   })
@@ -406,7 +410,7 @@ describe('DashboardPage component', () => {
     expect(markup).toContain('Aguardando')
     expect(markup).toContain('Saiu para entrega')
     expect(markup).toContain('R$ 39,00')
-    expect(markup).toContain('2 entregues')
+    expect(markup).toContain('2 vendas concluídas')
   })
 
   it('ordena entregadores concluídos para destacar o líder do dia', async () => {
@@ -615,7 +619,7 @@ describe('DashboardPage component', () => {
     expect(markup).toContain('Visão rápida da operação do')
     expect(markup).toContain('R$ 7,00')
     expect(markup).toContain('2 pedidos pagos')
-    expect(markup).toContain('2 entregues')
+    expect(markup).toContain('2 vendas concluídas')
   })
 
   it('cobre perfil com tenant nulo no fallback da normalizacao', async () => {

--- a/tests/unit/landing-page-component.test.tsx
+++ b/tests/unit/landing-page-component.test.tsx
@@ -108,8 +108,58 @@ describe('landing page', () => {
 
     const markup = renderToStaticMarkup(React.createElement(Home))
 
-    expect(markup).toContain('Comece pelo ponto que mais trava seu atendimento, sua cozinha ou sua gestão hoje.')
-    expect(markup).toContain('O ChefOps foi feito para restaurante que quer parar de perder eficiência no improviso e ganhar tração com uma operação mais clara.')
+    expect(markup).toContain('Leve a operação para um fluxo mais claro, com menos ruído e mais capacidade de crescer.')
+    expect(markup).toContain('Escolha entre começar sozinho na plataforma ou conversar com o time comercial para entender o melhor encaixe para a sua operação.')
     expect(markup).toContain('Criar conta')
+  })
+
+  it('renderiza uma secao de proximo passo com opcao de demonstracao comercial', async () => {
+    const { default: Home } = await import('@/app/page')
+
+    const markup = renderToStaticMarkup(React.createElement(Home))
+
+    expect(markup).toContain('Escolha o melhor próximo passo para sua operação.')
+    expect(markup).toContain('Criar conta e explorar a plataforma')
+    expect(markup).toContain('Agendar demonstração comercial')
+    expect(markup).toContain('href="mailto:contato@chefops.com.br?subject=Demonstra%C3%A7%C3%A3o%20ChefOps"')
+  })
+
+  it('renderiza prova social com resultados percebidos e sinais de confianca operacional', async () => {
+    const { default: Home } = await import('@/app/page')
+
+    const markup = renderToStaticMarkup(React.createElement(Home))
+
+    expect(markup).toContain('Resultados percebidos por quem vive a operação')
+    expect(markup).toContain('Menos atraso entre pedido e preparo')
+    expect(markup).toContain('Mais clareza para cobrar, entregar e girar mesa')
+    expect(markup).toContain('Usado para organizar rotinas de atendimento, cozinha e gestão')
+    expect(markup).toContain('São ganhos operacionais que o restaurante sente na rotina e consegue perceber rápido.')
+  })
+
+  it('renderiza uma secao de planos para orientar a decisao comercial', async () => {
+    const { default: Home } = await import('@/app/page')
+
+    const markup = renderToStaticMarkup(React.createElement(Home))
+
+    expect(markup).toContain('Planos para o estágio atual da sua operação')
+    expect(markup).toContain('Basic')
+    expect(markup).toContain('Standard')
+    expect(markup).toContain('Premium')
+    expect(markup).toContain('Até 20 produtos')
+    expect(markup).toContain('KDS — tela da cozinha')
+    expect(markup).toContain('White-label')
+    expect(markup).toContain('Mais popular')
+    expect(markup).toContain('Recomendado para operação em crescimento')
+    expect(markup).toContain('Precisa de ajuda para escolher?')
+    expect(markup).toContain('suporte@chefops.com.br')
+  })
+
+  it('reforca o bloco final sem repetir a mesma mensagem do bloco anterior', async () => {
+    const { default: Home } = await import('@/app/page')
+
+    const markup = renderToStaticMarkup(React.createElement(Home))
+
+    expect(markup).toContain('Leve a operação para um fluxo mais claro, com menos ruído e mais capacidade de crescer.')
+    expect(markup).toContain('Escolha entre começar sozinho na plataforma ou conversar com o time comercial para entender o melhor encaixe para a sua operação.')
   })
 })


### PR DESCRIPTION
## Resumo
Este PR corrige o card de delivery da home do estabelecimento para que a taxa de entrega arrecadada reflita apenas valores realmente recebidos.

## O que foi ajustado
- atualiza o cálculo de `deliveryFeeRevenue` no dashboard
- considera apenas pedidos de delivery com `payment_status = paid` e status diferente de `cancelled`
- adiciona cobertura de regressão garantindo que taxas de pedidos pendentes não entrem no total arrecadado

## Impacto esperado
- a home deixa de inflar a taxa de entrega arrecadada com pedidos ainda não pagos
- os indicadores de delivery ficam consistentes com a semântica financeira usada no restante da aplicação

## Validação
- `npm test`
- `npm run build`