### PR TITLE
fix: hide redundant public checkout notices during active tracking

### DIFF
--- a/features/menu/MenuStatusPanel.tsx
+++ b/features/menu/MenuStatusPanel.tsx
@@ -1,5 +1,9 @@
 import { PublicOrderStatusCard } from '@/features/menu/PublicOrderStatusCard'
-import { getCheckoutNoticeTone, type PublicOrderStatus } from '@/features/menu/public-menu'
+import {
+  getCheckoutNoticeTone,
+  shouldShowCheckoutNoticeBanner,
+  type PublicOrderStatus,
+} from '@/features/menu/public-menu'
 
 export function MenuStatusPanel({
   checkoutNotice,
@@ -17,10 +21,15 @@ export function MenuStatusPanel({
   tableInfo: { id: string; number: string } | null
 }) {
   const checkoutNoticeTone = getCheckoutNoticeTone(publicOrderStatus)
+  const shouldShowNotice = shouldShowCheckoutNoticeBanner({
+    checkoutNotice,
+    publicOrderStatus,
+    cartOpen,
+  })
 
   return (
     <>
-      {checkoutNotice && (
+      {shouldShowNotice && checkoutNotice && (
         <div
           className={`mb-6 rounded-xl px-4 py-3 text-sm ${
             checkoutNoticeTone === 'danger'

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -629,6 +629,24 @@ export function getCheckoutNoticeTone(publicOrderStatus: PublicOrderStatus | nul
   return 'info'
 }
 
+export function shouldShowCheckoutNoticeBanner(params: {
+  checkoutNotice: string | null
+  publicOrderStatus: PublicOrderStatus | null
+  cartOpen: boolean
+}) {
+  if (!params.checkoutNotice) return false
+  if (params.cartOpen) return true
+  if (!params.publicOrderStatus) return true
+  if (['delivered', 'cancelled'].includes(params.publicOrderStatus.status)) return true
+
+  const statusNotice = getPublicOrderStatusNotice(params.publicOrderStatus)
+  if (statusNotice && statusNotice === params.checkoutNotice) {
+    return false
+  }
+
+  return true
+}
+
 export function formatPhone(value: string) {
   return value
     .replace(/\D/g, '')

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1335,7 +1335,7 @@ describe('menu components', () => {
     expect(markup).toContain('3')
   })
 
-  it('renderiza painel de status com aviso, pedido e banner de mesa', async () => {
+  it('renderiza painel de status com aviso distinto, pedido e banner de mesa', async () => {
     const { MenuStatusPanel } = await import('@/features/menu/MenuStatusPanel')
 
     const markup = renderToStaticMarkup(
@@ -1360,6 +1360,31 @@ describe('menu components', () => {
     expect(markup).toContain('border-blue-200 bg-blue-50 text-blue-700')
     expect(markup).toContain('Pedido em preparo #42')
     expect(markup).toContain('Mesa 9')
+  })
+
+  it('oculta o banner quando ele só repete o status em andamento já exibido no card', async () => {
+    const { MenuStatusPanel } = await import('@/features/menu/MenuStatusPanel')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(MenuStatusPanel, {
+        checkoutNotice: 'Seu pedido está em preparo.',
+        publicOrderStatus: {
+          id: 'order-duplicate',
+          order_number: 77,
+          status: 'preparing',
+          payment_status: 'paid',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        cartOpen: false,
+        headline: 'em preparo',
+        onTrackOrder: vi.fn(),
+        tableInfo: null,
+      })
+    )
+
+    expect(markup).not.toContain('border-blue-200 bg-blue-50 text-blue-700')
+    expect(markup).toContain('Pedido em preparo #77')
   })
 
   it('nao renderiza card de pedido em andamento para estados finais no painel de status', async () => {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -70,6 +70,7 @@ import {
   shouldContinueOrderPolling,
   shouldPersistActiveOrder,
   getCheckoutNoticeTone,
+  shouldShowCheckoutNoticeBanner,
   shouldShowPublicDeliveryConfirmButton,
   validateCPF,
   validateCustomerAddress,
@@ -714,6 +715,30 @@ describe('public menu helpers', () => {
       ...publicOrderStatus,
       status: 'delivered',
     })).toBe('success')
+    expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Seu pedido está em preparo.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'preparing',
+      },
+      cartOpen: false,
+    })).toBe(false)
+    expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Pagamento pendente.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'preparing',
+      },
+      cartOpen: false,
+    })).toBe(true)
+    expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Pedido cancelado.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'cancelled',
+      },
+      cartOpen: false,
+    })).toBe(true)
     expect(isDeliveryStepCompleted(publicOrderStatus)).toBe(true)
     expect(getDeliveryStepMessage(publicOrderStatus)).toContain('com Carlos')
     expect(getDeliveryStepMessage({


### PR DESCRIPTION
## Resumo
Este PR reduz redundância visual no painel público de acompanhamento do pedido, escondendo o banner principal quando ele só repete o mesmo status já apresentado no card resumido.

## O que foi ajustado
- adiciona o helper `shouldShowCheckoutNoticeBanner`
- faz o `MenuStatusPanel` usar essa regra antes de renderizar o aviso principal
- mantém visíveis:
  - avisos distintos como `Pagamento pendente`
  - avisos de estados finais como cancelamento e entrega

## Impacto esperado
- o acompanhamento do pedido fica mais limpo e fácil de escanear
- reduz repetição entre banner e card resumido
- preserva avisos importantes que ainda agregam contexto real

## Validação
- `npm test`
- `npm run build`
