### PR TITLE
feat: add WhatsApp code verification to public checkout phone flow

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -117,6 +117,10 @@ export default function MenuClient({
   const [publicOrderStatus, setPublicOrderStatus] = useState<PublicOrderStatus | null>(null)
   const [cancelOrderLoading, setCancelOrderLoading] = useState(false)
   const [confirmDeliveryLoading, setConfirmDeliveryLoading] = useState(false)
+  const [verificationCode, setVerificationCode] = useState('')
+  const [codeSent, setCodeSent] = useState(false)
+  const [sendingPhoneCode, setSendingPhoneCode] = useState(false)
+  const [verifyingPhoneCode, setVerifyingPhoneCode] = useState(false)
   const activeOrderStorageKey = getActiveOrderStorageKey(tenant.slug, tableInfo?.id)
 
   const createOrder = useCreatePublicOrder()
@@ -167,33 +171,105 @@ export default function MenuClient({
     setCart([])
   }
 
+  async function lookupCustomer(cleanPhone: string) {
+    const res = await fetch(`/api/customers?phone=${cleanPhone}&tenant_id=${tenant.id}`)
+    const json = await res.json()
+
+    if (json.data) {
+      const nextState = getLookupCustomerFoundState(json.data)
+      setExistingCustomer(nextState.existingCustomer)
+      setCustomerName(nextState.customerName)
+      setIsNewCustomer(nextState.isNewCustomer)
+      setPhoneVerified(nextState.phoneVerified)
+      const def = json.data.addresses?.find((a: CustomerAddress) => a.is_default)
+      if (def) setAddress(def)
+      return
+    }
+
+    const nextState = getLookupCustomerMissingState()
+    setExistingCustomer(nextState.existingCustomer)
+    setIsNewCustomer(nextState.isNewCustomer)
+    setCustomerName(nextState.customerName)
+    setPhoneVerified(nextState.phoneVerified)
+  }
+
   async function handlePhoneLookup() {
     const cleanPhone = phone.replace(/\D/g, '')
     if (cleanPhone.length < 10) {
       toast.error('Informe um telefone válido para continuar.')
       return
     }
-    if (!isPaidPlan) { setPhoneVerified(true); return }
-    setLookingUpPhone(true)
+    if (!isPaidPlan) {
+      setPhoneVerified(true)
+      return
+    }
+    setSendingPhoneCode(true)
     try {
-      const res = await fetch(`/api/customers?phone=${cleanPhone}&tenant_id=${tenant.id}`)
+      const res = await fetch('/api/public/phone-verification/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tenant_id: tenant.id,
+          phone: cleanPhone,
+        }),
+      })
       const json = await res.json()
-      if (json.data) {
-        const nextState = getLookupCustomerFoundState(json.data)
-        setExistingCustomer(nextState.existingCustomer)
-        setCustomerName(nextState.customerName)
-        setIsNewCustomer(nextState.isNewCustomer)
-        setPhoneVerified(nextState.phoneVerified)
-        const def = json.data.addresses?.find((a: CustomerAddress) => a.is_default)
-        if (def) setAddress(def)
-      } else {
-        const nextState = getLookupCustomerMissingState()
-        setExistingCustomer(nextState.existingCustomer)
-        setIsNewCustomer(nextState.isNewCustomer)
-        setCustomerName(nextState.customerName)
-        setPhoneVerified(nextState.phoneVerified)
+
+      if (!res.ok) {
+        throw new Error(json.error || 'Não foi possível enviar o código.')
       }
-    } finally { setLookingUpPhone(false) }
+
+      setCodeSent(true)
+      setVerificationCode('')
+      toast.success('Enviamos um código de verificação para o seu WhatsApp.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Não foi possível enviar o código.')
+    } finally {
+      setSendingPhoneCode(false)
+      setLookingUpPhone(false)
+    }
+  }
+
+  async function handlePhoneCodeVerify() {
+    const cleanPhone = phone.replace(/\D/g, '')
+    const cleanCode = verificationCode.replace(/\D/g, '')
+
+    if (cleanCode.length !== 6) {
+      toast.error('Informe o código de 6 dígitos para continuar.')
+      return
+    }
+
+    setVerifyingPhoneCode(true)
+    try {
+      const res = await fetch('/api/public/phone-verification/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tenant_id: tenant.id,
+          phone: cleanPhone,
+          code: cleanCode,
+        }),
+      })
+      const json = await res.json()
+
+      if (!res.ok) {
+        throw new Error(json.error || 'Não foi possível validar o código.')
+      }
+
+      setPhoneVerified(true)
+      setCodeSent(false)
+      toast.success('Telefone validado com sucesso.')
+
+      if (isPaidPlan) {
+        setLookingUpPhone(true)
+        await lookupCustomer(cleanPhone)
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Não foi possível validar o código.')
+    } finally {
+      setVerifyingPhoneCode(false)
+      setLookingUpPhone(false)
+    }
   }
 
   async function handleCepLookup(cep: string) {
@@ -594,10 +670,17 @@ export default function MenuClient({
             setExistingCustomer(nextState.existingCustomer)
             setIsNewCustomer(nextState.isNewCustomer)
             setCustomerName(nextState.customerName)
+            setVerificationCode('')
+            setCodeSent(false)
           },
           phoneVerified,
           onPhoneLookup: handlePhoneLookup,
-          lookingUpPhone,
+          verificationCode,
+          onVerificationCodeChange: setVerificationCode,
+          onVerifyPhoneCode: handlePhoneCodeVerify,
+          codeSent,
+          lookingUpPhone: lookingUpPhone || sendingPhoneCode,
+          verifyingPhoneCode,
           errors,
           isPaidPlan,
           existingCustomer,

--- a/app/api/public/phone-verification/send/route.ts
+++ b/app/api/public/phone-verification/send/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { sendCustomerPhoneVerificationCode } from '@/lib/customer-phone-verification'
+
+const schema = z.object({
+  tenant_id: z.string().uuid(),
+  phone: z.string().min(10, 'Telefone inválido'),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const parsed = schema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      )
+    }
+
+    const result = await sendCustomerPhoneVerificationCode({
+      tenantId: parsed.data.tenant_id,
+      phone: parsed.data.phone,
+    })
+
+    return NextResponse.json({ data: result })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Não foi possível enviar o código de verificação.',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/public/phone-verification/verify/route.ts
+++ b/app/api/public/phone-verification/verify/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { verifyCustomerPhoneVerificationCode } from '@/lib/customer-phone-verification'
+
+const schema = z.object({
+  tenant_id: z.string().uuid(),
+  phone: z.string().min(10, 'Telefone inválido'),
+  code: z.string().length(6, 'Código inválido'),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const parsed = schema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      )
+    }
+
+    const result = await verifyCustomerPhoneVerificationCode({
+      tenantId: parsed.data.tenant_id,
+      phone: parsed.data.phone,
+      code: parsed.data.code,
+    })
+
+    if (!result.verified) {
+      const errorMessage =
+        result.reason === 'expired'
+          ? 'O código expirou. Solicite um novo.'
+          : 'Código inválido.'
+
+      return NextResponse.json({ error: errorMessage }, { status: 400 })
+    }
+
+    return NextResponse.json({ data: result })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Não foi possível validar o código.',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/features/menu/MenuInfoStep.tsx
+++ b/features/menu/MenuInfoStep.tsx
@@ -16,7 +16,12 @@ export function MenuInfoStep({
   onPhoneChange,
   phoneVerified,
   onPhoneLookup,
+  verificationCode,
+  onVerificationCodeChange,
+  onVerifyPhoneCode,
+  codeSent,
   lookingUpPhone,
+  verifyingPhoneCode,
   errors,
   isPaidPlan,
   existingCustomer,
@@ -42,7 +47,12 @@ export function MenuInfoStep({
   onPhoneChange: (value: string) => void
   phoneVerified: boolean
   onPhoneLookup: () => void
+  verificationCode: string
+  onVerificationCodeChange: (value: string) => void
+  onVerifyPhoneCode: () => void
+  codeSent: boolean
   lookingUpPhone: boolean
+  verifyingPhoneCode: boolean
   errors: Record<string, string>
   isPaidPlan: boolean
   existingCustomer: ExistingCustomer
@@ -106,11 +116,30 @@ export function MenuInfoStep({
                 disabled={lookingUpPhone || phone.replace(/\D/g, '').length < 10}
                 className="w-full"
               >
-                {lookingUpPhone ? 'Validando...' : 'Validar telefone'}
+                {lookingUpPhone ? 'Enviando...' : codeSent ? 'Reenviar código' : 'Enviar código'}
               </Button>
             )}
           </div>
           {errors.phone && <p className="text-xs text-red-500 mt-1">{errors.phone}</p>}
+          {!phoneVerified && codeSent && (
+            <div className="mt-3 space-y-2">
+              <Input
+                placeholder="Digite o código de 6 dígitos"
+                value={verificationCode}
+                onChange={(e) => onVerificationCodeChange(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                inputMode="numeric"
+                maxLength={6}
+              />
+              <Button
+                size="sm"
+                className="w-full"
+                onClick={onVerifyPhoneCode}
+                disabled={verifyingPhoneCode || verificationCode.length !== 6}
+              >
+                {verifyingPhoneCode ? 'Confirmando...' : 'Confirmar código'}
+              </Button>
+            </div>
+          )}
           {customerBannerState === 'existing' && (
             <div className="mt-2 bg-green-50 border border-green-200 rounded-lg px-3 py-2">
               <p className="text-xs text-green-700">

--- a/lib/customer-phone-verification.ts
+++ b/lib/customer-phone-verification.ts
@@ -1,0 +1,197 @@
+import { randomInt, createHash } from 'crypto'
+import { createAdminClient } from '@/lib/supabase/admin'
+import {
+  normalizeBrazilPhone,
+  normalizeWhatsappChannelAddress,
+} from '@/lib/order-whatsapp'
+
+const VERIFICATION_TTL_MINUTES = 10
+
+function getTwilioVerificationConfig() {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID
+  const authToken = process.env.TWILIO_AUTH_TOKEN
+  const from = process.env.TWILIO_WHATSAPP_FROM
+
+  if (!accountSid || !authToken || !from) {
+    return null
+  }
+
+  return {
+    accountSid,
+    authToken,
+    from: normalizeWhatsappChannelAddress(from),
+  }
+}
+
+export function generateCustomerPhoneVerificationCode() {
+  return String(randomInt(100000, 1000000))
+}
+
+export function buildCustomerPhoneVerificationMessage(params: {
+  tenantName: string
+  code: string
+}) {
+  return `Seu código de verificação da ${params.tenantName} é ${params.code}. Ele expira em ${VERIFICATION_TTL_MINUTES} minutos.`
+}
+
+function buildVerificationCodeHash(params: {
+  tenantId: string
+  phone: string
+  code: string
+}) {
+  return createHash('sha256')
+    .update(`${params.tenantId}:${params.phone}:${params.code}`)
+    .digest('hex')
+}
+
+export async function sendCustomerPhoneVerificationCode(params: {
+  tenantId: string
+  phone: string
+}) {
+  const admin = createAdminClient()
+  const config = getTwilioVerificationConfig()
+
+  if (!config) {
+    throw new Error('WhatsApp de verificação não configurado.')
+  }
+
+  const normalizedPhone = normalizeBrazilPhone(params.phone)
+  if (!normalizedPhone) {
+    throw new Error('Telefone inválido.')
+  }
+
+  const { data: tenant, error: tenantError } = await admin
+    .from('tenants')
+    .select('id, name')
+    .eq('id', params.tenantId)
+    .maybeSingle()
+
+  if (tenantError || !tenant) {
+    throw tenantError ?? new Error('Estabelecimento não encontrado.')
+  }
+
+  const code = generateCustomerPhoneVerificationCode()
+  const expiresAt = new Date(Date.now() + VERIFICATION_TTL_MINUTES * 60_000).toISOString()
+
+  const { data: record, error: insertError } = await admin
+    .from('customer_phone_verifications')
+    .insert({
+      tenant_id: params.tenantId,
+      phone: normalizedPhone.replace(/[^\d]/g, ''),
+      code_hash: buildVerificationCodeHash({
+        tenantId: params.tenantId,
+        phone: normalizedPhone,
+        code,
+      }),
+      channel: 'whatsapp',
+      expires_at: expiresAt,
+      attempts: 0,
+    })
+    .select('id')
+    .single()
+
+  if (insertError || !record) {
+    throw insertError ?? new Error('Não foi possível registrar a verificação.')
+  }
+
+  const response = await fetch(
+    `https://api.twilio.com/2010-04-01/Accounts/${config.accountSid}/Messages.json`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${config.accountSid}:${config.authToken}`).toString('base64')}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        To: `whatsapp:${normalizedPhone}`,
+        From: config.from,
+        Body: buildCustomerPhoneVerificationMessage({
+          tenantName: tenant.name,
+          code,
+        }),
+      }),
+    }
+  )
+
+  const json = await response.json().catch(() => null)
+
+  if (!response.ok) {
+    await admin
+      .from('customer_phone_verifications')
+      .update({
+        error_message: json?.message || 'twilio-send-failed',
+      })
+      .eq('id', record.id)
+
+    throw new Error(json?.message || 'Não foi possível enviar o código de verificação.')
+  }
+
+  await admin
+    .from('customer_phone_verifications')
+    .update({
+      provider_message_id: json?.sid ?? null,
+      sent_at: new Date().toISOString(),
+      error_message: null,
+    })
+    .eq('id', record.id)
+
+  return { sent: true as const, expiresInMinutes: VERIFICATION_TTL_MINUTES }
+}
+
+export async function verifyCustomerPhoneVerificationCode(params: {
+  tenantId: string
+  phone: string
+  code: string
+}) {
+  const admin = createAdminClient()
+  const normalizedPhone = normalizeBrazilPhone(params.phone)
+
+  if (!normalizedPhone) {
+    throw new Error('Telefone inválido.')
+  }
+
+  const { data: record, error } = await admin
+    .from('customer_phone_verifications')
+    .select('id, code_hash, expires_at, attempts')
+    .eq('tenant_id', params.tenantId)
+    .eq('phone', normalizedPhone.replace(/[^\d]/g, ''))
+    .is('verified_at', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) throw error
+
+  if (!record) {
+    return { verified: false as const, reason: 'missing' as const }
+  }
+
+  if (new Date(record.expires_at).getTime() < Date.now()) {
+    return { verified: false as const, reason: 'expired' as const }
+  }
+
+  const expectedHash = buildVerificationCodeHash({
+    tenantId: params.tenantId,
+    phone: normalizedPhone,
+    code: params.code,
+  })
+
+  if (record.code_hash !== expectedHash) {
+    await admin
+      .from('customer_phone_verifications')
+      .update({ attempts: Number(record.attempts ?? 0) + 1 })
+      .eq('id', record.id)
+
+    return { verified: false as const, reason: 'invalid' as const }
+  }
+
+  await admin
+    .from('customer_phone_verifications')
+    .update({
+      verified_at: new Date().toISOString(),
+      attempts: Number(record.attempts ?? 0) + 1,
+    })
+    .eq('id', record.id)
+
+  return { verified: true as const }
+}

--- a/tests/integration/api-public-phone-verification-routes.test.ts
+++ b/tests/integration/api-public-phone-verification-routes.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/customer-phone-verification', () => ({
+  sendCustomerPhoneVerificationCode: vi.fn(),
+  verifyCustomerPhoneVerificationCode: vi.fn(),
+}))
+
+const { sendCustomerPhoneVerificationCode, verifyCustomerPhoneVerificationCode } = await import(
+  '@/lib/customer-phone-verification'
+)
+const sendRoute = await import('@/app/api/public/phone-verification/send/route')
+const verifyRoute = await import('@/app/api/public/phone-verification/verify/route')
+
+describe('api public phone verification routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('envia código e confirma telefone', async () => {
+    vi.mocked(sendCustomerPhoneVerificationCode).mockResolvedValueOnce({
+      sent: true,
+      expiresInMinutes: 10,
+    } as never)
+    vi.mocked(verifyCustomerPhoneVerificationCode).mockResolvedValueOnce({
+      verified: true,
+    } as never)
+
+    const sendResponse = await sendRoute.POST(
+      new Request('https://chefops.test/api/public/phone-verification/send', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: '550e8400-e29b-41d4-a716-446655440000',
+          phone: '11999999999',
+        }),
+      }) as never,
+    )
+
+    expect(sendResponse.status).toBe(200)
+    await expect(sendResponse.json()).resolves.toEqual({
+      data: { sent: true, expiresInMinutes: 10 },
+    })
+
+    const verifyResponse = await verifyRoute.POST(
+      new Request('https://chefops.test/api/public/phone-verification/verify', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: '550e8400-e29b-41d4-a716-446655440000',
+          phone: '11999999999',
+          code: '123456',
+        }),
+      }) as never,
+    )
+
+    expect(verifyResponse.status).toBe(200)
+    await expect(verifyResponse.json()).resolves.toEqual({
+      data: { verified: true },
+    })
+  })
+
+  it('retorna erros de validação e código expirado', async () => {
+    expect(
+      (
+        await sendRoute.POST(
+          new Request('https://chefops.test/api/public/phone-verification/send', {
+            method: 'POST',
+            body: JSON.stringify({ tenant_id: 'bad-id', phone: '1199' }),
+          }) as never,
+        )
+      ).status
+    ).toBe(400)
+
+    vi.mocked(verifyCustomerPhoneVerificationCode).mockResolvedValueOnce({
+      verified: false,
+      reason: 'expired',
+    } as never)
+
+    const verifyResponse = await verifyRoute.POST(
+      new Request('https://chefops.test/api/public/phone-verification/verify', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: '550e8400-e29b-41d4-a716-446655440000',
+          phone: '11999999999',
+          code: '123456',
+        }),
+      }) as never,
+    )
+
+    expect(verifyResponse.status).toBe(400)
+    await expect(verifyResponse.json()).resolves.toEqual({
+      error: 'O código expirou. Solicite um novo.',
+    })
+  })
+})

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -401,6 +401,7 @@ describe('MenuClient component', () => {
     stateValues[15] = 'Sem cebola'
     stateValues[17] = 'order-1'
     stateValues[22] = createPublicOrderStatus()
+    stateValues[25] = '123456'
 
     const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
 
@@ -424,6 +425,7 @@ describe('MenuClient component', () => {
       drawerProps: {
         infoStepProps: {
           onPhoneLookup: () => Promise<void>
+          onVerifyPhoneCode: () => Promise<void>
           onContinue: () => Promise<void>
         }
         addressStepProps: {
@@ -436,10 +438,13 @@ describe('MenuClient component', () => {
     }
 
     await props.drawerProps.infoStepProps.onPhoneLookup()
+    await props.drawerProps.infoStepProps.onVerifyPhoneCode()
     await props.drawerProps.addressStepProps.onCepLookup('12345-678')
     await props.drawerProps.infoStepProps.onContinue()
     await props.drawerProps.doneStepProps.onCancelOrder()
 
+    expect(fetch).toHaveBeenCalledWith('/api/public/phone-verification/send', expect.anything())
+    expect(fetch).toHaveBeenCalledWith('/api/public/phone-verification/verify', expect.anything())
     expect(fetch).toHaveBeenCalledWith('/api/customers?phone=11999999999&tenant_id=tenant-1')
     expect(fetch).toHaveBeenCalledWith('/api/cep/12345678')
     expect(fetch).toHaveBeenCalledWith('/api/customers', {
@@ -1221,8 +1226,23 @@ describe('MenuClient component', () => {
 
   it('marca cliente como novo quando lookup pago nao encontra cadastro', async () => {
     stateValues[5] = '(11) 99999-9999'
+    stateValues[25] = '123456'
 
     const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/phone-verification/send') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({ data: { sent: true } }),
+        }
+      }
+
+      if (url === '/api/public/phone-verification/verify') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({ data: { verified: true } }),
+        }
+      }
+
       if (url.startsWith('/api/customers?')) {
         return {
           ok: true,
@@ -1260,12 +1280,16 @@ describe('MenuClient component', () => {
       drawerProps: {
         infoStepProps: {
           onPhoneLookup: () => Promise<void>
+          onVerifyPhoneCode: () => Promise<void>
         }
       }
     }
 
     await props.drawerProps.infoStepProps.onPhoneLookup()
+    await props.drawerProps.infoStepProps.onVerifyPhoneCode()
 
+    expect(fetchMock).toHaveBeenCalledWith('/api/public/phone-verification/send', expect.anything())
+    expect(fetchMock).toHaveBeenCalledWith('/api/public/phone-verification/verify', expect.anything())
     expect(fetchMock).toHaveBeenCalledWith('/api/customers?phone=11999999999&tenant_id=tenant-1')
     expect(stateSetters[9]).toHaveBeenCalledWith(true)
     expect(stateSetters[9]).toHaveBeenCalledWith(false)
@@ -1277,8 +1301,23 @@ describe('MenuClient component', () => {
 
   it('nao define endereco quando lookup pago encontra cliente sem endereco padrao', async () => {
     stateValues[5] = '(11) 99999-9999'
+    stateValues[25] = '123456'
 
     const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/phone-verification/send') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({ data: { sent: true } }),
+        }
+      }
+
+      if (url === '/api/public/phone-verification/verify') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({ data: { verified: true } }),
+        }
+      }
+
       if (url.startsWith('/api/customers?')) {
         return {
           ok: true,
@@ -1331,11 +1370,13 @@ describe('MenuClient component', () => {
       drawerProps: {
         infoStepProps: {
           onPhoneLookup: () => Promise<void>
+          onVerifyPhoneCode: () => Promise<void>
         }
       }
     }
 
     await props.drawerProps.infoStepProps.onPhoneLookup()
+    await props.drawerProps.infoStepProps.onVerifyPhoneCode()
 
     expect(fetchMock).toHaveBeenCalledWith('/api/customers?phone=11999999999&tenant_id=tenant-1')
     expect(stateSetters[12]).not.toHaveBeenCalled()

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -444,7 +444,12 @@ describe('menu components', () => {
         onPhoneChange: vi.fn(),
         phoneVerified: true,
         onPhoneLookup: vi.fn(),
+        verificationCode: '',
+        onVerificationCodeChange: vi.fn(),
+        onVerifyPhoneCode: vi.fn(),
+        codeSent: false,
         lookingUpPhone: false,
+        verifyingPhoneCode: false,
         errors: {},
         isPaidPlan: true,
         existingCustomer: { id: 'cust-1', name: 'Maria', phone: '11999999999' },
@@ -483,7 +488,12 @@ describe('menu components', () => {
         onPhoneChange: vi.fn(),
         phoneVerified: false,
         onPhoneLookup: vi.fn(),
+        verificationCode: '',
+        onVerificationCodeChange: vi.fn(),
+        onVerifyPhoneCode: vi.fn(),
+        codeSent: false,
         lookingUpPhone: false,
+        verifyingPhoneCode: false,
         errors: { phone: 'Telefone inválido', name: 'Nome obrigatório' },
         isPaidPlan: false,
         existingCustomer: null,
@@ -513,7 +523,7 @@ describe('menu components', () => {
     expect(markup).toContain('Nome obrigatório')
     expect(markup).toContain('Pix')
     expect(markup).toContain('Dinheiro')
-    expect(markup).toContain('Validar')
+    expect(markup).toContain('Enviar código')
     expect(markup).not.toContain('Taxa de entrega')
     expect(markup).not.toContain('Primeiro pedido? Preencha seus dados.')
   })
@@ -523,6 +533,8 @@ describe('menu components', () => {
 
     const onPhoneChange = vi.fn()
     const onPhoneLookup = vi.fn()
+    const onVerificationCodeChange = vi.fn()
+    const onVerifyPhoneCode = vi.fn()
     const onCustomerNameChange = vi.fn()
     const onCustomerCpfChange = vi.fn()
     const onPaymentMethodChange = vi.fn()
@@ -537,7 +549,12 @@ describe('menu components', () => {
         onPhoneChange,
         phoneVerified: false,
         onPhoneLookup,
+        verificationCode: '123456',
+        onVerificationCodeChange,
+        onVerifyPhoneCode,
+        codeSent: true,
         lookingUpPhone: true,
+        verifyingPhoneCode: false,
         errors: { cpf: 'CPF obrigatório' },
         isPaidPlan: true,
         existingCustomer: null,
@@ -567,17 +584,19 @@ describe('menu components', () => {
     const buttons = elements.filter(
       (element) => element.type === 'button' && typeof element.props.onClick === 'function'
     )
+    const backButton = buttons.find((element) => getTextContent(element) === 'Voltar')
 
     expect(getTextContent(elements)).toContain('Primeiro pedido? Preencha seus dados.')
     expect(getTextContent(elements)).toContain('CPF obrigatório')
     expect(getTextContent(elements)).toContain('Taxa de entrega')
     expect(buttons[0].props.disabled).toBe(true)
-    expect(getTextContent(buttons[0])).toContain('...')
+    expect(getTextContent(buttons[0])).toContain('Enviando')
 
     inputs[0].props.onChange({ target: { value: 'Cliente Teste' } })
     inputs[1].props.onChange({ target: { value: '(11) 98888-7777' } })
-    inputs[2].props.onChange({ target: { value: '123.456.789-00' } })
-    inputs[3].props.onChange({ target: { value: 'Sem gelo' } })
+    inputs[2].props.onChange({ target: { value: '123456' } })
+    inputs[3].props.onChange({ target: { value: '123.456.789-00' } })
+    inputs[4].props.onChange({ target: { value: 'Sem gelo' } })
     buttons[0].props.onClick()
     buttons[1].props.onClick()
     buttons[2].props.onClick()
@@ -586,15 +605,19 @@ describe('menu components', () => {
 
     expect(onCustomerNameChange).toHaveBeenCalledWith('Cliente Teste')
     expect(onPhoneChange).toHaveBeenCalledWith('(11) 98888-7777')
+    expect(onVerificationCodeChange).toHaveBeenCalledWith('123456')
+    expect(onVerifyPhoneCode).toHaveBeenCalledOnce()
     expect(onCustomerCpfChange).toHaveBeenCalledWith('123.456.789-00')
     expect(onNotesChange).toHaveBeenCalledWith('Sem gelo')
     expect(onPhoneLookup).toHaveBeenCalledOnce()
     expect(onPaymentMethodChange).toHaveBeenNthCalledWith(1, 'online')
     expect(onPaymentMethodChange).toHaveBeenNthCalledWith(2, 'cash')
     expect(onContinue).toHaveBeenCalledOnce()
+    expect(backButton).toBeTruthy()
+    backButton?.props.onClick()
     expect(onBack).toHaveBeenCalledOnce()
-    expect(buttons[3].props.disabled).toBe(true)
-    expect(getTextContent(buttons[0])).toContain('Validando')
+    expect(buttons[4].props.disabled).toBe(true)
+    expect(getTextContent(buttons[1])).toContain('Confirmar código')
   })
 
   it('renderiza passo de endereço com loading de CEP', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona verificação de telefone por código via WhatsApp no checkout público para planos pagos, tornando a identificação do cliente mais segura antes do lookup/cadastro.

## O que foi ajustado
- cria as rotas públicas:
  - `POST /api/public/phone-verification/send`
  - `POST /api/public/phone-verification/verify`
- adiciona o serviço `customer-phone-verification` para:
  - gerar código
  - enviar via Twilio WhatsApp
  - persistir tentativas
  - validar o código informado
- atualiza o passo de dados do cliente para:
  - enviar código
  - exibir input do código
  - confirmar o código
- faz o `MenuClient` executar lookup/cadastro do cliente só após a verificação do código em planos pagos
- adiciona a migration da tabela `customer_phone_verifications`

## Impacto esperado
- o telefone do cliente passa a ser confirmado antes de reutilizar dados sensíveis como endereço
- o checkout público fica mais seguro para pedidos remotos
- o fluxo de identificação continua claro e guiado para o usuário final

## Validação
- `npm test`
- `npm run build`

## Observações
- o comportamento atual do plano `Basic` foi preservado sem exigir código nesta etapa