### PR TITLE
fix: add visual feature gate to delivery drivers page

### DIFF
--- a/app/(dashboard)/entregadores/page.tsx
+++ b/app/(dashboard)/entregadores/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/features/delivery/hooks/useDeliveryDrivers'
 import { useUser } from '@/features/auth/hooks/useUser'
 import { DeliveryDriversPageContent } from '@/features/delivery/DeliveryDriversPageContent'
+import FeatureGate from '@/features/plans/components/FeatureGate'
 import { toast } from 'sonner'
 
 export default function EntregadoresPage() {
@@ -98,29 +99,31 @@ export default function EntregadoresPage() {
   const activeDrivers = drivers?.filter((driver) => driver.active).length ?? 0
 
   return (
-    <DeliveryDriversPageContent
-      canManage={canManage}
-      activeDrivers={activeDrivers}
-      isLoading={isLoading}
-      drivers={drivers}
-      openCreate={openCreate}
-      openEdit={openEdit}
-      onDelete={handleDelete}
-      open={open}
-      onOpenChange={setOpen}
-      editingDriver={editingDriver}
-      name={name}
-      onNameChange={setName}
-      phone={phone}
-      onPhoneChange={setPhone}
-      vehicleType={vehicleType}
-      onVehicleTypeChange={setVehicleType}
-      notes={notes}
-      onNotesChange={setNotes}
-      active={active}
-      onActiveChange={setActive}
-      onSubmit={handleSubmit}
-      submitDisabled={createDriver.isPending || updateDriver.isPending}
-    />
+    <FeatureGate feature="orders">
+      <DeliveryDriversPageContent
+        canManage={canManage}
+        activeDrivers={activeDrivers}
+        isLoading={isLoading}
+        drivers={drivers}
+        openCreate={openCreate}
+        openEdit={openEdit}
+        onDelete={handleDelete}
+        open={open}
+        onOpenChange={setOpen}
+        editingDriver={editingDriver}
+        name={name}
+        onNameChange={setName}
+        phone={phone}
+        onPhoneChange={setPhone}
+        vehicleType={vehicleType}
+        onVehicleTypeChange={setVehicleType}
+        notes={notes}
+        onNotesChange={setNotes}
+        active={active}
+        onActiveChange={setActive}
+        onSubmit={handleSubmit}
+        submitDisabled={createDriver.isPending || updateDriver.isPending}
+      />
+    </FeatureGate>
   )
 }

--- a/tests/unit/entregadores-plan-gate.test.tsx
+++ b/tests/unit/entregadores-plan-gate.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const useHasFeatureMock = vi.fn()
+const useUserMock = vi.fn()
+const useDeliveryDriversMock = vi.fn()
+const useCreateDeliveryDriverMock = vi.fn()
+const useUpdateDeliveryDriverMock = vi.fn()
+const useDeleteDeliveryDriverMock = vi.fn()
+
+vi.mock('@/features/plans/hooks/usePlan', async () => {
+  const actual = await vi.importActual<typeof import('@/features/plans/hooks/usePlan')>(
+    '@/features/plans/hooks/usePlan'
+  )
+
+  return {
+    ...actual,
+    useHasFeature: (...args: Parameters<typeof useHasFeatureMock>) => useHasFeatureMock(...args),
+  }
+})
+
+vi.mock('@/features/auth/hooks/useUser', () => ({
+  useUser: () => useUserMock(),
+}))
+
+vi.mock('@/features/delivery/hooks/useDeliveryDrivers', () => ({
+  useDeliveryDrivers: () => useDeliveryDriversMock(),
+  useCreateDeliveryDriver: () => useCreateDeliveryDriverMock(),
+  useUpdateDeliveryDriver: () => useUpdateDeliveryDriverMock(),
+  useDeleteDeliveryDriver: () => useDeleteDeliveryDriverMock(),
+}))
+
+vi.mock('@/features/delivery/DeliveryDriversPageContent', () => ({
+  DeliveryDriversPageContent: () =>
+    React.createElement('div', null, 'Delivery Drivers Page Content Mock'),
+}))
+
+describe('Entregadores page plan gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useUserMock.mockReturnValue({ user: { profile: { role: 'owner' } } })
+    useDeliveryDriversMock.mockReturnValue({ data: [], isLoading: false })
+    useCreateDeliveryDriverMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+    useUpdateDeliveryDriverMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+    useDeleteDeliveryDriverMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+  })
+
+  it('mostra bloqueio quando a feature de pedidos não está disponível', async () => {
+    useHasFeatureMock.mockReturnValue(false)
+
+    const { default: EntregadoresPage } = await import('@/app/(dashboard)/entregadores/page')
+    const markup = renderToStaticMarkup(React.createElement(EntregadoresPage))
+
+    expect(markup).toContain('Recurso não disponível')
+    expect(markup).toContain('Ver planos disponíveis')
+    expect(markup).not.toContain('Delivery Drivers Page Content Mock')
+  })
+})

--- a/tests/unit/entregadores-stateful-page-component.test.tsx
+++ b/tests/unit/entregadores-stateful-page-component.test.tsx
@@ -43,6 +43,11 @@ vi.mock('@/features/delivery/DeliveryDriversPageContent', () => ({
   },
 }))
 
+vi.mock('@/features/plans/components/FeatureGate', () => ({
+  default: ({ children }: React.PropsWithChildren) =>
+    React.createElement(React.Fragment, null, children),
+}))
+
 vi.mock('sonner', () => ({
   toast: {
     success: (...args: Parameters<typeof toastSuccessMock>) => toastSuccessMock(...args),

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -3807,6 +3807,127 @@ describe('menu components', () => {
     expect(tabMarkup).toContain('Entregador atribuído')
   })
 
+  it('nao renderiza historico de whatsapp para pedidos locais mesmo com notificacoes', async () => {
+    const { OrderCard } = await import('@/features/orders/OrderCard')
+
+    const counterMarkup = renderToStaticMarkup(
+      React.createElement(OrderCard, {
+        order: {
+          id: 'order-local-1',
+          tenant_id: 'tenant-1',
+          order_number: 125,
+          customer_name: 'Paulo',
+          customer_phone: '11988887777',
+          customer_cpf: null,
+          customer_id: null,
+          table_number: null,
+          tab: null,
+          status: 'confirmed',
+          payment_method: 'counter',
+          payment_status: 'pending',
+          subtotal: 28,
+          total: 28,
+          notes: null,
+          cancelled_reason: null,
+          delivery_address: null,
+          created_at: '2026-03-21T18:30:00.000Z',
+          updated_at: '2026-03-21T18:30:00.000Z',
+          items: [
+            {
+              id: 'item-local-1',
+              order_id: 'order-local-1',
+              menu_item_id: 'menu-local-1',
+              name: 'Hambúrguer',
+              price: 28,
+              quantity: 1,
+              notes: null,
+            },
+          ],
+          notifications: [
+            {
+              id: 'notif-local-1',
+              channel: 'whatsapp',
+              event_key: 'order_received',
+              status: 'sent',
+              recipient: '11988887777',
+              created_at: '2026-03-21T18:31:00.000Z',
+            },
+          ],
+        } as never,
+        config: { label: 'Confirmado', color: 'bg-blue-100 text-blue-800', nextLabel: 'Iniciar preparo' },
+        deliveryDrivers: [],
+        hasWhatsappNotifications: true,
+        updatePending: false,
+        onAssignDriver: vi.fn(),
+        onAdvance: vi.fn(),
+        onAdvanceDelivery: vi.fn(),
+        onConfirmPayment: vi.fn(),
+        onCancel: vi.fn(),
+      })
+    )
+
+    const tableMarkup = renderToStaticMarkup(
+      React.createElement(OrderCard, {
+        order: {
+          id: 'order-local-2',
+          tenant_id: 'tenant-1',
+          order_number: 126,
+          customer_name: 'Lara',
+          customer_phone: '11977776655',
+          customer_cpf: null,
+          customer_id: null,
+          table_number: '12',
+          tab: null,
+          status: 'pending',
+          payment_method: 'table',
+          payment_status: 'pending',
+          subtotal: 22,
+          total: 22,
+          notes: null,
+          cancelled_reason: null,
+          delivery_address: null,
+          created_at: '2026-03-21T18:40:00.000Z',
+          updated_at: '2026-03-21T18:40:00.000Z',
+          items: [
+            {
+              id: 'item-local-2',
+              order_id: 'order-local-2',
+              menu_item_id: 'menu-local-2',
+              name: 'Suco natural',
+              price: 22,
+              quantity: 1,
+              notes: null,
+            },
+          ],
+          notifications: [
+            {
+              id: 'notif-local-2',
+              channel: 'whatsapp',
+              event_key: 'order_received',
+              status: 'sent',
+              recipient: '11977776655',
+              created_at: '2026-03-21T18:41:00.000Z',
+            },
+          ],
+        } as never,
+        config: { label: 'Aguardando', color: 'bg-amber-100 text-amber-800', nextLabel: 'Confirmar' },
+        deliveryDrivers: [],
+        hasWhatsappNotifications: true,
+        updatePending: false,
+        onAssignDriver: vi.fn(),
+        onAdvance: vi.fn(),
+        onAdvanceDelivery: vi.fn(),
+        onConfirmPayment: vi.fn(),
+        onCancel: vi.fn(),
+      })
+    )
+
+    expect(counterMarkup).not.toContain('WhatsApp')
+    expect(counterMarkup).not.toContain('Pedido recebido')
+    expect(tableMarkup).not.toContain('WhatsApp')
+    expect(tableMarkup).not.toContain('Pedido recebido')
+  })
+
   it('aciona handlers do card de pedido com entrega e pagamento pendente', async () => {
     const { OrderCard } = await import('@/features/orders/OrderCard')
 

--- a/tests/unit/orders-page.test.ts
+++ b/tests/unit/orders-page.test.ts
@@ -72,6 +72,18 @@ describe('orders-page helpers', () => {
       notifications: [{ id: '1', created_at: '2026-03-21T12:00:00.000Z' }],
     } as never, false)).toBe(false)
 
+    expect(shouldShowWhatsappCard({
+      payment_method: 'counter',
+      table_number: null,
+      notifications: [{ id: '1', created_at: '2026-03-21T12:00:00.000Z' }],
+    } as never, true)).toBe(false)
+
+    expect(shouldShowWhatsappCard({
+      payment_method: 'table',
+      table_number: '7',
+      notifications: [{ id: '1', created_at: '2026-03-21T12:00:00.000Z' }],
+    } as never, true)).toBe(false)
+
     expect(shouldShowAdvanceButton({
       status: 'confirmed',
       delivery_address: null,

--- a/tests/unit/plans-delivery-pages-component.test.tsx
+++ b/tests/unit/plans-delivery-pages-component.test.tsx
@@ -84,6 +84,11 @@ vi.mock('@/features/delivery/DeliveryDriversPageContent', () => ({
   },
 }))
 
+vi.mock('@/features/plans/components/FeatureGate', () => ({
+  default: ({ children }: React.PropsWithChildren) =>
+    React.createElement(React.Fragment, null, children),
+}))
+
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),


### PR DESCRIPTION
## Resumo
Este PR adiciona bloqueio visual por feature na página de entregadores, mantendo o padrão de proteção já usado em outras rotas do dashboard.

## O que foi ajustado
- envolve `/entregadores` com `FeatureGate feature="orders"`
- adiciona teste unitário dedicado garantindo que a página mostra o estado de recurso indisponível quando a feature não está liberada
- atualiza os testes stateful existentes para manter a cobertura da lógica da tela sem acoplamento ao gate

## Impacto esperado
- acesso direto à página de entregadores passa a exibir o bloqueio visual padrão quando a feature não estiver disponível
- a experiência fica consistente com outras páginas protegidas por plano/feature
- a suíte continua cobrindo a lógica interna da tela sem regressões

## Validação
- `npm test`
- `npm run build`