### PR TITLE
feat: add contextual progress titles to public order completion flow

### DIFF
--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -7,6 +7,7 @@ import {
   getPaymentStatusLabel,
   getPublicOrderCompletionTitle,
   getPublicOrderCompletionSubtitle,
+  getPublicOrderProgressTitle,
   getPublicOrderReferenceLabel,
   isDeliveryStepCompleted,
   shouldShowPublicDeliveryConfirmButton,
@@ -79,7 +80,12 @@ export function MenuDoneStep({
         </div>
       ) : (
         <div className="mt-6 w-full rounded-xl border border-slate-200 bg-slate-50 p-4 text-left">
-          <p className="mb-4 text-sm font-medium text-slate-700">Acompanhe o status do pedido</p>
+          <p className="mb-4 text-sm font-medium text-slate-700">
+            {getPublicOrderProgressTitle({
+              tableInfo,
+              paymentMethod: publicOrderStatus?.payment_method,
+            })}
+          </p>
           <div className="space-y-3">
             {orderSteps.map((step) => {
               const state = getStepState(step.key)

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -383,6 +383,15 @@ export function getPublicOrderCompletionCloseLabel(params: {
   return 'Acompanhar depois'
 }
 
+export function getPublicOrderProgressTitle(params: {
+  tableInfo: { id: string; number: string } | null
+  paymentMethod?: PublicOrderStatus['payment_method'] | null
+}) {
+  if (params.tableInfo) return 'Acompanhe a comanda'
+  if (params.paymentMethod === 'counter') return 'Acompanhe a retirada'
+  return 'Acompanhe o status do pedido'
+}
+
 export function getContinueFlowTarget(
   paymentMethod: string,
   tableInfo: { id: string; number: string } | null

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -890,6 +890,7 @@ describe('menu components', () => {
     expect(markup).toContain('Comanda aberta!')
     expect(markup).toContain('Acompanhe a comanda da sua mesa.')
     expect(markup).toContain('Número da comanda')
+    expect(markup).toContain('Acompanhe a comanda')
     expect(markup).toContain('Estoque indisponível')
     expect(markup).toContain('Reembolso solicitado com sucesso')
     expect(markup).toContain('Mesa 8')
@@ -926,6 +927,7 @@ describe('menu components', () => {
     expect(markup).toContain('Pedido pronto para retirada!')
     expect(markup).toContain('Use este número para retirar o pedido.')
     expect(markup).toContain('Voltar ao cardápio')
+    expect(markup).toContain('Acompanhe a retirada')
     expect(markup).toContain('#321')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -44,6 +44,7 @@ import {
   getPublicOrderCompletionTitle,
   getPublicOrderCompletionSubtitle,
   getPublicOrderCompletionCloseLabel,
+  getPublicOrderProgressTitle,
   getPublicOrderReferenceLabel,
   getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardActionLabel,
@@ -650,6 +651,18 @@ describe('public menu helpers', () => {
       tableInfo: null,
       paymentMethod: 'delivery',
     })).toBe('Acompanhar depois')
+    expect(getPublicOrderProgressTitle({
+      tableInfo: { id: 'table-1', number: '10' },
+      paymentMethod: 'table',
+    })).toBe('Acompanhe a comanda')
+    expect(getPublicOrderProgressTitle({
+      tableInfo: null,
+      paymentMethod: 'counter',
+    })).toBe('Acompanhe a retirada')
+    expect(getPublicOrderProgressTitle({
+      tableInfo: null,
+      paymentMethod: 'delivery',
+    })).toBe('Acompanhe o status do pedido')
     expect(getPublicOrderReferenceLabel({
       tableInfo: { id: 'table-1', number: '10' },
       paymentMethod: 'table',


### PR DESCRIPTION
## Resumo
Este PR melhora o passo final do pedido público com um título mais coerente para o bloco de acompanhamento.

## O que foi ajustado
- adiciona o helper `getPublicOrderProgressTitle`
- atualiza o `MenuDoneStep` para variar o título do bloco de progresso conforme o contexto:
  - mesa
  - retirada/balcão
  - pedido comum/delivery
- adiciona cobertura unitária para o helper e para a renderização do passo final

## Impacto esperado
- o bloco de acompanhamento fica mais claro para cada tipo de atendimento
- mesa e retirada deixam de usar o mesmo texto genérico do pedido delivery
- melhora a leitura do passo final sem alterar o fluxo funcional

## Validação
- `npm test`
- `npm run build`
