### PR TITLE
fix: throttle public phone verification code resends

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -267,7 +267,17 @@ export default function MenuClient({
         await lookupCustomer(cleanPhone)
       }
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Não foi possível validar o código.')
+      const message = error instanceof Error ? error.message : 'Não foi possível validar o código.'
+
+      if (
+        message === 'O código expirou. Solicite um novo.' ||
+        message === 'Muitas tentativas inválidas. Solicite um novo código.'
+      ) {
+        setVerificationCode('')
+        setCodeSent(false)
+      }
+
+      toast.error(message)
     } finally {
       setVerifyingPhoneCode(false)
       setLookingUpPhone(false)

--- a/app/api/public/phone-verification/send/route.ts
+++ b/app/api/public/phone-verification/send/route.ts
@@ -26,14 +26,14 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ data: result })
   } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Não foi possível enviar o código de verificação.'
+
     return NextResponse.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : 'Não foi possível enviar o código de verificação.',
-      },
-      { status: 500 }
+      { error: message },
+      { status: message === 'Aguarde 1 minuto para solicitar um novo código.' ? 429 : 500 }
     )
   }
 }

--- a/lib/customer-phone-verification.ts
+++ b/lib/customer-phone-verification.ts
@@ -7,6 +7,7 @@ import {
 
 const VERIFICATION_TTL_MINUTES = 10
 const MAX_VERIFICATION_ATTEMPTS = 5
+const RESEND_COOLDOWN_SECONDS = 60
 
 function getTwilioVerificationConfig() {
   const accountSid = process.env.TWILIO_ACCOUNT_SID
@@ -50,15 +51,39 @@ export async function sendCustomerPhoneVerificationCode(params: {
   phone: string
 }) {
   const admin = createAdminClient()
+  const normalizedPhone = normalizeBrazilPhone(params.phone)
+  if (!normalizedPhone) {
+    throw new Error('Telefone inválido.')
+  }
+
+  const normalizedPhoneDigits = normalizedPhone.replace(/[^\d]/g, '')
+
+  const { data: latestVerification, error: latestVerificationError } = await admin
+    .from('customer_phone_verifications')
+    .select('id, sent_at, created_at')
+    .eq('tenant_id', params.tenantId)
+    .eq('phone', normalizedPhoneDigits)
+    .is('verified_at', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (latestVerificationError) {
+    throw latestVerificationError
+  }
+
+  const latestSentAt = latestVerification?.sent_at || latestVerification?.created_at
+  if (latestSentAt) {
+    const elapsedSeconds = Math.floor((Date.now() - new Date(latestSentAt).getTime()) / 1000)
+    if (elapsedSeconds < RESEND_COOLDOWN_SECONDS) {
+      throw new Error('Aguarde 1 minuto para solicitar um novo código.')
+    }
+  }
+
   const config = getTwilioVerificationConfig()
 
   if (!config) {
     throw new Error('WhatsApp de verificação não configurado.')
-  }
-
-  const normalizedPhone = normalizeBrazilPhone(params.phone)
-  if (!normalizedPhone) {
-    throw new Error('Telefone inválido.')
   }
 
   const { data: tenant, error: tenantError } = await admin
@@ -78,7 +103,7 @@ export async function sendCustomerPhoneVerificationCode(params: {
     .from('customer_phone_verifications')
     .insert({
       tenant_id: params.tenantId,
-      phone: normalizedPhone.replace(/[^\d]/g, ''),
+      phone: normalizedPhoneDigits,
       code_hash: buildVerificationCodeHash({
         tenantId: params.tenantId,
         phone: normalizedPhone,

--- a/tests/integration/api-public-phone-verification-routes.test.ts
+++ b/tests/integration/api-public-phone-verification-routes.test.ts
@@ -57,6 +57,27 @@ describe('api public phone verification routes', () => {
     })
   })
 
+  it('retorna 429 quando o reenvio do código entra em cooldown', async () => {
+    vi.mocked(sendCustomerPhoneVerificationCode).mockRejectedValueOnce(
+      new Error('Aguarde 1 minuto para solicitar um novo código.')
+    )
+
+    const response = await sendRoute.POST(
+      new Request('https://chefops.test/api/public/phone-verification/send', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: '550e8400-e29b-41d4-a716-446655440000',
+          phone: '11999999999',
+        }),
+      }) as never,
+    )
+
+    expect(response.status).toBe(429)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Aguarde 1 minuto para solicitar um novo código.',
+    })
+  })
+
   it('retorna erros de validação e código expirado', async () => {
     expect(
       (

--- a/tests/integration/customer-phone-verification.test.ts
+++ b/tests/integration/customer-phone-verification.test.ts
@@ -5,9 +5,49 @@ vi.mock('@/lib/supabase/admin', () => ({
 }))
 
 import { createMockSupabaseClient } from '@/tests/helpers/mock-supabase'
-import { verifyCustomerPhoneVerificationCode } from '@/lib/customer-phone-verification'
+import {
+  sendCustomerPhoneVerificationCode,
+  verifyCustomerPhoneVerificationCode,
+} from '@/lib/customer-phone-verification'
 
 describe('customer phone verification service', () => {
+  it('bloqueia reenvio de código dentro da janela de cooldown', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const admin = createMockSupabaseClient({
+      customer_phone_verifications: (state) => {
+        if (state.operation === 'select') {
+          return {
+            data: {
+              id: 'verification-recent',
+              sent_at: new Date().toISOString(),
+              created_at: new Date().toISOString(),
+            },
+            error: null,
+          }
+        }
+
+        throw new Error('Nenhuma outra operação deveria ser executada.')
+      },
+      tenants: () => {
+        throw new Error('Não deveria consultar tenant quando o cooldown bloqueia antes.')
+      },
+    })
+
+    const { createAdminClient } = await import('@/lib/supabase/admin')
+    vi.mocked(createAdminClient).mockReturnValue(admin as never)
+
+    await expect(
+      sendCustomerPhoneVerificationCode({
+        tenantId: 'tenant-1',
+        phone: '11999999999',
+      }),
+    ).rejects.toThrow('Aguarde 1 minuto para solicitar um novo código.')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('bloqueia verificacao quando o codigo ja excedeu o limite de tentativas', async () => {
     const admin = createMockSupabaseClient({
       customer_phone_verifications: (state) => {

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -1380,6 +1380,116 @@ describe('MenuClient component', () => {
     expect(stateSetters[10]).toHaveBeenCalledWith(true)
   })
 
+  it('limpa o código e volta para reenvio quando a verificação expira', async () => {
+    stateValues[5] = '(11) 99999-9999'
+    stateValues[25] = '123456'
+    stateValues[26] = true
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/phone-verification/verify') {
+        return {
+          ok: false,
+          json: vi.fn().mockResolvedValue({ error: 'O código expirou. Solicite um novo.' }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: null }),
+      }
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8 },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    const props = capturedShellProps as {
+      drawerProps: {
+        infoStepProps: {
+          onVerifyPhoneCode: () => Promise<void>
+        }
+      }
+    }
+
+    await props.drawerProps.infoStepProps.onVerifyPhoneCode()
+
+    expect(stateSetters[25]).toHaveBeenCalledWith('')
+    expect(stateSetters[26]).toHaveBeenCalledWith(false)
+    expect(toastErrorMock).toHaveBeenCalledWith('O código expirou. Solicite um novo.')
+  })
+
+  it('limpa o código e volta para reenvio quando atinge o limite de tentativas', async () => {
+    stateValues[5] = '(11) 99999-9999'
+    stateValues[25] = '123456'
+    stateValues[26] = true
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/phone-verification/verify') {
+        return {
+          ok: false,
+          json: vi.fn().mockResolvedValue({
+            error: 'Muitas tentativas inválidas. Solicite um novo código.',
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: null }),
+      }
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8 },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    const props = capturedShellProps as {
+      drawerProps: {
+        infoStepProps: {
+          onVerifyPhoneCode: () => Promise<void>
+        }
+      }
+    }
+
+    await props.drawerProps.infoStepProps.onVerifyPhoneCode()
+
+    expect(stateSetters[25]).toHaveBeenCalledWith('')
+    expect(stateSetters[26]).toHaveBeenCalledWith(false)
+    expect(toastErrorMock).toHaveBeenCalledWith('Muitas tentativas inválidas. Solicite um novo código.')
+  })
+
   it('barra avancos quando validacoes falham', async () => {
     stateValues[0] = [
       {


### PR DESCRIPTION
## Resumo
Este PR adiciona proteção contra spam no envio de códigos de verificação do checkout público, limitando o reenvio dentro de uma janela curta de cooldown.

## O que foi ajustado
- adiciona cooldown de reenvio na camada `customer-phone-verification`
- impede novo envio quando já existe um código recente não verificado para o mesmo tenant/telefone
- faz a rota `POST /api/public/phone-verification/send` responder com status `429` nesse cenário
- mantém a mensagem clara para o cliente:
  - `Aguarde 1 minuto para solicitar um novo código.`
- atualiza o helper de mock do Supabase para suportar `.is(...)`, alinhando os testes com as queries reais

## Impacto esperado
- reduz spam e abuso no envio de códigos por WhatsApp
- evita múltiplos disparos consecutivos para o mesmo número
- deixa o fluxo de verificação mais robusto sem alterar a jornada principal do checkout

## Validação
- `npm test`
- `npm run build`