### PR TITLE
feat: add dedicated summary messages to public order status cards

### DIFF
--- a/features/menu/MenuStatusPanel.tsx
+++ b/features/menu/MenuStatusPanel.tsx
@@ -37,7 +37,6 @@ export function MenuStatusPanel({
       {publicOrderStatus && !cartOpen && !['delivered', 'cancelled'].includes(publicOrderStatus.status) && headline && (
         <PublicOrderStatusCard
           publicOrderStatus={publicOrderStatus}
-          headline={headline}
           onTrack={onTrackOrder}
         />
       )}

--- a/features/menu/PublicOrderStatusCard.tsx
+++ b/features/menu/PublicOrderStatusCard.tsx
@@ -1,17 +1,15 @@
 import { Button } from '@/components/ui/button'
 import {
+  getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardTitle,
-  getPublicOrderTrackingMessage,
   type PublicOrderStatus,
 } from '@/features/menu/public-menu'
 
 export function PublicOrderStatusCard({
   publicOrderStatus,
-  headline,
   onTrack,
 }: {
   publicOrderStatus: PublicOrderStatus
-  headline: string
   onTrack: () => void
 }) {
   return (
@@ -22,7 +20,7 @@ export function PublicOrderStatusCard({
             {getPublicOrderStatusCardTitle(publicOrderStatus)}
           </p>
           <p className="mt-1 text-sm text-emerald-700">
-            {getPublicOrderTrackingMessage(publicOrderStatus, headline)}
+            {getPublicOrderStatusCardMessage(publicOrderStatus)}
           </p>
         </div>
         <Button

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -522,6 +522,34 @@ export function getPublicOrderStatusCardTitle(publicOrderStatus: PublicOrderStat
   return `Pedido #${publicOrderStatus.order_number}`
 }
 
+export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderStatus) {
+  if (publicOrderStatus.status === 'pending') {
+    return 'Seu pedido entrou na fila do estabelecimento.'
+  }
+
+  if (publicOrderStatus.status === 'confirmed') {
+    return 'O estabelecimento confirmou seu pedido.'
+  }
+
+  if (publicOrderStatus.status === 'preparing') {
+    return 'Seu pedido está sendo preparado.'
+  }
+
+  if (
+    publicOrderStatus.payment_method === 'delivery' &&
+    publicOrderStatus.status === 'ready' &&
+    publicOrderStatus.delivery_status === 'out_for_delivery'
+  ) {
+    return 'Acompanhe o deslocamento da entrega.'
+  }
+
+  if (publicOrderStatus.status === 'ready') {
+    return 'Seu pedido está pronto para a próxima etapa.'
+  }
+
+  return 'Acompanhe o andamento do seu pedido.'
+}
+
 export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus | null) {
   if (!publicOrderStatus) return null
   if (publicOrderStatus.status === 'cancelled') {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -98,13 +98,12 @@ describe('menu components', () => {
           created_at: '2026-03-21T00:00:00.000Z',
           updated_at: '2026-03-21T00:00:00.000Z',
         },
-        headline: 'em preparo',
         onTrack: vi.fn(),
       })
     )
 
     expect(markup).toContain('Pedido em preparo #42')
-    expect(markup).toContain('Seu pedido está em preparo.')
+    expect(markup).toContain('Seu pedido está sendo preparado.')
     expect(markup).toContain('Acompanhar')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -41,6 +41,7 @@ import {
   getPaymentStatusLabel,
   getPhoneChangeState,
   getPublicOrderHeadline,
+  getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardTitle,
   getPublicOrderStatusNotice,
   getPublicOrderTrackingMessage,
@@ -631,15 +632,28 @@ describe('public menu helpers', () => {
       ...publicOrderStatus,
       status: 'pending',
     })).toBe('Pedido recebido #42')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
+      status: 'pending',
+    })).toBe('Seu pedido entrou na fila do estabelecimento.')
     expect(getPublicOrderStatusCardTitle({
       ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Pedido em preparo #42')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
+      status: 'preparing',
+    })).toBe('Seu pedido está sendo preparado.')
     expect(getPublicOrderStatusCardTitle({
       ...publicOrderStatus,
       status: 'ready',
       delivery_status: 'out_for_delivery',
     })).toBe('Pedido saiu para entrega #42')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
+      status: 'ready',
+      delivery_status: 'out_for_delivery',
+    })).toBe('Acompanhe o deslocamento da entrega.')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
       status: 'confirmed',


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido de acompanhamento do pedido no cardápio público com mensagens mais úteis e menos redundantes.

## O que foi ajustado
- adiciona o helper `getPublicOrderStatusCardMessage`
- faz o `PublicOrderStatusCard` usar um subtítulo próprio, em vez de reutilizar a mensagem detalhada do tracking
- remove a dependência de `headline` dentro do card resumido
- mantém o tracking detalhado intacto na tela completa do pedido

## Impacto esperado
- o card resumido fica mais escaneável
- reduz repetição entre título e subtítulo
- melhora a clareza do resumo do pedido sem mudar o fluxo funcional

## Validação
- `npm test`
- `npm run build`