### PR TITLE
feat: add contextual completion subtitles to public order flow

### DIFF
--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -5,6 +5,7 @@ import {
   getDeliveryStepMessage,
   getPaymentStatusLabel,
   getPublicOrderCompletionTitle,
+  getPublicOrderCompletionSubtitle,
   getPublicOrderReferenceLabel,
   isDeliveryStepCompleted,
   shouldShowPublicDeliveryConfirmButton,
@@ -47,6 +48,12 @@ export function MenuDoneStep({
           paymentMethod: publicOrderStatus?.payment_method,
         })}
       </h3>
+      <p className="text-slate-500 text-sm mb-1">
+        {getPublicOrderCompletionSubtitle({
+          tableInfo,
+          paymentMethod: publicOrderStatus?.payment_method,
+        })}
+      </p>
       <p className="text-slate-500 text-sm mb-1">
         {getPublicOrderReferenceLabel({
           tableInfo,

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -363,6 +363,15 @@ export function getPublicOrderCompletionTitle(params: {
   return 'Pedido realizado!'
 }
 
+export function getPublicOrderCompletionSubtitle(params: {
+  tableInfo: { id: string; number: string } | null
+  paymentMethod?: PublicOrderStatus['payment_method'] | null
+}) {
+  if (params.tableInfo) return 'Acompanhe a comanda da sua mesa.'
+  if (params.paymentMethod === 'counter') return 'Use este número para retirar o pedido.'
+  return 'Acompanhe o andamento do pedido até a entrega.'
+}
+
 export function getContinueFlowTarget(
   paymentMethod: string,
   tableInfo: { id: string; number: string } | null

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -854,6 +854,7 @@ describe('menu components', () => {
     )
 
     expect(markup).toContain('Pedido realizado!')
+    expect(markup).toContain('Acompanhe o andamento do pedido até a entrega.')
     expect(markup).toContain('Número do pedido')
     expect(markup).toContain('#42')
     expect(markup).toContain('Acompanhe o status do pedido')
@@ -887,6 +888,7 @@ describe('menu components', () => {
 
     expect(markup).toContain('Pedido cancelado')
     expect(markup).toContain('Comanda aberta!')
+    expect(markup).toContain('Acompanhe a comanda da sua mesa.')
     expect(markup).toContain('Número da comanda')
     expect(markup).toContain('Estoque indisponível')
     expect(markup).toContain('Reembolso solicitado com sucesso')
@@ -922,6 +924,7 @@ describe('menu components', () => {
 
     expect(markup).toContain('Número para retirada')
     expect(markup).toContain('Pedido pronto para retirada!')
+    expect(markup).toContain('Use este número para retirar o pedido.')
     expect(markup).toContain('#321')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -42,6 +42,7 @@ import {
   getPhoneChangeState,
   getPublicOrderHeadline,
   getPublicOrderCompletionTitle,
+  getPublicOrderCompletionSubtitle,
   getPublicOrderReferenceLabel,
   getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardActionLabel,
@@ -624,6 +625,18 @@ describe('public menu helpers', () => {
       tableInfo: null,
       paymentMethod: 'delivery',
     })).toBe('Pedido realizado!')
+    expect(getPublicOrderCompletionSubtitle({
+      tableInfo: { id: 'table-1', number: '10' },
+      paymentMethod: 'table',
+    })).toBe('Acompanhe a comanda da sua mesa.')
+    expect(getPublicOrderCompletionSubtitle({
+      tableInfo: null,
+      paymentMethod: 'counter',
+    })).toBe('Use este número para retirar o pedido.')
+    expect(getPublicOrderCompletionSubtitle({
+      tableInfo: null,
+      paymentMethod: 'delivery',
+    })).toBe('Acompanhe o andamento do pedido até a entrega.')
     expect(getPublicOrderReferenceLabel({
       tableInfo: { id: 'table-1', number: '10' },
       paymentMethod: 'table',


### PR DESCRIPTION
## Resumo
Este PR melhora o passo final do pedido público com um subtítulo mais coerente com o tipo de atendimento.

## O que foi ajustado
- adiciona o helper `getPublicOrderCompletionSubtitle`
- atualiza o `MenuDoneStep` para variar o subtítulo conforme o contexto:
  - mesa
  - retirada/balcão
  - pedido comum/delivery
- adiciona cobertura unitária para o helper e para a renderização do passo final

## Impacto esperado
- o fechamento do fluxo fica mais claro e contextual
- mesa e retirada deixam de usar um subtítulo genérico de pedido
- a experiência final do cliente fica mais alinhada ao tipo de atendimento

## Validação
- `npm test`
- `npm run build`
