### PR TITLE
fix: exclude cancelled deliveries from dashboard operational metrics

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -125,7 +125,11 @@ export default async function DashboardPage() {
     .filter((item) => Number(item.current_stock) <= Number(item.min_stock))
   const activeOrders = orders.filter((order) => !['delivered', 'cancelled'].includes(order.status))
   const paidOrders = orders.filter((order) => order.payment_status === 'paid' && order.status !== 'cancelled')
-  const deliveryOrders = orders.filter((order) => order.payment_method === 'delivery' || order.delivery_fee)
+  const deliveryOrders = orders.filter(
+    (order) =>
+      order.status !== 'cancelled' &&
+      (order.payment_method === 'delivery' || order.delivery_fee)
+  )
   const paidDeliveryOrders = deliveryOrders.filter(
     (order) => order.payment_status === 'paid' && order.status !== 'cancelled'
   )

--- a/tests/unit/dashboard-page-component.test.tsx
+++ b/tests/unit/dashboard-page-component.test.tsx
@@ -684,4 +684,78 @@ describe('DashboardPage component', () => {
     expect(markup).toContain('1 pedidos pagos')
     expect(markup).toContain('O controle de estoque completo está disponível a partir do plano Standard.')
   })
+
+  it('ignora deliveries cancelados nos cards e na lista de atenção', async () => {
+    hasPlanFeatureMock.mockImplementation((plan: string, feature: string) => {
+      expect(plan).toBe('basic')
+      return ['orders', 'tables', 'stock', 'sales'].includes(feature)
+    })
+
+    createClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn(async () => ({
+          data: { user: { id: 'user-cancelled' } },
+        })),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'profiles') {
+          return queryBuilder({
+            full_name: 'Nina Rocha',
+            tenant_id: 'tenant-cancelled',
+            tenants: { name: 'Delivery Teste', plan: 'basic' },
+          })
+        }
+
+        if (table === 'orders') {
+          return queryBuilder([
+            {
+              id: 'order-c1',
+              order_number: 601,
+              customer_name: 'Cliente Cancelado',
+              status: 'cancelled',
+              payment_status: 'pending',
+              payment_method: 'delivery',
+              total: 50,
+              delivery_fee: 9,
+              delivery_status: 'waiting_dispatch',
+              delivery_driver_id: null,
+              created_at: '2026-03-22T10:00:00.000Z',
+            },
+            {
+              id: 'order-c2',
+              order_number: 602,
+              customer_name: 'Cliente Pago',
+              status: 'confirmed',
+              payment_status: 'paid',
+              payment_method: 'delivery',
+              total: 42,
+              delivery_fee: 6,
+              delivery_status: 'waiting_dispatch',
+              delivery_driver_id: null,
+              created_at: '2026-03-22T10:30:00.000Z',
+            },
+          ])
+        }
+
+        if (table === 'delivery_drivers') {
+          return queryBuilder(null)
+        }
+
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    })
+
+    createAdminClientMock.mockReturnValue({
+      from: vi.fn(() => queryBuilder([])),
+    })
+
+    const { default: DashboardPage } = await import('@/app/(dashboard)/dashboard/page')
+    const markup = renderToStaticMarkup(await DashboardPage())
+
+    expect(markup).toContain('Delivery Teste')
+    expect(markup).toContain('R$ 6,00')
+    expect(markup).toContain('#602')
+    expect(markup).not.toContain('#601')
+    expect(markup).not.toContain('R$ 9,00')
+  })
 })


### PR DESCRIPTION
## Resumo
Este PR corrige a home do estabelecimento para que pedidos de delivery cancelados não contaminem os indicadores operacionais do dia.

## O que foi ajustado
- filtra pedidos `cancelled` da base usada pelos blocos de delivery no dashboard
- evita que delivery cancelado entre em:
  - contagem de `Delivery hoje`
  - `Aguardando despacho`
  - `Saiu para entrega`
  - `Taxa de entrega arrecadada`
  - `Top entregador`
- adiciona teste de regressão garantindo que pedidos cancelados não apareçam nos cards nem na lista de atenção

## Impacto esperado
- a home operacional deixa de inflar métricas de delivery com pedidos inválidos
- a lista de atenção mostra apenas itens realmente acionáveis
- os indicadores ficam mais coerentes com a operação real do dia

## Validação
- `npm test`
- `npm run build`