### PR TITLE
feat: add contextual payment labels to public order completion step

### DIFF
--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -7,6 +7,7 @@ import {
   getPaymentStatusLabel,
   getPublicOrderCompletionTitle,
   getPublicOrderCompletionSubtitle,
+  getPublicOrderPaymentLabel,
   getPublicOrderProgressTitle,
   getPublicOrderReferenceLabel,
   isDeliveryStepCompleted,
@@ -134,7 +135,7 @@ export function MenuDoneStep({
           </div>
 
           <div className="mt-4 flex items-center justify-between rounded-lg bg-white px-3 py-2 text-xs text-slate-500">
-            <span>Pagamento</span>
+            <span>{getPublicOrderPaymentLabel(publicOrderStatus?.payment_method)}</span>
             <span className="font-medium text-slate-700">
               {getPaymentStatusLabel(publicOrderStatus?.payment_status, publicOrderStatus?.payment_method)}
             </span>

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -392,6 +392,14 @@ export function getPublicOrderProgressTitle(params: {
   return 'Acompanhe o status do pedido'
 }
 
+export function getPublicOrderPaymentLabel(paymentMethod?: PublicOrderStatus['payment_method'] | null) {
+  if (paymentMethod === 'table') return 'Pagamento no local'
+  if (paymentMethod === 'counter') return 'Pagamento na retirada'
+  if (paymentMethod === 'delivery') return 'Pagamento na entrega'
+  if (paymentMethod === 'online') return 'Pagamento online'
+  return 'Pagamento'
+}
+
 export function getContinueFlowTarget(
   paymentMethod: string,
   tableInfo: { id: string; number: string } | null

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -858,6 +858,7 @@ describe('menu components', () => {
     expect(markup).toContain('Número do pedido')
     expect(markup).toContain('#42')
     expect(markup).toContain('Acompanhe o status do pedido')
+    expect(markup).toContain('Pagamento na entrega')
     expect(markup).toContain('Cancelar pedido')
     expect(markup).toContain('Aprovado')
   })
@@ -928,6 +929,7 @@ describe('menu components', () => {
     expect(markup).toContain('Use este número para retirar o pedido.')
     expect(markup).toContain('Voltar ao cardápio')
     expect(markup).toContain('Acompanhe a retirada')
+    expect(markup).toContain('Pagamento na retirada')
     expect(markup).toContain('#321')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -45,6 +45,7 @@ import {
   getPublicOrderCompletionSubtitle,
   getPublicOrderCompletionCloseLabel,
   getPublicOrderProgressTitle,
+  getPublicOrderPaymentLabel,
   getPublicOrderReferenceLabel,
   getPublicOrderStatusCardMessage,
   getPublicOrderStatusCardActionLabel,
@@ -663,6 +664,10 @@ describe('public menu helpers', () => {
       tableInfo: null,
       paymentMethod: 'delivery',
     })).toBe('Acompanhe o status do pedido')
+    expect(getPublicOrderPaymentLabel('table')).toBe('Pagamento no local')
+    expect(getPublicOrderPaymentLabel('counter')).toBe('Pagamento na retirada')
+    expect(getPublicOrderPaymentLabel('delivery')).toBe('Pagamento na entrega')
+    expect(getPublicOrderPaymentLabel('online')).toBe('Pagamento online')
     expect(getPublicOrderReferenceLabel({
       tableInfo: { id: 'table-1', number: '10' },
       paymentMethod: 'table',


### PR DESCRIPTION
## Resumo
Este PR melhora o passo final do pedido público com um rótulo de pagamento mais coerente com o método escolhido.

## O que foi ajustado
- adiciona o helper `getPublicOrderPaymentLabel`
- atualiza o `MenuDoneStep` para variar o rótulo do bloco de pagamento conforme o contexto:
  - mesa
  - retirada/balcão
  - delivery
  - online
- ajusta a smoke do cenário cancelado para não esperar o bloco de pagamento quando ele não é renderizado
- adiciona cobertura unitária para o helper e para a renderização do passo final

## Impacto esperado
- o bloco de pagamento fica mais claro para o cliente final
- métodos presenciais e delivery deixam de compartilhar o mesmo rótulo genérico
- melhora a leitura do passo final sem alterar a lógica do pagamento

## Validação
- `npm test`
- `npm run build`
