### PR TITLE
feat: add contextual order reference labels to public order completion step

### DIFF
--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -4,6 +4,7 @@ import {
   getCancelledOrderMessage,
   getDeliveryStepMessage,
   getPaymentStatusLabel,
+  getPublicOrderReferenceLabel,
   isDeliveryStepCompleted,
   shouldShowPublicDeliveryConfirmButton,
   shouldShowCancelOrderButton,
@@ -40,7 +41,12 @@ export function MenuDoneStep({
         <ChefHat className="w-8 h-8 text-green-600" />
       </div>
       <h3 className="text-xl font-semibold text-slate-900 mb-2">Pedido realizado!</h3>
-      <p className="text-slate-500 text-sm mb-1">Seu número de pedido é</p>
+      <p className="text-slate-500 text-sm mb-1">
+        {getPublicOrderReferenceLabel({
+          tableInfo,
+          paymentMethod: publicOrderStatus?.payment_method,
+        })}
+      </p>
       <p className="text-4xl font-bold text-slate-900 mb-4">#{orderNumber}</p>
       {tableInfo && (
         <p className="text-sm text-slate-500">

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -345,6 +345,15 @@ export function getCheckoutStepTitle(step: 'cart' | 'info' | 'address' | 'done')
   return 'Pedido realizado!'
 }
 
+export function getPublicOrderReferenceLabel(params: {
+  tableInfo: { id: string; number: string } | null
+  paymentMethod?: PublicOrderStatus['payment_method'] | null
+}) {
+  if (params.tableInfo) return 'Número da comanda'
+  if (params.paymentMethod === 'counter') return 'Número para retirada'
+  return 'Número do pedido'
+}
+
 export function getContinueFlowTarget(
   paymentMethod: string,
   tableInfo: { id: string; number: string } | null

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -854,6 +854,7 @@ describe('menu components', () => {
     )
 
     expect(markup).toContain('Pedido realizado!')
+    expect(markup).toContain('Número do pedido')
     expect(markup).toContain('#42')
     expect(markup).toContain('Acompanhe o status do pedido')
     expect(markup).toContain('Cancelar pedido')
@@ -885,9 +886,41 @@ describe('menu components', () => {
     )
 
     expect(markup).toContain('Pedido cancelado')
+    expect(markup).toContain('Número da comanda')
     expect(markup).toContain('Estoque indisponível')
     expect(markup).toContain('Reembolso solicitado com sucesso')
     expect(markup).toContain('Mesa 8')
+  })
+
+  it('renderiza rótulo de retirada no passo final de balcão', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 321,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-counter',
+          order_number: 321,
+          status: 'confirmed',
+          payment_status: 'pending',
+          payment_method: 'counter',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [
+          { key: 'pending', label: 'Recebido', description: 'Entrou na fila.' },
+          { key: 'confirmed', label: 'Confirmado', description: 'Confirmado.' },
+        ],
+        getStepState: () => 'current',
+        cancelOrderLoading: false,
+        onCancelOrder: vi.fn(),
+        onClose: vi.fn(),
+      }),
+    )
+
+    expect(markup).toContain('Número para retirada')
+    expect(markup).toContain('#321')
   })
 
   it('aciona handlers e renderiza etapa de entrega no passo final', async () => {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -41,6 +41,7 @@ import {
   getPaymentStatusLabel,
   getPhoneChangeState,
   getPublicOrderHeadline,
+  getPublicOrderReferenceLabel,
   getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardActionLabel,
   getPublicOrderStatusCardTone,
@@ -610,6 +611,18 @@ describe('public menu helpers', () => {
     expect(getCheckoutStepTitle('info')).toBe('Seus dados')
     expect(getCheckoutStepTitle('address')).toBe('Endereço de entrega')
     expect(getCheckoutStepTitle('done')).toBe('Pedido realizado!')
+    expect(getPublicOrderReferenceLabel({
+      tableInfo: { id: 'table-1', number: '10' },
+      paymentMethod: 'table',
+    })).toBe('Número da comanda')
+    expect(getPublicOrderReferenceLabel({
+      tableInfo: null,
+      paymentMethod: 'counter',
+    })).toBe('Número para retirada')
+    expect(getPublicOrderReferenceLabel({
+      tableInfo: null,
+      paymentMethod: 'delivery',
+    })).toBe('Número do pedido')
 
     expect(getPublicOrderHeadline(publicOrderStatus, orderSteps)).toBe('pronto')
     expect(getCancelledOrderMessage(publicOrderStatus)).toBe('Cliente desistiu')


### PR DESCRIPTION
## Resumo
Este PR melhora o passo final do pedido público com um rótulo mais contextual para o identificador mostrado ao cliente.

## O que foi ajustado
- adiciona o helper `getPublicOrderReferenceLabel`
- atualiza o `MenuDoneStep` para variar o rótulo conforme o contexto:
  - mesa
  - retirada/balcão
  - pedido comum/delivery
- adiciona cobertura unitária para o helper e para a renderização do passo final

## Impacto esperado
- o cliente vê uma linguagem mais coerente com o tipo de atendimento
- pedidos de mesa e retirada deixam de usar o rótulo genérico de pedido
- melhora a clareza do fechamento do fluxo sem alterar comportamento funcional

## Validação
- `npm test`
- `npm run build`
