### PR TITLE
feat: add contextual titles to public order status cards

### DIFF
--- a/features/menu/PublicOrderStatusCard.tsx
+++ b/features/menu/PublicOrderStatusCard.tsx
@@ -1,5 +1,9 @@
 import { Button } from '@/components/ui/button'
-import { getPublicOrderTrackingMessage, type PublicOrderStatus } from '@/features/menu/public-menu'
+import {
+  getPublicOrderStatusCardTitle,
+  getPublicOrderTrackingMessage,
+  type PublicOrderStatus,
+} from '@/features/menu/public-menu'
 
 export function PublicOrderStatusCard({
   publicOrderStatus,
@@ -15,7 +19,7 @@ export function PublicOrderStatusCard({
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="text-sm font-semibold text-emerald-900">
-            Pedido em andamento #{publicOrderStatus.order_number}
+            {getPublicOrderStatusCardTitle(publicOrderStatus)}
           </p>
           <p className="mt-1 text-sm text-emerald-700">
             {getPublicOrderTrackingMessage(publicOrderStatus, headline)}

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -507,6 +507,21 @@ export function getPublicOrderTrackingMessage(
   return `Seu pedido está em ${headline}.`
 }
 
+export function getPublicOrderStatusCardTitle(publicOrderStatus: PublicOrderStatus) {
+  if (publicOrderStatus.status === 'pending') return `Pedido recebido #${publicOrderStatus.order_number}`
+  if (publicOrderStatus.status === 'confirmed') return `Pedido confirmado #${publicOrderStatus.order_number}`
+  if (publicOrderStatus.status === 'preparing') return `Pedido em preparo #${publicOrderStatus.order_number}`
+  if (
+    publicOrderStatus.payment_method === 'delivery' &&
+    publicOrderStatus.status === 'ready' &&
+    publicOrderStatus.delivery_status === 'out_for_delivery'
+  ) {
+    return `Pedido saiu para entrega #${publicOrderStatus.order_number}`
+  }
+  if (publicOrderStatus.status === 'ready') return `Pedido pronto #${publicOrderStatus.order_number}`
+  return `Pedido #${publicOrderStatus.order_number}`
+}
+
 export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus | null) {
   if (!publicOrderStatus) return null
   if (publicOrderStatus.status === 'cancelled') {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -85,7 +85,7 @@ function getTextContent(node: React.ReactNode): string {
 }
 
 describe('menu components', () => {
-  it('renderiza card de status do pedido em andamento', async () => {
+  it('renderiza card de status do pedido com título contextual', async () => {
     const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
 
     const markup = renderToStaticMarkup(
@@ -103,7 +103,7 @@ describe('menu components', () => {
       })
     )
 
-    expect(markup).toContain('Pedido em andamento #42')
+    expect(markup).toContain('Pedido em preparo #42')
     expect(markup).toContain('Seu pedido está em preparo.')
     expect(markup).toContain('Acompanhar')
   })
@@ -1359,7 +1359,7 @@ describe('menu components', () => {
 
     expect(markup).toContain('Pagamento pendente.')
     expect(markup).toContain('border-blue-200 bg-blue-50 text-blue-700')
-    expect(markup).toContain('Pedido em andamento #42')
+    expect(markup).toContain('Pedido em preparo #42')
     expect(markup).toContain('Mesa 9')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -41,6 +41,7 @@ import {
   getPaymentStatusLabel,
   getPhoneChangeState,
   getPublicOrderHeadline,
+  getPublicOrderStatusCardTitle,
   getPublicOrderStatusNotice,
   getPublicOrderTrackingMessage,
   getValidationErrorToastMessage,
@@ -626,6 +627,19 @@ describe('public menu helpers', () => {
       status: 'cancelled',
       payment_status: 'refunded',
     }, 'cancelado')).toBe('Seu pedido foi cancelado e o reembolso foi solicitado.')
+    expect(getPublicOrderStatusCardTitle({
+      ...publicOrderStatus,
+      status: 'pending',
+    })).toBe('Pedido recebido #42')
+    expect(getPublicOrderStatusCardTitle({
+      ...publicOrderStatus,
+      status: 'preparing',
+    })).toBe('Pedido em preparo #42')
+    expect(getPublicOrderStatusCardTitle({
+      ...publicOrderStatus,
+      status: 'ready',
+      delivery_status: 'out_for_delivery',
+    })).toBe('Pedido saiu para entrega #42')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
       status: 'confirmed',


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido de acompanhamento do pedido no cardápio público, deixando o título mais contextual ao estado atual do pedido.

## O que foi ajustado
- adiciona o helper `getPublicOrderStatusCardTitle`
- atualiza o `PublicOrderStatusCard` para usar títulos contextuais por status
- cobre os principais estados:
  - recebido
  - confirmado
  - em preparo
  - pronto
  - saiu para entrega

## Impacto esperado
- o card de acompanhamento fica mais informativo logo no título
- reduz repetição entre o título e a mensagem descritiva abaixo
- melhora a leitura rápida do estado atual do pedido

## Validação
- `npm test`
- `npm run build`