### PR TITLE
feat: make delivered-step messaging contextual in public order timeline

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -315,6 +315,11 @@ export function getOrderSteps(
     : paymentMethod === 'delivery'
       ? 'Seu pedido está pronto para sair para entrega.'
       : 'Seu pedido está pronto para retirada.'
+  const deliveredDescription = tableInfo
+    ? 'Pedido servido na mesa com sucesso.'
+    : paymentMethod === 'delivery'
+      ? 'Pedido entregue com sucesso.'
+      : 'Pedido retirado com sucesso.'
 
   return [
     { key: 'pending', label: 'Recebido', description: 'Seu pedido entrou na fila do estabelecimento.' },
@@ -325,7 +330,7 @@ export function getOrderSteps(
       label: 'Pronto',
       description: readyDescription,
     },
-    { key: 'delivered', label: 'Entregue', description: 'Pedido finalizado com sucesso.' },
+    { key: 'delivered', label: 'Entregue', description: deliveredDescription },
   ] as const satisfies Array<{
     key: PublicOrderStatus['status']
     label: string

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -562,17 +562,32 @@ describe('public menu helpers', () => {
       label: 'Pronto',
       description: 'Seu pedido está pronto para servir.',
     })
+    expect(getOrderSteps({ id: 'table-1', number: '10' }, 'table')[4]).toEqual({
+      key: 'delivered',
+      label: 'Entregue',
+      description: 'Pedido servido na mesa com sucesso.',
+    })
 
     expect(getOrderSteps(null, 'counter')[3]).toEqual({
       key: 'ready',
       label: 'Pronto',
       description: 'Seu pedido está pronto para retirada.',
     })
+    expect(getOrderSteps(null, 'counter')[4]).toEqual({
+      key: 'delivered',
+      label: 'Entregue',
+      description: 'Pedido retirado com sucesso.',
+    })
 
     expect(getOrderSteps(null, 'delivery')[3]).toEqual({
       key: 'ready',
       label: 'Pronto',
       description: 'Seu pedido está pronto para sair para entrega.',
+    })
+    expect(getOrderSteps(null, 'delivery')[4]).toEqual({
+      key: 'delivered',
+      label: 'Entregue',
+      description: 'Pedido entregue com sucesso.',
     })
   })
 


### PR DESCRIPTION
## Resumo
Este PR melhora a etapa final da timeline pública para que a mensagem de `Entregue` reflita o tipo real de atendimento do pedido.

## O que foi ajustado
- atualiza `getOrderSteps` para variar a descrição da etapa `delivered` conforme o contexto:
  - mesa
  - retirada/balcão
  - delivery
- ajusta os testes unitários para cobrir as três variantes

## Impacto esperado
- a timeline do cliente fica mais natural até o fim do fluxo
- pedidos servidos na mesa e retirados deixam de usar texto genérico de entrega
- a experiência pública fica mais coerente com o tipo de atendimento

## Validação
- `npm test`
- `npm run build`
