### PR TITLE
feat: add contextual tones to public order status cards

### DIFF
--- a/features/menu/PublicOrderStatusCard.tsx
+++ b/features/menu/PublicOrderStatusCard.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button'
 import {
   getPublicOrderStatusCardActionLabel,
   getPublicOrderStatusCardMessage,
+  getPublicOrderStatusCardTone,
   getPublicOrderStatusCardTitle,
   type PublicOrderStatus,
 } from '@/features/menu/public-menu'
@@ -13,20 +14,48 @@ export function PublicOrderStatusCard({
   publicOrderStatus: PublicOrderStatus
   onTrack: () => void
 }) {
+  const tone = getPublicOrderStatusCardTone(publicOrderStatus)
+  const toneClasses = {
+    warning: {
+      container: 'border-amber-200 bg-amber-50',
+      title: 'text-amber-900',
+      message: 'text-amber-700',
+      button: 'bg-amber-600 hover:bg-amber-700',
+    },
+    progress: {
+      container: 'border-sky-200 bg-sky-50',
+      title: 'text-sky-900',
+      message: 'text-sky-700',
+      button: 'bg-sky-600 hover:bg-sky-700',
+    },
+    delivery: {
+      container: 'border-violet-200 bg-violet-50',
+      title: 'text-violet-900',
+      message: 'text-violet-700',
+      button: 'bg-violet-600 hover:bg-violet-700',
+    },
+    success: {
+      container: 'border-emerald-200 bg-emerald-50',
+      title: 'text-emerald-900',
+      message: 'text-emerald-700',
+      button: 'bg-emerald-600 hover:bg-emerald-700',
+    },
+  }[tone]
+
   return (
-    <div className="mb-6 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 shadow-sm">
+    <div className={`mb-6 rounded-2xl border px-4 py-4 shadow-sm ${toneClasses.container}`}>
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-sm font-semibold text-emerald-900">
+          <p className={`text-sm font-semibold ${toneClasses.title}`}>
             {getPublicOrderStatusCardTitle(publicOrderStatus)}
           </p>
-          <p className="mt-1 text-sm text-emerald-700">
+          <p className={`mt-1 text-sm ${toneClasses.message}`}>
             {getPublicOrderStatusCardMessage(publicOrderStatus)}
           </p>
         </div>
         <Button
           size="sm"
-          className="bg-emerald-600 text-white hover:bg-emerald-700"
+          className={`text-white ${toneClasses.button}`}
           onClick={onTrack}
         >
           {getPublicOrderStatusCardActionLabel(publicOrderStatus)}

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -562,6 +562,24 @@ export function getPublicOrderStatusCardActionLabel(publicOrderStatus: PublicOrd
   return 'Ver pedido'
 }
 
+export function getPublicOrderStatusCardTone(publicOrderStatus: PublicOrderStatus) {
+  if (publicOrderStatus.status === 'pending') return 'warning'
+
+  if (
+    publicOrderStatus.payment_method === 'delivery' &&
+    publicOrderStatus.status === 'ready' &&
+    publicOrderStatus.delivery_status === 'out_for_delivery'
+  ) {
+    return 'delivery'
+  }
+
+  if (publicOrderStatus.status === 'confirmed' || publicOrderStatus.status === 'preparing') {
+    return 'progress'
+  }
+
+  return 'success'
+}
+
 export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus | null) {
   if (!publicOrderStatus) return null
   if (publicOrderStatus.status === 'cancelled') {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -105,6 +105,8 @@ describe('menu components', () => {
     expect(markup).toContain('Pedido em preparo #42')
     expect(markup).toContain('Seu pedido está sendo preparado.')
     expect(markup).toContain('Ver pedido')
+    expect(markup).toContain('border-sky-200')
+    expect(markup).toContain('bg-sky-50')
   })
 
   it('renderiza modal de meia a meia com sabores elegíveis', async () => {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -43,6 +43,7 @@ import {
   getPublicOrderHeadline,
   getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardActionLabel,
+  getPublicOrderStatusCardTone,
   getPublicOrderStatusCardTitle,
   getPublicOrderStatusNotice,
   getPublicOrderTrackingMessage,
@@ -665,6 +666,26 @@ describe('public menu helpers', () => {
       ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Ver pedido')
+    expect(getPublicOrderStatusCardTone({
+      ...publicOrderStatus,
+      status: 'pending',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('warning')
+    expect(getPublicOrderStatusCardTone({
+      ...publicOrderStatus,
+      status: 'preparing',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('progress')
+    expect(getPublicOrderStatusCardTone({
+      ...publicOrderStatus,
+      status: 'ready',
+      delivery_status: 'out_for_delivery',
+    })).toBe('delivery')
+    expect(getPublicOrderStatusCardTone({
+      ...publicOrderStatus,
+      status: 'ready',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('success')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
       status: 'confirmed',


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do acompanhamento público aplicando tons visuais diferentes para cada etapa operacional do pedido.

## O que foi ajustado
- adiciona o helper `getPublicOrderStatusCardTone`
- atualiza o `PublicOrderStatusCard` para variar borda, fundo, texto e botão conforme o status
- cobre os principais estados:
  - pedido recebido
  - confirmado / em preparo
  - pronto
  - saiu para entrega
- adiciona cobertura unitária para o helper e para a renderização do card

## Impacto esperado
- o card resumido fica mais expressivo visualmente
- o consumidor identifica melhor a etapa atual do pedido num rápido olhar
- o fluxo funcional continua o mesmo, com melhoria apenas de comunicação visual

## Validação
- `npm test`
- `npm run build`
