### PR TITLE
test: lock cooldown behavior for public phone verification resend

### DIFF
--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -1490,6 +1490,62 @@ describe('MenuClient component', () => {
     expect(toastErrorMock).toHaveBeenCalledWith('Muitas tentativas inválidas. Solicite um novo código.')
   })
 
+  it('mantem o estado atual do código quando o reenvio entra em cooldown', async () => {
+    stateValues[5] = '(11) 99999-9999'
+    stateValues[25] = '123456'
+    stateValues[26] = true
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/phone-verification/send') {
+        return {
+          ok: false,
+          json: vi.fn().mockResolvedValue({
+            error: 'Aguarde 1 minuto para solicitar um novo código.',
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: null }),
+      }
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8 },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    const props = capturedShellProps as {
+      drawerProps: {
+        infoStepProps: {
+          onPhoneLookup: () => Promise<void>
+        }
+      }
+    }
+
+    await props.drawerProps.infoStepProps.onPhoneLookup()
+
+    expect(stateSetters[25]).not.toHaveBeenCalledWith('')
+    expect(stateSetters[26]).not.toHaveBeenCalledWith(false)
+    expect(toastErrorMock).toHaveBeenCalledWith('Aguarde 1 minuto para solicitar um novo código.')
+  })
+
   it('barra avancos quando validacoes falham', async () => {
     stateValues[0] = [
       {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura de regressão para garantir que o cooldown de reenvio do código de verificação não desorganize a etapa atual do checkout público.

## O que foi ajustado
- adiciona teste no `MenuClient` garantindo que, ao receber erro de cooldown no reenvio:
  - o código digitado não é apagado
  - o estado de confirmação continua ativo
  - o toast exibe a mensagem correta

## Impacto esperado
- impede regressão de UX no fluxo de verificação por código
- mantém o usuário na etapa atual quando ele ainda pode usar o código já recebido
- protege um comportamento útil sem alterar a implementação existente

## Validação
- `npm test`
- `npm run build`