### PR TITLE
feat: add contextual notice tones to public order status panel

### DIFF
--- a/features/menu/MenuStatusPanel.tsx
+++ b/features/menu/MenuStatusPanel.tsx
@@ -1,5 +1,5 @@
 import { PublicOrderStatusCard } from '@/features/menu/PublicOrderStatusCard'
-import type { PublicOrderStatus } from '@/features/menu/public-menu'
+import { getCheckoutNoticeTone, type PublicOrderStatus } from '@/features/menu/public-menu'
 
 export function MenuStatusPanel({
   checkoutNotice,
@@ -16,10 +16,20 @@ export function MenuStatusPanel({
   onTrackOrder: () => void
   tableInfo: { id: string; number: string } | null
 }) {
+  const checkoutNoticeTone = getCheckoutNoticeTone(publicOrderStatus)
+
   return (
     <>
       {checkoutNotice && (
-        <div className="mb-6 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+        <div
+          className={`mb-6 rounded-xl px-4 py-3 text-sm ${
+            checkoutNoticeTone === 'danger'
+              ? 'border border-red-200 bg-red-50 text-red-700'
+              : checkoutNoticeTone === 'success'
+                ? 'border border-green-200 bg-green-50 text-green-700'
+                : 'border border-blue-200 bg-blue-50 text-blue-700'
+          }`}
+        >
           {checkoutNotice}
         </div>
       )}

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -574,6 +574,18 @@ export function shouldShowPublicDeliveryConfirmButton(publicOrderStatus: PublicO
   )
 }
 
+export function getCheckoutNoticeTone(publicOrderStatus: PublicOrderStatus | null) {
+  if (publicOrderStatus?.status === 'cancelled') {
+    return 'danger'
+  }
+
+  if (publicOrderStatus?.status === 'delivered') {
+    return 'success'
+  }
+
+  return 'info'
+}
+
 export function formatPhone(value: string) {
   return value
     .replace(/\D/g, '')

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1358,6 +1358,7 @@ describe('menu components', () => {
     )
 
     expect(markup).toContain('Pagamento pendente.')
+    expect(markup).toContain('border-blue-200 bg-blue-50 text-blue-700')
     expect(markup).toContain('Pedido em andamento #42')
     expect(markup).toContain('Mesa 9')
   })
@@ -1402,8 +1403,10 @@ describe('menu components', () => {
     )
 
     expect(cancelledMarkup).toContain('Pedido cancelado.')
+    expect(cancelledMarkup).toContain('border-red-200 bg-red-50 text-red-700')
     expect(cancelledMarkup).not.toContain('Pedido em andamento')
     expect(deliveredMarkup).toContain('Pedido entregue com sucesso.')
+    expect(deliveredMarkup).toContain('border-green-200 bg-green-50 text-green-700')
     expect(deliveredMarkup).not.toContain('Pedido em andamento')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -67,6 +67,7 @@ import {
   shouldContinueCheckoutPolling,
   shouldContinueOrderPolling,
   shouldPersistActiveOrder,
+  getCheckoutNoticeTone,
   shouldShowPublicDeliveryConfirmButton,
   validateCPF,
   validateCustomerAddress,
@@ -676,6 +677,15 @@ describe('public menu helpers', () => {
       ...publicOrderStatus,
       status: 'delivered',
     })).toBe(false)
+    expect(getCheckoutNoticeTone(publicOrderStatus)).toBe('info')
+    expect(getCheckoutNoticeTone({
+      ...publicOrderStatus,
+      status: 'cancelled',
+    })).toBe('danger')
+    expect(getCheckoutNoticeTone({
+      ...publicOrderStatus,
+      status: 'delivered',
+    })).toBe('success')
     expect(isDeliveryStepCompleted(publicOrderStatus)).toBe(true)
     expect(getDeliveryStepMessage(publicOrderStatus)).toContain('com Carlos')
     expect(getDeliveryStepMessage({


### PR DESCRIPTION
## Resumo
Este PR melhora o painel público de acompanhamento do pedido ao aplicar tom visual contextual ao aviso principal.

## O que foi ajustado
- adiciona o helper `getCheckoutNoticeTone`
- aplica tom visual no `MenuStatusPanel` para:
  - `info` em estados normais
  - `danger` em cancelamento
  - `success` em entrega concluída
- atualiza a suíte para validar:
  - o helper de tom
  - as classes renderizadas no painel

## Impacto esperado
- o aviso principal fica mais intuitivo visualmente
- cancelamento e entrega deixam de compartilhar a mesma aparência de mensagem apenas informativa
- melhora a leitura do tracking público sem alterar o fluxo funcional

## Validação
- `npm test`
- `npm run build`