### PR TITLE
refactor: improve public checkout customer info step clarity

### DIFF
--- a/features/menu/MenuInfoStep.tsx
+++ b/features/menu/MenuInfoStep.tsx
@@ -76,9 +76,22 @@ export function MenuInfoStep({
 
         <div>
           <label className="text-sm font-medium text-slate-700 block mb-1">
+            Nome completo <span className="text-red-500">*</span>
+          </label>
+          <Input
+            placeholder="Ex: João Silva"
+            value={customerName}
+            onChange={(e) => onCustomerNameChange(e.target.value)}
+            disabled={isPaidPlan && !!existingCustomer}
+          />
+          {errors.name && <p className="text-xs text-red-500 mt-1">{errors.name}</p>}
+        </div>
+
+        <div>
+          <label className="text-sm font-medium text-slate-700 block mb-1">
             Telefone <span className="text-red-500">*</span>
           </label>
-          <div className="flex gap-2">
+          <div className="space-y-2">
             <Input
               placeholder="(11) 99999-9999"
               value={phone}
@@ -91,8 +104,9 @@ export function MenuInfoStep({
                 variant="outline"
                 onClick={onPhoneLookup}
                 disabled={lookingUpPhone || phone.replace(/\D/g, '').length < 10}
+                className="w-full"
               >
-                {lookingUpPhone ? '...' : 'OK'}
+                {lookingUpPhone ? 'Validando...' : 'Validar telefone'}
               </Button>
             )}
           </div>
@@ -109,19 +123,6 @@ export function MenuInfoStep({
               <p className="text-xs text-blue-700">Primeiro pedido? Preencha seus dados.</p>
             </div>
           )}
-        </div>
-
-        <div>
-          <label className="text-sm font-medium text-slate-700 block mb-1">
-            Nome completo <span className="text-red-500">*</span>
-          </label>
-          <Input
-            placeholder="Ex: João Silva"
-            value={customerName}
-            onChange={(e) => onCustomerNameChange(e.target.value)}
-            disabled={isPaidPlan && !!existingCustomer}
-          />
-          {errors.name && <p className="text-xs text-red-500 mt-1">{errors.name}</p>}
         </div>
 
         {tableInfo && (

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -513,6 +513,7 @@ describe('menu components', () => {
     expect(markup).toContain('Nome obrigatório')
     expect(markup).toContain('Pix')
     expect(markup).toContain('Dinheiro')
+    expect(markup).toContain('Validar')
     expect(markup).not.toContain('Taxa de entrega')
     expect(markup).not.toContain('Primeiro pedido? Preencha seus dados.')
   })
@@ -573,8 +574,8 @@ describe('menu components', () => {
     expect(buttons[0].props.disabled).toBe(true)
     expect(getTextContent(buttons[0])).toContain('...')
 
-    inputs[0].props.onChange({ target: { value: '(11) 98888-7777' } })
-    inputs[1].props.onChange({ target: { value: 'Cliente Teste' } })
+    inputs[0].props.onChange({ target: { value: 'Cliente Teste' } })
+    inputs[1].props.onChange({ target: { value: '(11) 98888-7777' } })
     inputs[2].props.onChange({ target: { value: '123.456.789-00' } })
     inputs[3].props.onChange({ target: { value: 'Sem gelo' } })
     buttons[0].props.onClick()
@@ -583,8 +584,8 @@ describe('menu components', () => {
     buttons[3].props.onClick()
     buttons[4].props.onClick()
 
-    expect(onPhoneChange).toHaveBeenCalledWith('(11) 98888-7777')
     expect(onCustomerNameChange).toHaveBeenCalledWith('Cliente Teste')
+    expect(onPhoneChange).toHaveBeenCalledWith('(11) 98888-7777')
     expect(onCustomerCpfChange).toHaveBeenCalledWith('123.456.789-00')
     expect(onNotesChange).toHaveBeenCalledWith('Sem gelo')
     expect(onPhoneLookup).toHaveBeenCalledOnce()
@@ -593,6 +594,7 @@ describe('menu components', () => {
     expect(onContinue).toHaveBeenCalledOnce()
     expect(onBack).toHaveBeenCalledOnce()
     expect(buttons[3].props.disabled).toBe(true)
+    expect(getTextContent(buttons[0])).toContain('Validando')
   })
 
   it('renderiza passo de endereço com loading de CEP', async () => {


### PR DESCRIPTION
## Resumo
Este PR melhora a clareza do passo de dados do checkout público, reorganizando os campos e tornando a ação de validação do telefone mais explícita.

## O que foi ajustado
- move `Nome completo` para antes de `Telefone`
- troca o rótulo do botão de lookup de `OK` para `Validar telefone`
- durante o loading, o botão passa a exibir `Validando...`
- posiciona o botão abaixo do campo de telefone, ocupando a largura total
- atualiza os testes do componente para refletir a nova ordem dos inputs e os novos rótulos

## Impacto esperado
- o fluxo de identificação do cliente fica mais legível e intuitivo
- a ação de validar o telefone deixa de parecer secundária ou ambígua
- prepara melhor o terreno para a próxima etapa de verificação por código

## Validação
- `npm test`
- `npm run build`