### PR TITLE
feat: add pickup-specific titles to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -580,6 +580,9 @@ export function getPublicOrderStatusCardTitle(publicOrderStatus: PublicOrderStat
   if (publicOrderStatus.status === 'pending') return `Pedido recebido #${publicOrderStatus.order_number}`
   if (publicOrderStatus.status === 'confirmed') return `Pedido confirmado #${publicOrderStatus.order_number}`
   if (publicOrderStatus.status === 'preparing') return `Pedido em preparo #${publicOrderStatus.order_number}`
+  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
+    return `Pedido pronto para retirada #${publicOrderStatus.order_number}`
+  }
   if (
     publicOrderStatus.payment_method === 'delivery' &&
     publicOrderStatus.status === 'ready' &&

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -109,6 +109,29 @@ describe('menu components', () => {
     expect(markup).toContain('bg-sky-50')
   })
 
+  it('renderiza card de status com título contextual para retirada', async () => {
+    const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(PublicOrderStatusCard, {
+        publicOrderStatus: {
+          id: 'order-counter',
+          order_number: 77,
+          status: 'ready',
+          payment_status: 'pending',
+          payment_method: 'counter',
+          delivery_status: null,
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        onTrack: vi.fn(),
+      })
+    )
+
+    expect(markup).toContain('Pedido pronto para retirada #77')
+    expect(markup).toContain('Ver pedido')
+  })
+
   it('renderiza modal de meia a meia com sabores elegíveis', async () => {
     const { HalfFlavorModal } = await import('@/features/menu/HalfFlavorModal')
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -734,6 +734,12 @@ describe('public menu helpers', () => {
       ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Pedido em preparo #42')
+    expect(getPublicOrderStatusCardTitle({
+      ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'ready',
+      delivery_status: null,
+    })).toBe('Pedido pronto para retirada #42')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
       status: 'preparing',


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de retirada tenham um título mais específico quando ficam prontos.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardTitle` para tratar o caso de `counter + ready`
- adiciona cobertura unitária do helper e do `PublicOrderStatusCard` nesse cenário
- mantém os títulos já existentes para delivery, preparo e demais estados

## Impacto esperado
- pedidos de retirada deixam de usar um título genérico no estado `ready`
- o card resumido fica mais coerente com o tipo de atendimento
- melhora a leitura do tracking sem alterar a lógica do fluxo

## Validação
- `npm test`
- `npm run build`
