### PR TITLE
feat: make public ready-step messaging contextual to fulfillment type

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -107,7 +107,9 @@ export default function MenuClient({
   const [isNewCustomer, setIsNewCustomer] = useState(false)
   const [address, setAddress] = useState<Partial<CustomerAddress>>({})
   const [loadingCep, setLoadingCep] = useState(false)
-  const [paymentMethod, setPaymentMethod] = useState<string>(tableInfo ? 'table' : '')
+  const [paymentMethod, setPaymentMethod] = useState<'' | NonNullable<PublicOrderStatus['payment_method']>>(
+    tableInfo ? 'table' : ''
+  )
   const [notes, setNotes] = useState('')
   const [orderNumber, setOrderNumber] = useState<number | null>(null)
   const [orderId, setOrderId] = useState<string | null>(null)
@@ -604,7 +606,7 @@ export default function MenuClient({
     }
   }
 
-  const orderSteps = getOrderSteps(tableInfo)
+  const orderSteps = getOrderSteps(tableInfo, (publicOrderStatus?.payment_method ?? paymentMethod) || null)
   const isCheckoutProcessing = getPublicCheckoutProcessingState(
     createOrder.isPending,
     onlineCheckoutLoading,
@@ -702,7 +704,8 @@ export default function MenuClient({
           onCustomerCpfChange: (value) => setCustomerCpf(formatCPF(value)),
           paymentOptions,
           paymentMethod,
-          onPaymentMethodChange: setPaymentMethod,
+          onPaymentMethodChange: (value) =>
+            setPaymentMethod(value as '' | NonNullable<PublicOrderStatus['payment_method']>),
           notes,
           onNotesChange: setNotes,
           cartTotal,

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -306,7 +306,16 @@ export function getPublicCheckoutProcessingState(
   return createOrderPending || onlineCheckoutLoading
 }
 
-export function getOrderSteps(tableInfo: { id: string; number: string } | null) {
+export function getOrderSteps(
+  tableInfo: { id: string; number: string } | null,
+  paymentMethod?: PublicOrderStatus['payment_method'] | null
+) {
+  const readyDescription = tableInfo
+    ? 'Seu pedido está pronto para servir.'
+    : paymentMethod === 'delivery'
+      ? 'Seu pedido está pronto para sair para entrega.'
+      : 'Seu pedido está pronto para retirada.'
+
   return [
     { key: 'pending', label: 'Recebido', description: 'Seu pedido entrou na fila do estabelecimento.' },
     { key: 'confirmed', label: 'Confirmado', description: 'O estabelecimento confirmou seu pedido.' },
@@ -314,7 +323,7 @@ export function getOrderSteps(tableInfo: { id: string; number: string } | null) 
     {
       key: 'ready',
       label: 'Pronto',
-      description: tableInfo ? 'Seu pedido está pronto para servir.' : 'Seu pedido está pronto para sair.',
+      description: readyDescription,
     },
     { key: 'delivered', label: 'Entregue', description: 'Pedido finalizado com sucesso.' },
   ] as const satisfies Array<{

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -557,21 +557,27 @@ describe('public menu helpers', () => {
   })
 
   it('monta steps do pedido conforme contexto de mesa', () => {
-    expect(getOrderSteps({ id: 'table-1', number: '10' })[3]).toEqual({
+    expect(getOrderSteps({ id: 'table-1', number: '10' }, 'table')[3]).toEqual({
       key: 'ready',
       label: 'Pronto',
       description: 'Seu pedido está pronto para servir.',
     })
 
-    expect(getOrderSteps(null)[3]).toEqual({
+    expect(getOrderSteps(null, 'counter')[3]).toEqual({
       key: 'ready',
       label: 'Pronto',
-      description: 'Seu pedido está pronto para sair.',
+      description: 'Seu pedido está pronto para retirada.',
+    })
+
+    expect(getOrderSteps(null, 'delivery')[3]).toEqual({
+      key: 'ready',
+      label: 'Pronto',
+      description: 'Seu pedido está pronto para sair para entrega.',
     })
   })
 
   it('resume checkout, cancelamento, pagamento e entrega do pedido público', () => {
-    const orderSteps = getOrderSteps(null)
+    const orderSteps = getOrderSteps(null, 'delivery')
     const publicOrderStatus = {
       id: 'order-1',
       order_number: 42,


### PR DESCRIPTION
## Resumo
Este PR melhora a timeline pública do pedido deixando a etapa `Pronto` contextual ao tipo de atendimento.

## O que foi ajustado
- atualiza `getOrderSteps` para variar a descrição da etapa `ready` conforme o contexto:
  - mesa
  - retirada/balcão
  - delivery
- faz o `MenuClient` repassar o método de pagamento atual ao montar os steps da timeline
- ajusta os testes unitários para cobrir as três variantes

## Impacto esperado
- a timeline do cliente fica mais clara e específica
- pedidos de retirada deixam de usar texto genérico
- pedidos de delivery comunicam melhor a transição para a entrega

## Validação
- `npm test`
- `npm run build`