### PR TITLE
feat: add contextual completion titles to public order flow

### DIFF
--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -4,6 +4,7 @@ import {
   getCancelledOrderMessage,
   getDeliveryStepMessage,
   getPaymentStatusLabel,
+  getPublicOrderCompletionTitle,
   getPublicOrderReferenceLabel,
   isDeliveryStepCompleted,
   shouldShowPublicDeliveryConfirmButton,
@@ -40,7 +41,12 @@ export function MenuDoneStep({
       <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mb-4">
         <ChefHat className="w-8 h-8 text-green-600" />
       </div>
-      <h3 className="text-xl font-semibold text-slate-900 mb-2">Pedido realizado!</h3>
+      <h3 className="text-xl font-semibold text-slate-900 mb-2">
+        {getPublicOrderCompletionTitle({
+          tableInfo,
+          paymentMethod: publicOrderStatus?.payment_method,
+        })}
+      </h3>
       <p className="text-slate-500 text-sm mb-1">
         {getPublicOrderReferenceLabel({
           tableInfo,

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -354,6 +354,15 @@ export function getPublicOrderReferenceLabel(params: {
   return 'Número do pedido'
 }
 
+export function getPublicOrderCompletionTitle(params: {
+  tableInfo: { id: string; number: string } | null
+  paymentMethod?: PublicOrderStatus['payment_method'] | null
+}) {
+  if (params.tableInfo) return 'Comanda aberta!'
+  if (params.paymentMethod === 'counter') return 'Pedido pronto para retirada!'
+  return 'Pedido realizado!'
+}
+
 export function getContinueFlowTarget(
   paymentMethod: string,
   tableInfo: { id: string; number: string } | null

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -886,6 +886,7 @@ describe('menu components', () => {
     )
 
     expect(markup).toContain('Pedido cancelado')
+    expect(markup).toContain('Comanda aberta!')
     expect(markup).toContain('Número da comanda')
     expect(markup).toContain('Estoque indisponível')
     expect(markup).toContain('Reembolso solicitado com sucesso')
@@ -920,6 +921,7 @@ describe('menu components', () => {
     )
 
     expect(markup).toContain('Número para retirada')
+    expect(markup).toContain('Pedido pronto para retirada!')
     expect(markup).toContain('#321')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -41,6 +41,7 @@ import {
   getPaymentStatusLabel,
   getPhoneChangeState,
   getPublicOrderHeadline,
+  getPublicOrderCompletionTitle,
   getPublicOrderReferenceLabel,
   getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardActionLabel,
@@ -611,6 +612,18 @@ describe('public menu helpers', () => {
     expect(getCheckoutStepTitle('info')).toBe('Seus dados')
     expect(getCheckoutStepTitle('address')).toBe('Endereço de entrega')
     expect(getCheckoutStepTitle('done')).toBe('Pedido realizado!')
+    expect(getPublicOrderCompletionTitle({
+      tableInfo: { id: 'table-1', number: '10' },
+      paymentMethod: 'table',
+    })).toBe('Comanda aberta!')
+    expect(getPublicOrderCompletionTitle({
+      tableInfo: null,
+      paymentMethod: 'counter',
+    })).toBe('Pedido pronto para retirada!')
+    expect(getPublicOrderCompletionTitle({
+      tableInfo: null,
+      paymentMethod: 'delivery',
+    })).toBe('Pedido realizado!')
     expect(getPublicOrderReferenceLabel({
       tableInfo: { id: 'table-1', number: '10' },
       paymentMethod: 'table',


### PR DESCRIPTION
## Resumo
Este PR melhora o passo final do pedido público com um título principal mais coerente com o tipo de atendimento.

## O que foi ajustado
- adiciona o helper `getPublicOrderCompletionTitle`
- atualiza o `MenuDoneStep` para variar o título conforme o contexto:
  - mesa
  - retirada/balcão
  - pedido comum/delivery
- adiciona cobertura unitária para o helper e para a renderização do passo final

## Impacto esperado
- o fechamento do fluxo fica mais natural para cada tipo de pedido
- pedidos de mesa e retirada deixam de usar o título genérico de pedido realizado
- melhora a clareza sem alterar comportamento funcional

## Validação
- `npm test`
- `npm run build`
