### PR TITLE
fix: add visual feature gates for integrations and team pages

### DIFF
--- a/app/(dashboard)/integracoes/page.tsx
+++ b/app/(dashboard)/integracoes/page.tsx
@@ -21,6 +21,7 @@ import {
   useDeliverySettings,
   useUpdateDeliverySettings,
 } from '@/features/delivery/hooks/useDeliverySettings'
+import FeatureGate from '@/features/plans/components/FeatureGate'
 
 export default function IntegracoesPage() {
   const params = useSearchParams()
@@ -47,36 +48,38 @@ export default function IntegracoesPage() {
     hasWhatsappNotifications && notificationSettings.data ? whatsappOptionDefinitions : []
 
   return (
-    <IntegrationsPageContent
-      connected={connected}
-      accountLoading={account.isLoading}
-      accountData={account.data ?? null}
-      disconnectPending={disconnect.isPending}
-      onDisconnect={() => disconnect.mutate()}
-      deliverySettingsLoading={deliverySettings.isLoading}
-      deliverySettingsData={deliverySettings.data ?? null}
-      deliverySettingsPending={updateDeliverySettings.isPending}
-      deliveryFeeValue={deliveryFeeValue}
-      onDeliveryToggle={async (payload) => {
-        await updateDeliverySettings.mutateAsync(payload)
-      }}
-      onDeliveryFeeInputChange={setDeliveryFeeInput}
-      onDeliveryFeeSave={async (payload) => {
-        await updateDeliverySettings.mutateAsync(payload)
-        setDeliveryFeeInput(null)
-      }}
-      hasWhatsappNotifications={hasWhatsappNotifications}
-      notificationSettingsLoading={
-        hasWhatsappNotifications ? notificationSettings.isLoading : false
-      }
-      notificationSettingsData={
-        hasWhatsappNotifications ? notificationSettings.data ?? null : null
-      }
-      notificationSettingsPending={updateNotificationSettings.isPending}
-      whatsappOptions={whatsappOptions}
-      onToggleWhatsappOption={async (payload) => {
-        await updateNotificationSettings.mutateAsync(payload)
-      }}
-    />
+    <FeatureGate feature="payments">
+      <IntegrationsPageContent
+        connected={connected}
+        accountLoading={account.isLoading}
+        accountData={account.data ?? null}
+        disconnectPending={disconnect.isPending}
+        onDisconnect={() => disconnect.mutate()}
+        deliverySettingsLoading={deliverySettings.isLoading}
+        deliverySettingsData={deliverySettings.data ?? null}
+        deliverySettingsPending={updateDeliverySettings.isPending}
+        deliveryFeeValue={deliveryFeeValue}
+        onDeliveryToggle={async (payload) => {
+          await updateDeliverySettings.mutateAsync(payload)
+        }}
+        onDeliveryFeeInputChange={setDeliveryFeeInput}
+        onDeliveryFeeSave={async (payload) => {
+          await updateDeliverySettings.mutateAsync(payload)
+          setDeliveryFeeInput(null)
+        }}
+        hasWhatsappNotifications={hasWhatsappNotifications}
+        notificationSettingsLoading={
+          hasWhatsappNotifications ? notificationSettings.isLoading : false
+        }
+        notificationSettingsData={
+          hasWhatsappNotifications ? notificationSettings.data ?? null : null
+        }
+        notificationSettingsPending={updateNotificationSettings.isPending}
+        whatsappOptions={whatsappOptions}
+        onToggleWhatsappOption={async (payload) => {
+          await updateNotificationSettings.mutateAsync(payload)
+        }}
+      />
+    </FeatureGate>
   )
 }

--- a/app/(dashboard)/usuarios/page.tsx
+++ b/app/(dashboard)/usuarios/page.tsx
@@ -21,6 +21,7 @@ import {
   paginateTeamUsers,
   type UsersRoleFilter,
 } from '@/features/users/users-page'
+import FeatureGate from '@/features/plans/components/FeatureGate'
 
 export default function UsuariosPage() {
   const { user } = useUser()
@@ -109,44 +110,48 @@ export default function UsuariosPage() {
   }
 
   return (
-    <UsersPageContent
-      isOwner={!!isOwner}
-      isLoading={isLoading}
-      data={data ?? null}
-      nameFilter={nameFilter}
-      onNameFilterChange={(value) => {
-        setNameFilter(value)
-        setPage(1)
-      }}
-      roleFilter={roleFilter}
-      onRoleFilterChange={(value) => {
-        setRoleFilter(value)
-        setPage(1)
-      }}
-      paginatedUsers={paginatedUsers}
-      canManageUser={(teamUser) => canManageTeamUser(!!isOwner, data?.current_user_id ?? '', teamUser.id)}
-      onOpenCreate={openCreate}
-      onOpenEdit={openEdit}
-      onDeleteUser={handleDeleteUser}
-      updatePending={updateUserRole.isPending}
-      deletePending={deleteUser.isPending}
-      page={page}
-      totalPages={getUsersTotalPages(filteredUsers.length, pageSize)}
-      onPageChange={setPage}
-      open={open}
-      onOpenChange={setOpen}
-      editingUser={editingUser}
-      fullName={fullName}
-      onFullNameChange={setFullName}
-      email={email}
-      onEmailChange={setEmail}
-      password={password}
-      onPasswordChange={setPassword}
-      role={role}
-      onRoleChange={setRole}
-      availableRoles={availableRoles}
-      onSubmit={handleSubmit}
-      createPending={createUser.isPending}
-    />
+    <FeatureGate feature="team">
+      <UsersPageContent
+        isOwner={!!isOwner}
+        isLoading={isLoading}
+        data={data ?? null}
+        nameFilter={nameFilter}
+        onNameFilterChange={(value) => {
+          setNameFilter(value)
+          setPage(1)
+        }}
+        roleFilter={roleFilter}
+        onRoleFilterChange={(value) => {
+          setRoleFilter(value)
+          setPage(1)
+        }}
+        paginatedUsers={paginatedUsers}
+        canManageUser={(teamUser) =>
+          canManageTeamUser(!!isOwner, data?.current_user_id ?? '', teamUser.id)
+        }
+        onOpenCreate={openCreate}
+        onOpenEdit={openEdit}
+        onDeleteUser={handleDeleteUser}
+        updatePending={updateUserRole.isPending}
+        deletePending={deleteUser.isPending}
+        page={page}
+        totalPages={getUsersTotalPages(filteredUsers.length, pageSize)}
+        onPageChange={setPage}
+        open={open}
+        onOpenChange={setOpen}
+        editingUser={editingUser}
+        fullName={fullName}
+        onFullNameChange={setFullName}
+        email={email}
+        onEmailChange={setEmail}
+        password={password}
+        onPasswordChange={setPassword}
+        role={role}
+        onRoleChange={setRole}
+        availableRoles={availableRoles}
+        onSubmit={handleSubmit}
+        createPending={createUser.isPending}
+      />
+    </FeatureGate>
   )
 }

--- a/tests/unit/catalog-pages-component.test.tsx
+++ b/tests/unit/catalog-pages-component.test.tsx
@@ -74,6 +74,11 @@ vi.mock('@/features/users/UsersPageContent', () => ({
   },
 }))
 
+vi.mock('@/features/plans/components/FeatureGate', () => ({
+  default: ({ children }: React.PropsWithChildren) =>
+    React.createElement(React.Fragment, null, children),
+}))
+
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),

--- a/tests/unit/integracoes-page-component.test.tsx
+++ b/tests/unit/integracoes-page-component.test.tsx
@@ -53,6 +53,11 @@ vi.mock('@/features/delivery/hooks/useDeliverySettings', () => ({
   useUpdateDeliverySettings: () => useUpdateDeliverySettingsMock(),
 }))
 
+vi.mock('@/features/plans/components/FeatureGate', () => ({
+  default: ({ children }: React.PropsWithChildren) =>
+    React.createElement(React.Fragment, null, children),
+}))
+
 vi.mock('@/features/payments/IntegrationsPageContent', () => ({
   IntegrationsPageContent: (props: Record<string, unknown>) => {
     capturedContentProps = props

--- a/tests/unit/integracoes-plan-gate.test.tsx
+++ b/tests/unit/integracoes-plan-gate.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const useMercadoPagoAccountMock = vi.fn()
+const useDisconnectMercadoPagoAccountMock = vi.fn()
+const useNotificationSettingsMock = vi.fn()
+const useUpdateNotificationSettingsMock = vi.fn()
+const useDeliverySettingsMock = vi.fn()
+const useUpdateDeliverySettingsMock = vi.fn()
+const useHasFeatureMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: vi.fn(() => null),
+  }),
+}))
+
+vi.mock('@/features/payments/hooks/useMercadoPagoAccount', () => ({
+  useMercadoPagoAccount: () => useMercadoPagoAccountMock(),
+  useDisconnectMercadoPagoAccount: () => useDisconnectMercadoPagoAccountMock(),
+}))
+
+vi.mock('@/features/notifications/hooks/useNotificationSettings', () => ({
+  useNotificationSettings: () => useNotificationSettingsMock(),
+  useUpdateNotificationSettings: () => useUpdateNotificationSettingsMock(),
+}))
+
+vi.mock('@/features/delivery/hooks/useDeliverySettings', () => ({
+  useDeliverySettings: () => useDeliverySettingsMock(),
+  useUpdateDeliverySettings: () => useUpdateDeliverySettingsMock(),
+}))
+
+vi.mock('@/features/plans/hooks/usePlan', async () => {
+  const actual = await vi.importActual<typeof import('@/features/plans/hooks/usePlan')>(
+    '@/features/plans/hooks/usePlan'
+  )
+
+  return {
+    ...actual,
+    useHasFeature: (...args: Parameters<typeof useHasFeatureMock>) => useHasFeatureMock(...args),
+  }
+})
+
+vi.mock('@/features/payments/IntegrationsPageContent', () => ({
+  IntegrationsPageContent: () => React.createElement('div', null, 'Integrations Page Content Mock'),
+}))
+
+describe('Integracoes page plan gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useMercadoPagoAccountMock.mockReturnValue({ data: null, isLoading: false })
+    useDisconnectMercadoPagoAccountMock.mockReturnValue({ isPending: false, mutate: vi.fn() })
+    useNotificationSettingsMock.mockReturnValue({ data: null, isLoading: false })
+    useUpdateNotificationSettingsMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+    useDeliverySettingsMock.mockReturnValue({ data: null, isLoading: false })
+    useUpdateDeliverySettingsMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+  })
+
+  it('mostra bloqueio quando o plano não inclui pagamentos', async () => {
+    useHasFeatureMock.mockReturnValue(false)
+
+    const { default: IntegracoesPage } = await import('@/app/(dashboard)/integracoes/page')
+    const markup = renderToStaticMarkup(React.createElement(IntegracoesPage))
+
+    expect(markup).toContain('Recurso não disponível')
+    expect(markup).toContain('Ver planos disponíveis')
+    expect(markup).not.toContain('Integrations Page Content Mock')
+  })
+})

--- a/tests/unit/usuarios-plan-gate.test.tsx
+++ b/tests/unit/usuarios-plan-gate.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const useHasFeatureMock = vi.fn()
+const useUserMock = vi.fn()
+const useUsersMock = vi.fn()
+const useCreateUserMock = vi.fn()
+const useUpdateUserRoleMock = vi.fn()
+const useDeleteUserMock = vi.fn()
+
+vi.mock('@/features/plans/hooks/usePlan', async () => {
+  const actual = await vi.importActual<typeof import('@/features/plans/hooks/usePlan')>(
+    '@/features/plans/hooks/usePlan'
+  )
+
+  return {
+    ...actual,
+    useHasFeature: (...args: Parameters<typeof useHasFeatureMock>) => useHasFeatureMock(...args),
+  }
+})
+
+vi.mock('@/features/auth/hooks/useUser', () => ({
+  useUser: () => useUserMock(),
+}))
+
+vi.mock('@/features/users/hooks/useUsers', () => ({
+  useUsers: () => useUsersMock(),
+  useCreateUser: () => useCreateUserMock(),
+  useUpdateUserRole: () => useUpdateUserRoleMock(),
+  useDeleteUser: () => useDeleteUserMock(),
+}))
+
+vi.mock('@/features/users/UsersPageContent', () => ({
+  UsersPageContent: () => React.createElement('div', null, 'Users Page Content Mock'),
+}))
+
+describe('Usuarios page plan gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useUserMock.mockReturnValue({ user: { profile: { role: 'owner' } } })
+    useUsersMock.mockReturnValue({ data: null, isLoading: false })
+    useCreateUserMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+    useUpdateUserRoleMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+    useDeleteUserMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+  })
+
+  it('mostra bloqueio quando o plano não inclui equipe', async () => {
+    useHasFeatureMock.mockReturnValue(false)
+
+    const { default: UsuariosPage } = await import('@/app/(dashboard)/usuarios/page')
+    const markup = renderToStaticMarkup(React.createElement(UsuariosPage))
+
+    expect(markup).toContain('Recurso não disponível')
+    expect(markup).toContain('Ver planos disponíveis')
+    expect(markup).not.toContain('Users Page Content Mock')
+  })
+})

--- a/tests/unit/usuarios-stateful-page-component.test.tsx
+++ b/tests/unit/usuarios-stateful-page-component.test.tsx
@@ -41,6 +41,11 @@ vi.mock('@/features/users/UsersPageContent', () => ({
   },
 }))
 
+vi.mock('@/features/plans/components/FeatureGate', () => ({
+  default: ({ children }: React.PropsWithChildren) =>
+    React.createElement(React.Fragment, null, children),
+}))
+
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),


### PR DESCRIPTION
## Resumo
Este PR adiciona bloqueio visual por plano nas páginas de Integrações e Usuários, alinhando essas telas ao mesmo padrão já aplicado em recursos premium do dashboard.

## O que foi ajustado
- envolve `/integracoes` com `FeatureGate feature="payments"`
- envolve `/usuarios` com `FeatureGate feature="team"`
- adiciona testes unitários dedicados para garantir o bloqueio visual quando a feature não está disponível
- atualiza os testes stateful dessas páginas para manter a cobertura da lógica interna sem acoplamento ao gate

## Impacto esperado
- tentativas de acesso direto a essas telas passam a exibir o estado de recurso indisponível, além do bloqueio por rota/sidebar
- a experiência fica consistente com outras páginas já protegidas por plano
- a baseline de testes continua verde com cobertura explícita do comportamento novo

## Validação
- `npm test`
- `npm run build`