### PR TITLE
fix: tighten public delivery confirmation button visibility

### DIFF
--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -5,6 +5,7 @@ import {
   getDeliveryStepMessage,
   getPaymentStatusLabel,
   isDeliveryStepCompleted,
+  shouldShowPublicDeliveryConfirmButton,
   shouldShowCancelOrderButton,
   shouldShowDeliveryStep,
   type PublicOrderStatus,
@@ -113,8 +114,7 @@ export function MenuDoneStep({
             </span>
           </div>
 
-          {publicOrderStatus?.payment_method === 'delivery' &&
-            publicOrderStatus?.delivery_status === 'out_for_delivery' && (
+          {shouldShowPublicDeliveryConfirmButton(publicOrderStatus) && (
               <Button
                 className="mt-4 w-full"
                 onClick={onConfirmDelivery}

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -556,6 +556,14 @@ export function getDeliveryStepMessage(publicOrderStatus: PublicOrderStatus | nu
   return 'Seu pedido vai aparecer aqui quando sair para entrega.'
 }
 
+export function shouldShowPublicDeliveryConfirmButton(publicOrderStatus: PublicOrderStatus | null) {
+  return (
+    publicOrderStatus?.payment_method === 'delivery' &&
+    publicOrderStatus?.status === 'ready' &&
+    publicOrderStatus?.delivery_status === 'out_for_delivery'
+  )
+}
+
 export function formatPhone(value: string) {
   return value
     .replace(/\D/g, '')

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1034,6 +1034,42 @@ describe('menu components', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
+  it('não mostra confirmar recebimento quando o pedido já está entregue mesmo com delivery_status inconsistente', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 500,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-500',
+          order_number: 500,
+          status: 'delivered',
+          payment_status: 'paid',
+          payment_method: 'delivery',
+          delivery_status: 'out_for_delivery',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [
+          { key: 'pending', label: 'Recebido', description: 'Entrou na fila.' },
+          { key: 'confirmed', label: 'Confirmado', description: 'Confirmado.' },
+          { key: 'ready', label: 'Pronto', description: 'Pronto para sair.' },
+          { key: 'delivered', label: 'Entregue', description: 'Finalizado.' },
+        ],
+        getStepState: (key: 'pending' | 'confirmed' | 'ready' | 'delivered') =>
+          key === 'delivered' ? 'current' : 'done',
+        cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose: vi.fn(),
+      }),
+    )
+
+    expect(markup).not.toContain('Confirmar recebimento')
+  })
+
   it('renderiza cancelamento em andamento e cancelado sem mensagem de reembolso', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -67,6 +67,7 @@ import {
   shouldContinueCheckoutPolling,
   shouldContinueOrderPolling,
   shouldPersistActiveOrder,
+  shouldShowPublicDeliveryConfirmButton,
   validateCPF,
   validateCustomerAddress,
   validateCustomerInfo,
@@ -650,6 +651,11 @@ describe('public menu helpers', () => {
     expect(shouldShowCancelOrderButton(undefined)).toBe(false)
     expect(shouldShowCancelOrderButton('ready')).toBe(false)
     expect(shouldShowDeliveryStep(publicOrderStatus)).toBe(true)
+    expect(shouldShowPublicDeliveryConfirmButton(publicOrderStatus)).toBe(true)
+    expect(shouldShowPublicDeliveryConfirmButton({
+      ...publicOrderStatus,
+      status: 'delivered',
+    })).toBe(false)
     expect(isDeliveryStepCompleted(publicOrderStatus)).toBe(true)
     expect(getDeliveryStepMessage(publicOrderStatus)).toContain('com Carlos')
     expect(getDeliveryStepMessage({


### PR DESCRIPTION
## Resumo
Este PR endurece a regra de exibição do botão público de confirmação de entrega no acompanhamento do pedido.

## O que foi ajustado
- extrai a condição de exibição para `shouldShowPublicDeliveryConfirmButton`
- faz o `MenuDoneStep` depender desse helper, em vez de uma condição inline mais frágil
- adiciona cobertura para garantir que o botão:
  - aparece apenas no cenário correto de delivery em rota
  - não aparece quando o pedido já está `delivered`, mesmo com `delivery_status` inconsistente

## Impacto esperado
- reduz risco de CTA incorreto no acompanhamento do pedido
- deixa a regra de tracking mais explícita e testável
- protege o fluxo público contra estados inconsistentes vindos do backend

## Validação
- `npm test`
- `npm run build`