### PR TITLE
fix: add cancelled-order messaging to public tracking helper

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -491,6 +491,11 @@ export function getPublicOrderTrackingMessage(
   if (publicOrderStatus.status === 'confirmed') return 'Seu pedido foi confirmado.'
   if (publicOrderStatus.status === 'preparing') return 'Seu pedido está em preparo.'
   if (publicOrderStatus.status === 'delivered') return 'Seu pedido foi entregue.'
+  if (publicOrderStatus.status === 'cancelled') {
+    return publicOrderStatus.payment_status === 'refunded'
+      ? 'Seu pedido foi cancelado e o reembolso foi solicitado.'
+      : 'Seu pedido foi cancelado.'
+  }
   if (
     publicOrderStatus.payment_method === 'delivery' &&
     publicOrderStatus.status === 'ready' &&

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -615,6 +615,16 @@ describe('public menu helpers', () => {
       status: 'delivered',
       delivery_status: 'delivered',
     }, 'entregue')).toBe('Seu pedido foi entregue.')
+    expect(getPublicOrderTrackingMessage({
+      ...publicOrderStatus,
+      status: 'cancelled',
+      payment_status: 'pending',
+    }, 'cancelado')).toBe('Seu pedido foi cancelado.')
+    expect(getPublicOrderTrackingMessage({
+      ...publicOrderStatus,
+      status: 'cancelled',
+      payment_status: 'refunded',
+    }, 'cancelado')).toBe('Seu pedido foi cancelado e o reembolso foi solicitado.')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
       status: 'confirmed',


### PR DESCRIPTION
## Resumo
Este PR melhora a camada de mensagens do tracking público para que pedidos cancelados não caiam em textos genéricos.

## O que foi ajustado
- atualiza `getPublicOrderTrackingMessage` para cobrir:
  - cancelamento sem reembolso
  - cancelamento com reembolso solicitado
- mantém o restante da lógica de tracking inalterado

## Impacto esperado
- evita fallback genérico em cenários de pedido cancelado
- deixa a camada de mensagens mais coerente e reutilizável
- protege a semântica do tracking caso esse helper seja usado em mais pontos da interface

## Validação
- `npm test`
- `npm run build`
