### PR TITLE
fix: handle missing public phone verification code gracefully

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -270,6 +270,7 @@ export default function MenuClient({
       const message = error instanceof Error ? error.message : 'Não foi possível validar o código.'
 
       if (
+        message === 'Solicite um código primeiro.' ||
         message === 'O código expirou. Solicite um novo.' ||
         message === 'Muitas tentativas inválidas. Solicite um novo código.'
       ) {

--- a/app/api/public/phone-verification/verify/route.ts
+++ b/app/api/public/phone-verification/verify/route.ts
@@ -28,11 +28,13 @@ export async function POST(request: NextRequest) {
 
     if (!result.verified) {
       const errorMessage =
-        result.reason === 'too_many_attempts'
-          ? 'Muitas tentativas inválidas. Solicite um novo código.'
-          : result.reason === 'expired'
-            ? 'O código expirou. Solicite um novo.'
-            : 'Código inválido.'
+        result.reason === 'missing'
+          ? 'Solicite um código primeiro.'
+          : result.reason === 'too_many_attempts'
+            ? 'Muitas tentativas inválidas. Solicite um novo código.'
+            : result.reason === 'expired'
+              ? 'O código expirou. Solicite um novo.'
+              : 'Código inválido.'
 
       return NextResponse.json({ error: errorMessage }, { status: 400 })
     }

--- a/tests/integration/api-public-phone-verification-routes.test.ts
+++ b/tests/integration/api-public-phone-verification-routes.test.ts
@@ -134,4 +134,27 @@ describe('api public phone verification routes', () => {
       error: 'Muitas tentativas inválidas. Solicite um novo código.',
     })
   })
+
+  it('retorna erro claro quando não existe código ativo para validar', async () => {
+    vi.mocked(verifyCustomerPhoneVerificationCode).mockResolvedValueOnce({
+      verified: false,
+      reason: 'missing',
+    } as never)
+
+    const verifyResponse = await verifyRoute.POST(
+      new Request('https://chefops.test/api/public/phone-verification/verify', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: '550e8400-e29b-41d4-a716-446655440000',
+          phone: '11999999999',
+          code: '123456',
+        }),
+      }) as never,
+    )
+
+    expect(verifyResponse.status).toBe(400)
+    await expect(verifyResponse.json()).resolves.toEqual({
+      error: 'Solicite um código primeiro.',
+    })
+  })
 })

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -1546,6 +1546,60 @@ describe('MenuClient component', () => {
     expect(toastErrorMock).toHaveBeenCalledWith('Aguarde 1 minuto para solicitar um novo código.')
   })
 
+  it('limpa o código e volta para solicitar envio quando não existe código ativo', async () => {
+    stateValues[5] = '(11) 99999-9999'
+    stateValues[25] = '123456'
+    stateValues[26] = true
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/phone-verification/verify') {
+        return {
+          ok: false,
+          json: vi.fn().mockResolvedValue({ error: 'Solicite um código primeiro.' }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: null }),
+      }
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8 },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    const props = capturedShellProps as {
+      drawerProps: {
+        infoStepProps: {
+          onVerifyPhoneCode: () => Promise<void>
+        }
+      }
+    }
+
+    await props.drawerProps.infoStepProps.onVerifyPhoneCode()
+
+    expect(stateSetters[25]).toHaveBeenCalledWith('')
+    expect(stateSetters[26]).toHaveBeenCalledWith(false)
+    expect(toastErrorMock).toHaveBeenCalledWith('Solicite um código primeiro.')
+  })
+
   it('barra avancos quando validacoes falham', async () => {
     stateValues[0] = [
       {


### PR DESCRIPTION
## Resumo
Este PR melhora o fluxo de verificação de telefone no checkout público quando o usuário tenta validar um código que já não existe mais ou nunca foi solicitado.

## O que foi ajustado
- faz a rota pública de verificação responder com a mensagem:
  - `Solicite um código primeiro.`
- trata esse caso no `MenuClient` como erro terminal do código
- ao receber esse erro, o checkout:
  - limpa o input do código
  - volta para o estado de solicitar novo envio
  - mostra o toast correspondente

## Impacto esperado
- evita feedback genérico de “código inválido” quando o problema real é ausência de código ativo
- melhora a clareza do fluxo para o usuário final
- mantém o checkout público consistente com os demais cenários de recuperação de código

## Validação
- `npm test`
- `npm run build`