### PR TITLE
fix: require phone verification only for remote public checkout

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -50,6 +50,7 @@ import {
   serializeStoredActiveOrder,
   getAddressFlowTarget,
   getTrackOrderState,
+  shouldRequirePhoneVerification,
   getValidationErrorToastMessage,
   shouldContinueCheckoutPolling,
   shouldContinueOrderPolling,
@@ -91,6 +92,7 @@ export default function MenuClient({
   checkoutResult,
 }: Props) {
   const isPaidPlan = tenant.plan !== 'free'
+  const requirePhoneVerification = shouldRequirePhoneVerification(isPaidPlan, tableInfo)
 
   const [cart, setCart] = useState<CartItem[]>([])
   const [cartOpen, setCartOpen] = useState(false)
@@ -199,7 +201,7 @@ export default function MenuClient({
       toast.error('Informe um telefone válido para continuar.')
       return
     }
-    if (!isPaidPlan) {
+    if (!requirePhoneVerification) {
       setPhoneVerified(true)
       return
     }

--- a/features/menu/MenuInfoStep.tsx
+++ b/features/menu/MenuInfoStep.tsx
@@ -1,6 +1,10 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { getCustomerBannerState, getInfoContinueLabel } from '@/features/menu/public-menu'
+import {
+  getCustomerBannerState,
+  getInfoContinueLabel,
+  shouldRequirePhoneVerification,
+} from '@/features/menu/public-menu'
 import type { CustomerAddress } from '@/features/orders/types'
 
 type ExistingCustomer = {
@@ -74,6 +78,7 @@ export function MenuInfoStep({
   onBack: () => void
 }) {
   const customerBannerState = getCustomerBannerState(isPaidPlan, existingCustomer, isNewCustomer)
+  const requirePhoneVerification = shouldRequirePhoneVerification(isPaidPlan, tableInfo)
 
   return (
     <div className="flex-1 flex flex-col">
@@ -108,7 +113,7 @@ export function MenuInfoStep({
               onChange={(e) => onPhoneChange(e.target.value)}
               className="flex-1"
             />
-            {!phoneVerified && (
+            {requirePhoneVerification && !phoneVerified && (
               <Button
                 size="sm"
                 variant="outline"
@@ -121,7 +126,7 @@ export function MenuInfoStep({
             )}
           </div>
           {errors.phone && <p className="text-xs text-red-500 mt-1">{errors.phone}</p>}
-          {!phoneVerified && codeSent && (
+          {requirePhoneVerification && !phoneVerified && codeSent && (
             <div className="mt-3 space-y-2">
               <Input
                 placeholder="Digite o código de 6 dígitos"
@@ -207,7 +212,11 @@ export function MenuInfoStep({
           <span className="text-slate-500">Total</span>
           <span className="font-semibold">R$ {orderTotal.toFixed(2)}</span>
         </div>
-        <Button className="w-full" onClick={onContinue} disabled={isProcessing || (isPaidPlan && !phoneVerified)}>
+        <Button
+          className="w-full"
+          onClick={onContinue}
+          disabled={isProcessing || (requirePhoneVerification && !phoneVerified)}
+        >
           {getInfoContinueLabel(isProcessing)}
         </Button>
         <Button variant="outline" className="w-full" onClick={onBack}>

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -430,6 +430,13 @@ export function getCustomerBannerState(
   return null
 }
 
+export function shouldRequirePhoneVerification(
+  isPaidPlan: boolean,
+  tableInfo: { id: string; number: string } | null
+) {
+  return isPaidPlan && !tableInfo
+}
+
 export function getInfoContinueLabel(isProcessing: boolean) {
   return isProcessing ? 'Processando...' : 'Continuar'
 }

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -438,14 +438,13 @@ describe('MenuClient component', () => {
     }
 
     await props.drawerProps.infoStepProps.onPhoneLookup()
-    await props.drawerProps.infoStepProps.onVerifyPhoneCode()
     await props.drawerProps.addressStepProps.onCepLookup('12345-678')
     await props.drawerProps.infoStepProps.onContinue()
     await props.drawerProps.doneStepProps.onCancelOrder()
 
-    expect(fetch).toHaveBeenCalledWith('/api/public/phone-verification/send', expect.anything())
-    expect(fetch).toHaveBeenCalledWith('/api/public/phone-verification/verify', expect.anything())
-    expect(fetch).toHaveBeenCalledWith('/api/customers?phone=11999999999&tenant_id=tenant-1')
+    expect(fetch).not.toHaveBeenCalledWith('/api/public/phone-verification/send', expect.anything())
+    expect(fetch).not.toHaveBeenCalledWith('/api/public/phone-verification/verify', expect.anything())
+    expect(fetch).not.toHaveBeenCalledWith('/api/customers?phone=11999999999&tenant_id=tenant-1')
     expect(fetch).toHaveBeenCalledWith('/api/cep/12345678')
     expect(fetch).toHaveBeenCalledWith('/api/customers', {
       method: 'POST',
@@ -471,8 +470,6 @@ describe('MenuClient component', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ cancelled_reason: 'Cliente desistiu' }),
     })
-    expect(stateSetters[9]).toHaveBeenCalledWith(true)
-    expect(stateSetters[9]).toHaveBeenCalledWith(false)
     expect(stateSetters[13]).toHaveBeenCalledWith(true)
     expect(stateSetters[13]).toHaveBeenCalledWith(false)
     expect(stateSetters[17]).toHaveBeenCalledWith('order-created')
@@ -2753,5 +2750,43 @@ describe('MenuClient component', () => {
     expect(stateSetters[6]).toHaveBeenCalledWith('Maria')
     expect(stateSetters[14]).toHaveBeenCalledWith('delivery')
     expect(stateSetters[15]).toHaveBeenCalledWith('Sem cebola')
+  })
+
+  it('nao envia codigo de telefone para pedidos de mesa no plano pago', async () => {
+    stateValues[5] = '(11) 99999-9999'
+
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'standard',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8 },
+        },
+        items: [createMenuItem()],
+        tableInfo: { id: 'table-1', number: '12' },
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    const props = capturedShellProps as {
+      drawerProps: {
+        infoStepProps: {
+          onPhoneLookup: () => Promise<void>
+        }
+      }
+    }
+
+    await props.drawerProps.infoStepProps.onPhoneLookup()
+
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/public/phone-verification/send', expect.anything())
+    expect(stateSetters[10]).toHaveBeenCalledWith(true)
   })
 })

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -523,9 +523,57 @@ describe('menu components', () => {
     expect(markup).toContain('Nome obrigatório')
     expect(markup).toContain('Pix')
     expect(markup).toContain('Dinheiro')
-    expect(markup).toContain('Enviar código')
+    expect(markup).not.toContain('Enviar código')
     expect(markup).not.toContain('Taxa de entrega')
     expect(markup).not.toContain('Primeiro pedido? Preencha seus dados.')
+  })
+
+  it('nao exige codigo de telefone em pedido de mesa no plano pago', async () => {
+    const { MenuInfoStep } = await import('@/features/menu/MenuInfoStep')
+
+    const elements = flattenElements(
+      React.createElement(MenuInfoStep, {
+        tableInfo: { id: 'table-1', number: '7' },
+        phone: '(11) 99999-9999',
+        onPhoneChange: vi.fn(),
+        phoneVerified: false,
+        onPhoneLookup: vi.fn(),
+        verificationCode: '',
+        onVerificationCodeChange: vi.fn(),
+        onVerifyPhoneCode: vi.fn(),
+        codeSent: false,
+        lookingUpPhone: false,
+        verifyingPhoneCode: false,
+        errors: {},
+        isPaidPlan: true,
+        existingCustomer: null,
+        isNewCustomer: false,
+        customerName: 'Maria',
+        onCustomerNameChange: vi.fn(),
+        customerCpf: '123.456.789-09',
+        onCustomerCpfChange: vi.fn(),
+        paymentOptions: [{ value: 'table', label: 'Na mesa' }],
+        paymentMethod: 'table',
+        onPaymentMethodChange: vi.fn(),
+        notes: '',
+        onNotesChange: vi.fn(),
+        cartTotal: 30,
+        deliveryFee: 0,
+        orderTotal: 30,
+        isProcessing: false,
+        onContinue: vi.fn(),
+        onBack: vi.fn(),
+      })
+    )
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function'
+    )
+    const continueButton = buttons.find((element) => getTextContent(element) === 'Continuar')
+
+    expect(getTextContent(elements)).not.toContain('Enviar código')
+    expect(getTextContent(elements)).not.toContain('Confirmar código')
+    expect(continueButton?.props.disabled).toBe(false)
   })
 
   it('aciona handlers e estados do passo de dados', async () => {
@@ -544,7 +592,7 @@ describe('menu components', () => {
 
     const elements = flattenElements(
       React.createElement(MenuInfoStep, {
-        tableInfo: { id: 'table-1', number: '4' },
+        tableInfo: null,
         phone: '1199999',
         onPhoneChange,
         phoneVerified: false,
@@ -555,13 +603,13 @@ describe('menu components', () => {
         codeSent: true,
         lookingUpPhone: true,
         verifyingPhoneCode: false,
-        errors: { cpf: 'CPF obrigatório' },
+        errors: {},
         isPaidPlan: true,
         existingCustomer: null,
         isNewCustomer: true,
         customerName: '',
         onCustomerNameChange,
-        customerCpf: '',
+        customerCpf: '123.456.789-00',
         onCustomerCpfChange,
         paymentOptions: [
           { value: 'online', label: 'Online' },
@@ -585,9 +633,9 @@ describe('menu components', () => {
       (element) => element.type === 'button' && typeof element.props.onClick === 'function'
     )
     const backButton = buttons.find((element) => getTextContent(element) === 'Voltar')
+    const continueButton = buttons.find((element) => getTextContent(element) === 'Continuar')
 
     expect(getTextContent(elements)).toContain('Primeiro pedido? Preencha seus dados.')
-    expect(getTextContent(elements)).toContain('CPF obrigatório')
     expect(getTextContent(elements)).toContain('Taxa de entrega')
     expect(buttons[0].props.disabled).toBe(true)
     expect(getTextContent(buttons[0])).toContain('Enviando')
@@ -595,28 +643,25 @@ describe('menu components', () => {
     inputs[0].props.onChange({ target: { value: 'Cliente Teste' } })
     inputs[1].props.onChange({ target: { value: '(11) 98888-7777' } })
     inputs[2].props.onChange({ target: { value: '123456' } })
-    inputs[3].props.onChange({ target: { value: '123.456.789-00' } })
-    inputs[4].props.onChange({ target: { value: 'Sem gelo' } })
+    inputs[3].props.onChange({ target: { value: 'Sem gelo' } })
     buttons[0].props.onClick()
     buttons[1].props.onClick()
     buttons[2].props.onClick()
     buttons[3].props.onClick()
-    buttons[4].props.onClick()
 
     expect(onCustomerNameChange).toHaveBeenCalledWith('Cliente Teste')
     expect(onPhoneChange).toHaveBeenCalledWith('(11) 98888-7777')
     expect(onVerificationCodeChange).toHaveBeenCalledWith('123456')
     expect(onVerifyPhoneCode).toHaveBeenCalledOnce()
-    expect(onCustomerCpfChange).toHaveBeenCalledWith('123.456.789-00')
     expect(onNotesChange).toHaveBeenCalledWith('Sem gelo')
     expect(onPhoneLookup).toHaveBeenCalledOnce()
     expect(onPaymentMethodChange).toHaveBeenNthCalledWith(1, 'online')
     expect(onPaymentMethodChange).toHaveBeenNthCalledWith(2, 'cash')
-    expect(onContinue).toHaveBeenCalledOnce()
+    expect(onContinue).not.toHaveBeenCalled()
     expect(backButton).toBeTruthy()
     backButton?.props.onClick()
     expect(onBack).toHaveBeenCalledOnce()
-    expect(buttons[4].props.disabled).toBe(true)
+    expect(continueButton?.props.disabled).toBe(true)
     expect(getTextContent(buttons[1])).toContain('Confirmar código')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -61,6 +61,7 @@ import {
   removeCartItem,
   resolvePublicCheckoutUrl,
   serializeStoredActiveOrder,
+  shouldRequirePhoneVerification,
   shouldShowCancelOrderButton,
   shouldShowDeliveryStep,
   shouldContinueCheckoutPolling,
@@ -800,6 +801,9 @@ describe('public menu helpers', () => {
     expect(getCustomerBannerState(true, { id: 'customer-1' }, false)).toBe('existing')
     expect(getCustomerBannerState(true, null, true)).toBe('new')
     expect(getCustomerBannerState(false, null, true)).toBeNull()
+    expect(shouldRequirePhoneVerification(true, null)).toBe(true)
+    expect(shouldRequirePhoneVerification(true, { id: 'table-1', number: '7' })).toBe(false)
+    expect(shouldRequirePhoneVerification(false, null)).toBe(false)
     expect(getInfoContinueLabel(true)).toBe('Processando...')
     expect(getInfoContinueLabel(false)).toBe('Continuar')
     expect(getAddressSubmitLabel('online', false)).toBe('Ir para pagamento')


### PR DESCRIPTION
## Resumo
Este PR restringe a verificação de telefone por código aos fluxos públicos remotos, removendo a exigência para pedidos por mesa/QR mesmo em planos pagos.

## O que foi ajustado
- adiciona o helper `shouldRequirePhoneVerification`
- aplica essa regra no `MenuInfoStep` para controlar:
  - visibilidade do botão de envio do código
  - visibilidade do campo de confirmação
  - bloqueio do botão `Continuar`
- aplica a mesma regra no `MenuClient` para evitar envio desnecessário de código em pedidos de mesa
- atualiza a suíte de testes para cobrir:
  - helper de decisão
  - UI do passo de dados
  - fluxo do cliente no checkout público

## Impacto esperado
- pedidos por mesa/QR deixam de exigir verificação de telefone
- o fluxo remoto continua protegido por código no plano pago
- a UX fica mais coerente com o risco real de exposição de endereço/dados

## Validação
- `npm test`
- `npm run build`