### PR TITLE
fix: show clear public tracking notices for cancelled orders

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -504,6 +504,11 @@ export function getPublicOrderTrackingMessage(
 
 export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus | null) {
   if (!publicOrderStatus) return null
+  if (publicOrderStatus.status === 'cancelled') {
+    return publicOrderStatus.payment_status === 'refunded'
+      ? 'Pedido cancelado e reembolso solicitado com sucesso.'
+      : 'Pedido cancelado.'
+  }
   if (publicOrderStatus.status === 'confirmed') {
     return 'Seu pedido foi confirmado pelo estabelecimento.'
   }

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -640,6 +640,16 @@ describe('public menu helpers', () => {
       status: 'ready',
       delivery_status: 'out_for_delivery',
     })).toBe('Seu pedido saiu para entrega.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
+      status: 'cancelled',
+      payment_status: 'pending',
+    })).toBe('Pedido cancelado.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
+      status: 'cancelled',
+      payment_status: 'refunded',
+    })).toBe('Pedido cancelado e reembolso solicitado com sucesso.')
     expect(getOnlineCheckoutErrorMessage(new Error('mp error'))).toBe('mp error')
     expect(getOnlineCheckoutErrorMessage(null)).toBe('Erro ao iniciar pagamento online.')
     expect(getPublicOrderPlacementErrorMessage(new Error('order error'))).toBe('order error')


### PR DESCRIPTION
## Resumo
Este PR melhora o acompanhamento público do pedido ao exibir avisos mais claros quando o pedido é cancelado, incluindo o caso com reembolso.

## O que foi ajustado
- atualiza `getPublicOrderStatusNotice` para cobrir:
  - pedido cancelado sem reembolso
  - pedido cancelado com reembolso solicitado
- mantém o restante do fluxo de tracking inalterado

## Impacto esperado
- o cliente final recebe um aviso principal coerente também em cenários de cancelamento
- pedidos reembolsados deixam de cair em mensagens genéricas ou silenciosas no acompanhamento
- a UX do tracking fica mais consistente em todo o ciclo do pedido

## Validação
- `npm test`
- `npm run build`