### PR TITLE
fix: limit invalid phone verification code attempts

### DIFF
--- a/app/api/public/phone-verification/verify/route.ts
+++ b/app/api/public/phone-verification/verify/route.ts
@@ -28,9 +28,11 @@ export async function POST(request: NextRequest) {
 
     if (!result.verified) {
       const errorMessage =
-        result.reason === 'expired'
-          ? 'O código expirou. Solicite um novo.'
-          : 'Código inválido.'
+        result.reason === 'too_many_attempts'
+          ? 'Muitas tentativas inválidas. Solicite um novo código.'
+          : result.reason === 'expired'
+            ? 'O código expirou. Solicite um novo.'
+            : 'Código inválido.'
 
       return NextResponse.json({ error: errorMessage }, { status: 400 })
     }

--- a/lib/customer-phone-verification.ts
+++ b/lib/customer-phone-verification.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/order-whatsapp'
 
 const VERIFICATION_TTL_MINUTES = 10
+const MAX_VERIFICATION_ATTEMPTS = 5
 
 function getTwilioVerificationConfig() {
   const accountSid = process.env.TWILIO_ACCOUNT_SID
@@ -166,6 +167,10 @@ export async function verifyCustomerPhoneVerificationCode(params: {
     return { verified: false as const, reason: 'missing' as const }
   }
 
+  if (Number(record.attempts ?? 0) >= MAX_VERIFICATION_ATTEMPTS) {
+    return { verified: false as const, reason: 'too_many_attempts' as const }
+  }
+
   if (new Date(record.expires_at).getTime() < Date.now()) {
     return { verified: false as const, reason: 'expired' as const }
   }
@@ -177,10 +182,16 @@ export async function verifyCustomerPhoneVerificationCode(params: {
   })
 
   if (record.code_hash !== expectedHash) {
+    const nextAttempts = Number(record.attempts ?? 0) + 1
+
     await admin
       .from('customer_phone_verifications')
-      .update({ attempts: Number(record.attempts ?? 0) + 1 })
+      .update({ attempts: nextAttempts })
       .eq('id', record.id)
+
+    if (nextAttempts >= MAX_VERIFICATION_ATTEMPTS) {
+      return { verified: false as const, reason: 'too_many_attempts' as const }
+    }
 
     return { verified: false as const, reason: 'invalid' as const }
   }

--- a/tests/helpers/mock-supabase.ts
+++ b/tests/helpers/mock-supabase.ts
@@ -1,5 +1,5 @@
 type QueryFilter = {
-  type: 'eq' | 'in' | 'limit' | 'order'
+  type: 'eq' | 'in' | 'is' | 'limit' | 'order'
   column: string
   value: unknown
 }
@@ -72,6 +72,11 @@ export function createMockSupabaseClient(handlers: Record<string, TableHandler>)
 
     in(column: string, value: unknown) {
       this.state.filters.push({ type: 'in', column, value })
+      return this
+    }
+
+    is(column: string, value: unknown) {
+      this.state.filters.push({ type: 'is', column, value })
       return this
     }
 

--- a/tests/integration/api-public-phone-verification-routes.test.ts
+++ b/tests/integration/api-public-phone-verification-routes.test.ts
@@ -90,4 +90,27 @@ describe('api public phone verification routes', () => {
       error: 'O código expirou. Solicite um novo.',
     })
   })
+
+  it('retorna erro claro quando o codigo excede o limite de tentativas', async () => {
+    vi.mocked(verifyCustomerPhoneVerificationCode).mockResolvedValueOnce({
+      verified: false,
+      reason: 'too_many_attempts',
+    } as never)
+
+    const verifyResponse = await verifyRoute.POST(
+      new Request('https://chefops.test/api/public/phone-verification/verify', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: '550e8400-e29b-41d4-a716-446655440000',
+          phone: '11999999999',
+          code: '123456',
+        }),
+      }) as never,
+    )
+
+    expect(verifyResponse.status).toBe(400)
+    await expect(verifyResponse.json()).resolves.toEqual({
+      error: 'Muitas tentativas inválidas. Solicite um novo código.',
+    })
+  })
 })

--- a/tests/integration/customer-phone-verification.test.ts
+++ b/tests/integration/customer-phone-verification.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+import { createMockSupabaseClient } from '@/tests/helpers/mock-supabase'
+import { verifyCustomerPhoneVerificationCode } from '@/lib/customer-phone-verification'
+
+describe('customer phone verification service', () => {
+  it('bloqueia verificacao quando o codigo ja excedeu o limite de tentativas', async () => {
+    const admin = createMockSupabaseClient({
+      customer_phone_verifications: (state) => {
+        if (state.operation === 'select') {
+          return {
+            data: {
+              id: 'verification-1',
+              code_hash: 'hash',
+              expires_at: '2099-03-27T10:00:00.000Z',
+              attempts: 5,
+            },
+            error: null,
+          }
+        }
+
+        throw new Error('Nenhum update deveria acontecer após bloquear o código.')
+      },
+    })
+
+    const { createAdminClient } = await import('@/lib/supabase/admin')
+    vi.mocked(createAdminClient).mockReturnValue(admin as never)
+
+    await expect(
+      verifyCustomerPhoneVerificationCode({
+        tenantId: 'tenant-1',
+        phone: '11999999999',
+        code: '123456',
+      }),
+    ).resolves.toEqual({
+      verified: false,
+      reason: 'too_many_attempts',
+    })
+  })
+
+  it('bloqueia o codigo ao atingir a quinta tentativa invalida', async () => {
+    let updateValues: Record<string, unknown> | undefined
+
+    const admin = createMockSupabaseClient({
+      customer_phone_verifications: (state) => {
+        if (state.operation === 'select') {
+          return {
+            data: {
+              id: 'verification-2',
+              code_hash: 'hash-diferente',
+              expires_at: '2099-03-27T10:00:00.000Z',
+              attempts: 4,
+            },
+            error: null,
+          }
+        }
+
+        if (state.operation === 'update') {
+          updateValues = state.values
+          return { data: null, error: null }
+        }
+
+        throw new Error('Operação inesperada')
+      },
+    })
+
+    const { createAdminClient } = await import('@/lib/supabase/admin')
+    vi.mocked(createAdminClient).mockReturnValue(admin as never)
+
+    await expect(
+      verifyCustomerPhoneVerificationCode({
+        tenantId: 'tenant-1',
+        phone: '11999999999',
+        code: '123456',
+      }),
+    ).resolves.toEqual({
+      verified: false,
+      reason: 'too_many_attempts',
+    })
+
+    expect(updateValues).toEqual({ attempts: 5 })
+  })
+})


### PR DESCRIPTION
## Resumo
Este PR endurece a verificação de telefone do checkout público ao limitar tentativas inválidas do código e devolver uma mensagem de erro mais clara quando o limite é atingido.

## O que foi ajustado
- adiciona limite de tentativas inválidas na verificação do código
- bloqueia novas validações do mesmo código após atingir o teto
- retorna `too_many_attempts` na camada de serviço
- mapeia esse caso na rota pública com a mensagem:
  - `Muitas tentativas inválidas. Solicite um novo código.`
- atualiza o helper de testes do Supabase para suportar `.is(...)`, alinhando o mock ao comportamento real das queries

## Impacto esperado
- reduz abuso/bruteforce no fluxo de verificação por código
- melhora a clareza do erro para o usuário final
- mantém a lógica coberta por testes de serviço e de rota

## Validação
- `npm test`
- `npm run build`