### PR TITLE
fix: disable WhatsApp settings loading when plan lacks the feature

### DIFF
--- a/app/(dashboard)/integracoes/page.tsx
+++ b/app/(dashboard)/integracoes/page.tsx
@@ -27,7 +27,7 @@ export default function IntegracoesPage() {
   const account = useMercadoPagoAccount()
   const disconnect = useDisconnectMercadoPagoAccount()
   const hasWhatsappNotifications = useHasFeature('whatsapp_notifications')
-  const notificationSettings = useNotificationSettings()
+  const notificationSettings = useNotificationSettings(hasWhatsappNotifications)
   const updateNotificationSettings = useUpdateNotificationSettings()
   const deliverySettings = useDeliverySettings()
   const updateDeliverySettings = useUpdateDeliverySettings()
@@ -43,7 +43,8 @@ export default function IntegracoesPage() {
 
   const connected = !!account.data
   const deliveryFeeValue = getDeliveryFeeValue(deliveryFeeInput, deliverySettings.data?.flat_fee)
-  const whatsappOptions = notificationSettings.data ? whatsappOptionDefinitions : []
+  const whatsappOptions =
+    hasWhatsappNotifications && notificationSettings.data ? whatsappOptionDefinitions : []
 
   return (
     <IntegrationsPageContent
@@ -65,8 +66,12 @@ export default function IntegracoesPage() {
         setDeliveryFeeInput(null)
       }}
       hasWhatsappNotifications={hasWhatsappNotifications}
-      notificationSettingsLoading={notificationSettings.isLoading}
-      notificationSettingsData={notificationSettings.data ?? null}
+      notificationSettingsLoading={
+        hasWhatsappNotifications ? notificationSettings.isLoading : false
+      }
+      notificationSettingsData={
+        hasWhatsappNotifications ? notificationSettings.data ?? null : null
+      }
       notificationSettingsPending={updateNotificationSettings.isPending}
       whatsappOptions={whatsappOptions}
       onToggleWhatsappOption={async (payload) => {

--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -168,7 +168,10 @@ export default function MenuClient({
 
   async function handlePhoneLookup() {
     const cleanPhone = phone.replace(/\D/g, '')
-    if (cleanPhone.length < 10) return
+    if (cleanPhone.length < 10) {
+      toast.error('Informe um telefone válido para continuar.')
+      return
+    }
     if (!isPaidPlan) { setPhoneVerified(true); return }
     setLookingUpPhone(true)
     try {

--- a/features/notifications/hooks/useNotificationSettings.ts
+++ b/features/notifications/hooks/useNotificationSettings.ts
@@ -13,9 +13,10 @@ export type NotificationSettings = {
   whatsapp_order_cancelled: boolean
 }
 
-export function useNotificationSettings() {
+export function useNotificationSettings(enabled = true) {
   return useQuery({
     queryKey: ['notification-settings'],
+    enabled,
     queryFn: async () => {
       const res = await fetch('/api/notification-settings')
       const json = await res.json()

--- a/tests/unit/integracoes-page-component.test.tsx
+++ b/tests/unit/integracoes-page-component.test.tsx
@@ -236,7 +236,7 @@ describe('IntegracoesPage component', () => {
     expect(props.deliverySettingsLoading).toBe(true)
     expect(props.deliverySettingsData).toBeNull()
     expect(props.hasWhatsappNotifications).toBe(false)
-    expect(props.notificationSettingsLoading).toBe(true)
+    expect(props.notificationSettingsLoading).toBe(false)
     expect(props.notificationSettingsData).toBeNull()
     expect(props.whatsappOptions).toEqual([])
   })

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -1179,6 +1179,44 @@ describe('MenuClient component', () => {
     expect(stateSetters[10]).toHaveBeenCalledWith(true)
   })
 
+  it('mostra toast quando tenta validar telefone inválido no plano pago', async () => {
+    stateValues[5] = '(11) 9999-999'
+
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8 },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    const props = capturedShellProps as {
+      drawerProps: {
+        infoStepProps: {
+          onPhoneLookup: () => Promise<void>
+        }
+      }
+    }
+
+    await props.drawerProps.infoStepProps.onPhoneLookup()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).toHaveBeenCalledWith('Informe um telefone válido para continuar.')
+  })
+
   it('marca cliente como novo quando lookup pago nao encontra cadastro', async () => {
     stateValues[5] = '(11) 99999-9999'
 

--- a/tests/unit/react-query-hooks.test.ts
+++ b/tests/unit/react-query-hooks.test.ts
@@ -147,6 +147,11 @@ describe('react-query hooks', () => {
     await expect(
       notifMutation.mutationFn({ whatsapp_order_received: true })
     ).rejects.toThrow('Falha ao atualizar notificações')
+
+    const notifQueryDisabled = notificationSettings.useNotificationSettings(false) as {
+      enabled: boolean
+    }
+    expect(notifQueryDisabled.enabled).toBe(false)
   })
 
   it('configura hooks de onboarding e pagamentos', async () => {


### PR DESCRIPTION
## Resumo
Este PR evita carregamento desnecessário das configurações de WhatsApp em tenants cujo plano não possui a feature habilitada.

## O que foi ajustado
- adiciona suporte a `enabled` no hook `useNotificationSettings`
- faz a página de integrações desabilitar a query quando `whatsapp_notifications` não está disponível no plano
- evita estado de loading e dados vazios artificiais para um recurso bloqueado
- atualiza a suíte da página de integrações e dos hooks para cobrir esse comportamento

## Impacto esperado
- tenants sem o recurso de WhatsApp não disparam fetch desnecessário para `/api/notification-settings`
- a tela de integrações fica mais coerente com o plano contratado
- reduz ruído de erro/403 desnecessário para features bloqueadas

## Validação
- `npm test`
- `npm run build`