### PR TITLE
feat: add contextual close actions to public order completion step

### DIFF
--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button'
 import { ChefHat } from 'lucide-react'
 import {
   getCancelledOrderMessage,
+  getPublicOrderCompletionCloseLabel,
   getDeliveryStepMessage,
   getPaymentStatusLabel,
   getPublicOrderCompletionTitle,
@@ -156,7 +157,10 @@ export function MenuDoneStep({
         </div>
       )}
       <Button className="mt-8 w-full" onClick={onClose}>
-        Fechar
+        {getPublicOrderCompletionCloseLabel({
+          tableInfo,
+          paymentMethod: publicOrderStatus?.payment_method,
+        })}
       </Button>
     </div>
   )

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -372,6 +372,17 @@ export function getPublicOrderCompletionSubtitle(params: {
   return 'Acompanhe o andamento do pedido até a entrega.'
 }
 
+export function getPublicOrderCompletionCloseLabel(params: {
+  tableInfo: { id: string; number: string } | null
+  paymentMethod?: PublicOrderStatus['payment_method'] | null
+}) {
+  if (params.tableInfo || params.paymentMethod === 'counter') {
+    return 'Voltar ao cardápio'
+  }
+
+  return 'Acompanhar depois'
+}
+
 export function getContinueFlowTarget(
   paymentMethod: string,
   tableInfo: { id: string; number: string } | null

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -925,6 +925,7 @@ describe('menu components', () => {
     expect(markup).toContain('Número para retirada')
     expect(markup).toContain('Pedido pronto para retirada!')
     expect(markup).toContain('Use este número para retirar o pedido.')
+    expect(markup).toContain('Voltar ao cardápio')
     expect(markup).toContain('#321')
   })
 
@@ -975,7 +976,7 @@ describe('menu components', () => {
 
     expect(buttons).toHaveLength(2)
     expect(getTextContent(buttons[0])).toContain('Confirmar recebimento')
-    expect(getTextContent(buttons[1])).toContain('Fechar')
+    expect(getTextContent(buttons[1])).toContain('Acompanhar depois')
 
     buttons[0].props.onClick()
     buttons[1].props.onClick()
@@ -2260,7 +2261,9 @@ describe('menu components', () => {
       (element) => element.type === 'button' && getTextContent(element) === 'Voltar'
     )
     const doneCloseButton = doneElements.find(
-      (element) => element.type === 'button' && getTextContent(element) === 'Fechar'
+      (element) =>
+        element.type === 'button' &&
+        ['Fechar', 'Voltar ao cardápio', 'Acompanhar depois'].includes(getTextContent(element))
     )
     const doneDrawerCloseButton = doneElements.find(
       (element) => element.type === 'button' && getTextContent(element) === ''

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -43,6 +43,7 @@ import {
   getPublicOrderHeadline,
   getPublicOrderCompletionTitle,
   getPublicOrderCompletionSubtitle,
+  getPublicOrderCompletionCloseLabel,
   getPublicOrderReferenceLabel,
   getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardActionLabel,
@@ -637,6 +638,18 @@ describe('public menu helpers', () => {
       tableInfo: null,
       paymentMethod: 'delivery',
     })).toBe('Acompanhe o andamento do pedido até a entrega.')
+    expect(getPublicOrderCompletionCloseLabel({
+      tableInfo: { id: 'table-1', number: '10' },
+      paymentMethod: 'table',
+    })).toBe('Voltar ao cardápio')
+    expect(getPublicOrderCompletionCloseLabel({
+      tableInfo: null,
+      paymentMethod: 'counter',
+    })).toBe('Voltar ao cardápio')
+    expect(getPublicOrderCompletionCloseLabel({
+      tableInfo: null,
+      paymentMethod: 'delivery',
+    })).toBe('Acompanhar depois')
     expect(getPublicOrderReferenceLabel({
       tableInfo: { id: 'table-1', number: '10' },
       paymentMethod: 'table',


### PR DESCRIPTION
## Resumo
Este PR melhora o passo final do pedido público com um CTA final mais coerente com o tipo de atendimento.

## O que foi ajustado
- adiciona o helper `getPublicOrderCompletionCloseLabel`
- atualiza o `MenuDoneStep` para variar o texto do botão final conforme o contexto:
  - mesa
  - retirada/balcão
  - pedido comum/delivery
- ajusta a smoke do drawer para não depender de um único rótulo fixo
- adiciona cobertura unitária para o helper e para a renderização do passo final

## Impacto esperado
- o fechamento do fluxo fica mais natural para cada tipo de pedido
- mesa e retirada passam a sugerir retorno ao cardápio
- delivery mantém uma saída mais coerente com acompanhamento posterior

## Validação
- `npm test`
- `npm run build`
