### PR TITLE
refactor: remove manual Mercado Pago charge action from order cards

### DIFF
--- a/app/(dashboard)/pedidos/page.tsx
+++ b/app/(dashboard)/pedidos/page.tsx
@@ -14,14 +14,10 @@ import {
   buildAdvanceOrderPayload,
   buildCancelOrderPayload,
   buildConfirmPaymentRequest,
-  buildMercadoPagoCheckoutRequest,
   buildDriverAssignmentPayload,
   getOrderFilterChangeState,
   getOrdersInvalidationQueryKey,
-  getMercadoPagoCheckoutErrorMessage,
-  getMercadoPagoWindowOpenFeatures,
   getOrderFilters,
-  resolveMercadoPagoCheckoutUrl,
 } from '@/features/orders/orders-page'
 import { OrdersPageContent } from '@/features/orders/OrdersPageContent'
 
@@ -31,7 +27,6 @@ export default function PedidosPage() {
   const [page, setPage] = useState(1)
   const pageSize = 10
   const [manualOrderOpen, setManualOrderOpen] = useState(false)
-  const [chargingOrderId, setChargingOrderId] = useState<string | null>(null)
   const { data, isLoading } = useOrders({ status: statusFilter, page, pageSize })
   const { data: deliveryDrivers } = useDeliveryDrivers()
   const hasWhatsappNotifications = useHasFeature('whatsapp_notifications')
@@ -47,27 +42,6 @@ export default function PedidosPage() {
     const reason = prompt('Motivo do cancelamento:')
     if (reason === null) return
     await updateStatus.mutateAsync(buildCancelOrderPayload(order, reason))
-  }
-
-  async function handleMercadoPagoCheckout(order: Order) {
-    try {
-      setChargingOrderId(order.id)
-      const request = buildMercadoPagoCheckoutRequest(order)
-      const res = await fetch(request.url, request.init)
-      const json = await res.json()
-
-      if (!res.ok) {
-        throw new Error(json.error)
-      }
-
-      const url = resolveMercadoPagoCheckoutUrl(json.data)
-
-      window.open(url, getMercadoPagoWindowOpenFeatures())
-    } catch (error) {
-      alert(getMercadoPagoCheckoutErrorMessage(error))
-    } finally {
-      setChargingOrderId(null)
-    }
   }
 
   async function handleAssignDriver(order: Order, deliveryDriverId: string) {
@@ -102,11 +76,9 @@ export default function PedidosPage() {
       deliveryDrivers={deliveryDrivers ?? []}
       hasWhatsappNotifications={hasWhatsappNotifications}
       updatePending={updateStatus.isPending}
-      chargingOrderId={chargingOrderId}
       onAssignDriver={handleAssignDriver}
       onAdvance={handleAdvance}
       onAdvanceDelivery={handleAdvanceDelivery}
-      onMercadoPagoCheckout={handleMercadoPagoCheckout}
       onConfirmPayment={async (targetOrder) => {
         const request = buildConfirmPaymentRequest(targetOrder)
         await fetch(request.url, request.init)

--- a/features/orders/OrderCard.tsx
+++ b/features/orders/OrderCard.tsx
@@ -17,11 +17,9 @@ export function OrderCard({
   deliveryDrivers,
   hasWhatsappNotifications,
   updatePending,
-  chargingOrderId,
   onAssignDriver,
   onAdvance,
   onAdvanceDelivery,
-  onMercadoPagoCheckout,
   onConfirmPayment,
   onCancel,
 }: {
@@ -30,11 +28,11 @@ export function OrderCard({
   deliveryDrivers: Array<{ id: string; name: string; vehicle_type: string; active: boolean }>
   hasWhatsappNotifications: boolean
   updatePending: boolean
-  chargingOrderId: string | null
+  chargingOrderId?: string | null
   onAssignDriver: (order: Order, deliveryDriverId: string) => void
   onAdvance: (order: Order) => void
   onAdvanceDelivery: (order: Order) => void
-  onMercadoPagoCheckout: (order: Order) => void
+  onMercadoPagoCheckout?: (order: Order) => void
   onConfirmPayment: (order: Order) => void
   onCancel: (order: Order) => void
 }) {
@@ -208,17 +206,6 @@ export function OrderCard({
             })}
           </p>
           <div className="mt-3 flex justify-end gap-2">
-            {order.payment_status === 'pending' && (
-              <Button
-                size="sm"
-                variant="outline"
-                className="border-blue-200 text-blue-700 hover:bg-blue-50"
-                disabled={chargingOrderId === order.id}
-                onClick={() => onMercadoPagoCheckout(order)}
-              >
-                {chargingOrderId === order.id ? 'Gerando...' : 'Cobrar com MP'}
-              </Button>
-            )}
             {shouldShowAdvanceButton(order) && (
               <Button size="sm" onClick={() => onAdvance(order)} disabled={updatePending}>
                 {config.nextLabel}

--- a/features/orders/OrdersListSection.tsx
+++ b/features/orders/OrdersListSection.tsx
@@ -14,11 +14,9 @@ export function OrdersListSection({
   deliveryDrivers,
   hasWhatsappNotifications,
   updatePending,
-  chargingOrderId,
   onAssignDriver,
   onAdvance,
   onAdvanceDelivery,
-  onMercadoPagoCheckout,
   onConfirmPayment,
   onCancel,
 }: {
@@ -31,11 +29,11 @@ export function OrdersListSection({
   deliveryDrivers: Array<{ id: string; name: string; vehicle_type: string; active: boolean }>
   hasWhatsappNotifications: boolean
   updatePending: boolean
-  chargingOrderId: string | null
+  chargingOrderId?: string | null
   onAssignDriver: (order: Order, deliveryDriverId: string) => void | Promise<void>
   onAdvance: (order: Order) => void | Promise<void>
   onAdvanceDelivery: (order: Order) => void | Promise<void>
-  onMercadoPagoCheckout: (order: Order) => void | Promise<void>
+  onMercadoPagoCheckout?: (order: Order) => void | Promise<void>
   onConfirmPayment: (order: Order) => void | Promise<void>
   onCancel: (order: Order) => void | Promise<void>
 }) {
@@ -55,11 +53,9 @@ export function OrdersListSection({
               deliveryDrivers={deliveryDrivers}
               hasWhatsappNotifications={hasWhatsappNotifications}
               updatePending={updatePending}
-              chargingOrderId={chargingOrderId}
               onAssignDriver={onAssignDriver}
               onAdvance={onAdvance}
               onAdvanceDelivery={onAdvanceDelivery}
-              onMercadoPagoCheckout={onMercadoPagoCheckout}
               onConfirmPayment={onConfirmPayment}
               onCancel={onCancel}
             />

--- a/features/orders/OrdersPageContent.tsx
+++ b/features/orders/OrdersPageContent.tsx
@@ -20,11 +20,11 @@ type Props = {
   deliveryDrivers: Array<{ id: string; name: string; vehicle_type: string; active: boolean }>
   hasWhatsappNotifications: boolean
   updatePending: boolean
-  chargingOrderId: string | null
+  chargingOrderId?: string | null
   onAssignDriver: (order: Order, deliveryDriverId: string) => void | Promise<void>
   onAdvance: (order: Order) => void | Promise<void>
   onAdvanceDelivery: (order: Order) => void | Promise<void>
-  onMercadoPagoCheckout: (order: Order) => void | Promise<void>
+  onMercadoPagoCheckout?: (order: Order) => void | Promise<void>
   onConfirmPayment: (order: Order) => void | Promise<void>
   onCancel: (order: Order) => void | Promise<void>
 }
@@ -44,11 +44,9 @@ export function OrdersPageContent({
   deliveryDrivers,
   hasWhatsappNotifications,
   updatePending,
-  chargingOrderId,
   onAssignDriver,
   onAdvance,
   onAdvanceDelivery,
-  onMercadoPagoCheckout,
   onConfirmPayment,
   onCancel,
 }: Props) {
@@ -72,11 +70,9 @@ export function OrdersPageContent({
         deliveryDrivers={deliveryDrivers}
         hasWhatsappNotifications={hasWhatsappNotifications}
         updatePending={updatePending}
-        chargingOrderId={chargingOrderId}
         onAssignDriver={onAssignDriver}
         onAdvance={onAdvance}
         onAdvanceDelivery={onAdvanceDelivery}
-        onMercadoPagoCheckout={onMercadoPagoCheckout}
         onConfirmPayment={onConfirmPayment}
         onCancel={onCancel}
       />

--- a/features/orders/orders-page.ts
+++ b/features/orders/orders-page.ts
@@ -139,19 +139,6 @@ export function getDeliveryActionLabel(order: Pick<Order, 'status' | 'delivery_s
     : 'Saiu para entrega'
 }
 
-export function resolveMercadoPagoCheckoutUrl(payload: {
-  checkout_url?: string | null
-  sandbox_init_point?: string | null
-  init_point?: string | null
-} | null | undefined) {
-  const url = payload?.checkout_url || payload?.sandbox_init_point || payload?.init_point
-  if (!url) {
-    throw new Error('Mercado Pago não retornou um link de pagamento.')
-  }
-
-  return url
-}
-
 export function buildDriverAssignmentPayload(order: Pick<Order, 'id' | 'status'>, deliveryDriverId: string) {
   return {
     id: order.id,
@@ -219,19 +206,6 @@ export function getOrderFilterChangeState(value: string) {
     statusFilter: value,
     page: 1,
   }
-}
-
-export function buildMercadoPagoCheckoutRequest(order: Pick<Order, 'id'>) {
-  return {
-    url: `/api/orders/${order.id}/mercado-pago`,
-    init: {
-      method: 'POST',
-    },
-  }
-}
-
-export function getMercadoPagoWindowOpenFeatures() {
-  return '_blank,noopener,noreferrer'
 }
 
 export function getOrdersInvalidationQueryKey() {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -2177,9 +2177,6 @@ describe('menu components', () => {
     const nextButton = elements.find(
       (element) => element.type === 'button' && getTextContent(element) === 'Próxima'
     )
-    const mpButton = elements.find(
-      (element) => element.type === 'button' && getTextContent(element) === 'Cobrar com MP'
-    )
     const deliveryButton = elements.find(
       (element) => element.type === 'button' && getTextContent(element) === 'Saiu para entrega'
     )
@@ -2194,7 +2191,6 @@ describe('menu components', () => {
     expect(readyFilter).toBeTruthy()
     expect(previousButton).toBeTruthy()
     expect(nextButton).toBeTruthy()
-    expect(mpButton).toBeTruthy()
     expect(deliveryButton).toBeTruthy()
     expect(cancelButton).toBeTruthy()
     expect(select).toBeTruthy()
@@ -2203,7 +2199,6 @@ describe('menu components', () => {
     readyFilter!.props.onClick()
     previousButton!.props.onClick()
     nextButton!.props.onClick()
-    mpButton!.props.onClick()
     deliveryButton!.props.onClick()
     cancelButton!.props.onClick()
     select!.props.onChange({ target: { value: '' } })
@@ -2212,7 +2207,6 @@ describe('menu components', () => {
     expect(onStatusFilterChange).toHaveBeenCalledWith('ready')
     expect(onPageChange).toHaveBeenCalledWith(1)
     expect(onPageChange).toHaveBeenCalledWith(3)
-    expect(onMercadoPagoCheckout).toHaveBeenCalledWith(order)
     expect(onAdvanceDelivery).toHaveBeenCalledWith(order)
     expect(onCancel).toHaveBeenCalledWith(order)
     expect(onAssignDriver).toHaveBeenCalledWith(order, '')
@@ -3297,7 +3291,7 @@ describe('menu components', () => {
     expect(emptyMarkup).toContain('Nenhum pedido encontrado.')
   })
 
-  it('renderiza card de pedido com entrega, whatsapp e ações', async () => {
+  it('renderiza card de pedido com entrega, whatsapp e ações sem cobrança manual por MP', async () => {
     const { OrderCard } = await import('@/features/orders/OrderCard')
 
     const markup = renderToStaticMarkup(
@@ -3380,7 +3374,7 @@ describe('menu components', () => {
     expect(markup).toContain('Endereço de entrega')
     expect(markup).toContain('WhatsApp')
     expect(markup).toContain('Saiu para entrega')
-    expect(markup).toContain('Cobrar com MP')
+    expect(markup).not.toContain('Cobrar com MP')
     expect(markup).toContain('Cancelar')
   })
 
@@ -3519,7 +3513,6 @@ describe('menu components', () => {
     expect(markup).toContain('Falhou')
     expect(markup).toContain('Motivo: Número inválido')
     expect(markup).toContain('Pedido recebido')
-    expect(markup).toContain('Gerando...')
     expect(markup).toContain('Iniciar preparo')
   })
 
@@ -3899,9 +3892,6 @@ describe('menu components', () => {
     const select = elements.find(
       (element) => element.type === 'select' && typeof element.props.onChange === 'function'
     )
-    const chargeButton = elements.find(
-      (element) => element.type === 'button' && getTextContent(element) === 'Cobrar com MP'
-    )
     const deliveryButton = elements.find(
       (element) => element.type === 'button' && getTextContent(element) === 'Saiu para entrega'
     )
@@ -3910,17 +3900,14 @@ describe('menu components', () => {
     )
 
     expect(select).toBeTruthy()
-    expect(chargeButton).toBeTruthy()
     expect(deliveryButton).toBeTruthy()
     expect(cancelButton).toBeTruthy()
 
     select!.props.onChange({ target: { value: 'driver-2' } })
-    chargeButton!.props.onClick()
     deliveryButton!.props.onClick()
     cancelButton!.props.onClick()
 
     expect(onAssignDriver).toHaveBeenCalledWith(order, 'driver-2')
-    expect(onMercadoPagoCheckout).toHaveBeenCalledWith(order)
     expect(onAdvance).not.toHaveBeenCalled()
     expect(onAdvanceDelivery).toHaveBeenCalledWith(order)
     expect(onCancel).toHaveBeenCalledWith(order)

--- a/tests/unit/orders-page-component.test.tsx
+++ b/tests/unit/orders-page-component.test.tsx
@@ -101,7 +101,6 @@ describe('PedidosPage component', () => {
       onStatusFilterChange: (value: string) => void
       onPageChange: (page: number) => void
       onConfirmPayment: (order: { id: string }) => Promise<void>
-      onMercadoPagoCheckout: (order: { id: string }) => Promise<void>
       onAssignDriver: (order: { id: string; status: string }, driverId: string) => Promise<void>
       onAdvance: (order: { id: string; status: string }) => Promise<void>
       onAdvanceDelivery: (order: { id: string; status: string; delivery_status?: string }) => Promise<void>
@@ -131,7 +130,6 @@ describe('PedidosPage component', () => {
     await props.onAdvanceDelivery({ id: 'order-1', status: 'ready', delivery_status: 'assigned' })
     await props.onAssignDriver({ id: 'order-1', status: 'ready' }, 'driver-1')
     await props.onCancel({ id: 'order-1' })
-    await props.onMercadoPagoCheckout({ id: 'order-1' })
     await props.onConfirmPayment({ id: 'order-1' })
 
     expect(mutateAsync).toHaveBeenCalledWith({ id: 'order-1', status: 'confirmed' })
@@ -151,8 +149,6 @@ describe('PedidosPage component', () => {
       cancelled_reason: 'Cliente desistiu',
     })
 
-    expect(fetch).toHaveBeenCalledWith('/api/orders/order-1/mercado-pago', { method: 'POST' })
-    expect(window.open).toHaveBeenCalledWith('https://mp.test/checkout', '_blank,noopener,noreferrer')
     expect(fetch).toHaveBeenCalledWith('/api/orders/order-1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -186,7 +182,6 @@ describe('PedidosPage component', () => {
       onAdvance: (order: { id: string; status: string }) => Promise<void>
       onAdvanceDelivery: (order: { id: string; status: string; delivery_status?: string }) => Promise<void>
       onCancel: (order: { id: string }) => Promise<void>
-      onMercadoPagoCheckout: (order: { id: string }) => Promise<void>
     }
 
     expect(props.deliveryDrivers).toEqual([])
@@ -195,10 +190,7 @@ describe('PedidosPage component', () => {
     await props.onAdvance({ id: 'order-1', status: 'cancelled' })
     await props.onAdvanceDelivery({ id: 'order-1', status: 'confirmed' })
     await props.onCancel({ id: 'order-1' })
-    await props.onMercadoPagoCheckout({ id: 'order-1' })
-
     expect(mutateAsync).not.toHaveBeenCalled()
-    expect(alert).toHaveBeenCalledWith('Falha ao gerar cobrança')
   })
 
   it('aplica fallbacks de listas quando os hooks retornam dados ausentes', async () => {

--- a/tests/unit/orders-page-content.test.tsx
+++ b/tests/unit/orders-page-content.test.tsx
@@ -52,7 +52,6 @@ describe('OrdersPageContent', () => {
     const onAssignDriver = vi.fn()
     const onAdvance = vi.fn()
     const onAdvanceDelivery = vi.fn()
-    const onMercadoPagoCheckout = vi.fn()
     const onConfirmPayment = vi.fn()
     const onCancel = vi.fn()
 
@@ -92,11 +91,9 @@ describe('OrdersPageContent', () => {
         deliveryDrivers: [{ id: 'driver-1', name: 'João', vehicle_type: 'bike', active: true }],
         hasWhatsappNotifications: true,
         updatePending: false,
-        chargingOrderId: null,
         onAssignDriver,
         onAdvance,
         onAdvanceDelivery,
-        onMercadoPagoCheckout,
         onConfirmPayment,
         onCancel,
       }),
@@ -127,12 +124,10 @@ describe('OrdersPageContent', () => {
       deliveryDrivers: [{ id: 'driver-1', name: 'João', vehicle_type: 'bike', active: true }],
       hasWhatsappNotifications: true,
       updatePending: false,
-      chargingOrderId: null,
       onPageChange,
       onAssignDriver,
       onAdvance,
       onAdvanceDelivery,
-      onMercadoPagoCheckout,
       onConfirmPayment,
       onCancel,
     })
@@ -162,11 +157,9 @@ describe('OrdersPageContent', () => {
       deliveryDrivers: [],
       hasWhatsappNotifications: false,
       updatePending: true,
-      chargingOrderId: 'order-2',
       onAssignDriver,
       onAdvance,
       onAdvanceDelivery,
-      onMercadoPagoCheckout,
       onConfirmPayment,
       onCancel,
     })
@@ -181,7 +174,6 @@ describe('OrdersPageContent', () => {
       deliveryDrivers: [],
       hasWhatsappNotifications: false,
       updatePending: true,
-      chargingOrderId: 'order-2',
     })
     expect(capturedDialogProps).toMatchObject({
       open: false,

--- a/tests/unit/orders-page.test.ts
+++ b/tests/unit/orders-page.test.ts
@@ -5,10 +5,7 @@ import {
   buildAdvanceOrderPayload,
   buildCancelOrderPayload,
   buildConfirmPaymentRequest,
-  buildMercadoPagoCheckoutRequest,
   buildDriverAssignmentPayload,
-  getMercadoPagoCheckoutErrorMessage,
-  getMercadoPagoWindowOpenFeatures,
   getDeliveryActionLabel,
   getOrderFilterChangeState,
   getLatestWhatsappNotification,
@@ -17,7 +14,6 @@ import {
   getOrdersTotalPages,
   getSortedNotifications,
   normalizeDeliveryAddress,
-  resolveMercadoPagoCheckoutUrl,
   shouldShowAdvanceButton,
   shouldShowWhatsappCard,
 } from '@/features/orders/orders-page'
@@ -91,7 +87,7 @@ describe('orders-page helpers', () => {
     expect(getDeliveryActionLabel({ status: 'confirmed', delivery_status: 'assigned' } as never)).toBeNull()
   })
 
-  it('monta payloads de pedidos, entrega, pagamento e checkout', () => {
+  it('monta payloads de pedidos, entrega e pagamento', () => {
     expect(buildAdvanceOrderPayload({ id: 'order-1', status: 'pending' } as never)).toEqual({
       id: 'order-1',
       status: 'confirmed',
@@ -129,28 +125,11 @@ describe('orders-page helpers', () => {
         body: JSON.stringify({ payment_status: 'paid' }),
       },
     })
-    expect(buildMercadoPagoCheckoutRequest({ id: 'order-9' })).toEqual({
-      url: '/api/orders/order-9/mercado-pago',
-      init: {
-        method: 'POST',
-      },
-    })
-
-    expect(resolveMercadoPagoCheckoutUrl({ sandbox_init_point: 'https://mp.test/checkout' })).toBe(
-      'https://mp.test/checkout'
-    )
-    expect(resolveMercadoPagoCheckoutUrl({ init_point: 'https://mp.test/init' })).toBe(
-      'https://mp.test/init'
-    )
-    expect(() => resolveMercadoPagoCheckoutUrl({})).toThrow('Mercado Pago não retornou um link de pagamento.')
     expect(buildCancelOrderPayload({ id: 'order-10' } as never, 'Cliente desistiu')).toEqual({
       id: 'order-10',
       status: 'cancelled',
       cancelled_reason: 'Cliente desistiu',
     })
-    expect(getMercadoPagoCheckoutErrorMessage(new Error('Falha MP'))).toBe('Falha MP')
-    expect(getMercadoPagoCheckoutErrorMessage(null)).toBe('Erro ao gerar cobrança.')
-    expect(getMercadoPagoWindowOpenFeatures()).toBe('_blank,noopener,noreferrer')
     expect(getOrderFilterChangeState('ready')).toEqual({ statusFilter: 'ready', page: 1 })
     expect(getOrdersInvalidationQueryKey()).toEqual(['orders'])
     expect(getOrdersTotalPages(0, 10)).toBe(1)


### PR DESCRIPTION
## Resumo
Este PR remove a ação manual de cobrança via Mercado Pago dos cards de pedidos do dashboard, simplificando a operação interna e alinhando a interface com o fluxo atual do produto.

## O que foi ajustado
- remove o botão `Cobrar com MP` do `OrderCard`
- elimina o handler e as props relacionadas a essa cobrança manual na página/listagem de pedidos
- remove helpers de checkout manual que ficaram sem uso
- atualiza a suíte de testes para refletir a operação sem esse CTA

## Impacto esperado
- pedidos internos deixam de exibir uma ação que não faz mais parte do fluxo operacional
- a listagem de pedidos fica mais simples e menos propensa a regressão
- a base de helpers e props fica mais enxuta

## Validação
- `npm test`
- `npm run build`