### PR TITLE
fix: show specific missing-field messages in public checkout toasts

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -50,6 +50,7 @@ import {
   serializeStoredActiveOrder,
   getAddressFlowTarget,
   getTrackOrderState,
+  getValidationErrorToastMessage,
   shouldContinueCheckoutPolling,
   shouldContinueOrderPolling,
   shouldPersistActiveOrder,
@@ -210,7 +211,7 @@ export default function MenuClient({
     const errs = validateCustomerInfo(customerName, phone, customerCpf, tableInfo, paymentMethod)
     setErrors(errs)
     if (Object.keys(errs).length > 0) {
-      toast.error('Confira os campos obrigatórios antes de continuar.')
+      toast.error(getValidationErrorToastMessage(errs))
     }
     return Object.keys(errs).length === 0
   }
@@ -219,7 +220,7 @@ export default function MenuClient({
     const errs = validateCustomerAddress(address)
     setErrors(errs)
     if (Object.keys(errs).length > 0) {
-      toast.error('Confira os campos obrigatórios antes de continuar.')
+      toast.error(getValidationErrorToastMessage(errs))
     }
     return Object.keys(errs).length === 0
   }

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -683,6 +683,15 @@ export function validateCustomerAddress(address: Partial<CustomerAddress>) {
   return errors
 }
 
+export function getValidationErrorToastMessage(errors: Record<string, string>) {
+  const messages = Object.values(errors).filter(Boolean)
+  if (messages.length === 0) {
+    return 'Confira os campos obrigatórios antes de continuar.'
+  }
+
+  return `Confira os campos obrigatórios: ${messages.join(', ')}`
+}
+
 export function getOrderStepState(
   currentStatus: PublicOrderStatus['status'] | null,
   stepKeys: PublicOrderStatus['status'][],

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -382,7 +382,9 @@ describe('MenuClient component', () => {
 
     await props.drawerProps.infoStepProps.onContinue()
 
-    expect(toastErrorMock).toHaveBeenCalledWith('Confira os campos obrigatórios antes de continuar.')
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Confira os campos obrigatórios: Nome obrigatório, Telefone inválido, Selecione uma forma de pagamento'
+    )
     expect(createOrderMutateAsyncMock).not.toHaveBeenCalled()
   })
 
@@ -1401,6 +1403,14 @@ describe('MenuClient component', () => {
       number: 'Número obrigatório',
       city: 'Cidade obrigatória',
     })
+    expect(toastErrorMock).toHaveBeenNthCalledWith(
+      1,
+      'Confira os campos obrigatórios: Nome obrigatório, Telefone inválido'
+    )
+    expect(toastErrorMock).toHaveBeenNthCalledWith(
+      2,
+      'Confira os campos obrigatórios: CEP obrigatório, Rua obrigatória, Número obrigatório, Cidade obrigatória'
+    )
     expect(stateSetters[2]).not.toHaveBeenCalledWith('address')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -43,6 +43,7 @@ import {
   getPublicOrderHeadline,
   getPublicOrderStatusNotice,
   getPublicOrderTrackingMessage,
+  getValidationErrorToastMessage,
   getLookupCustomerFoundState,
   getLookupCustomerMissingState,
   getOnlineCheckoutErrorMessage,
@@ -654,6 +655,12 @@ describe('public menu helpers', () => {
       ...publicOrderStatus,
       delivery_status: 'assigned',
     })).toContain('vai aparecer aqui')
+    expect(
+      getValidationErrorToastMessage({
+        name: 'Nome obrigatório',
+        phone: 'Telefone inválido',
+      })
+    ).toBe('Confira os campos obrigatórios: Nome obrigatório, Telefone inválido')
   })
 
   it('monta payloads e decide o fluxo do checkout público', () => {


### PR DESCRIPTION
## Resumo
Este PR melhora o feedback do checkout público ao informar no toast quais campos obrigatórios estão impedindo o avanço.

## O que foi ajustado
- adiciona `getValidationErrorToastMessage` para compor mensagens a partir dos erros de validação
- usa esse helper no `MenuClient` para os passos de dados e endereço
- atualiza a suíte de testes para validar as mensagens específicas exibidas ao usuário

## Impacto esperado
- o cliente entende exatamente o que precisa corrigir para continuar
- reduz frustração no fluxo de pedido público
- mantém o comportamento validado por testes e sem alterar o restante do checkout

## Validação
- `npm test`
- `npm run build`