### PR TITLE
feat: add pickup-specific messages to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -615,6 +615,10 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
     return 'Acompanhe o deslocamento da entrega.'
   }
 
+  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
+    return 'Seu pedido está aguardando retirada.'
+  }
+
   if (publicOrderStatus.status === 'ready') {
     return 'Seu pedido está pronto para a próxima etapa.'
   }

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -129,6 +129,7 @@ describe('menu components', () => {
     )
 
     expect(markup).toContain('Pedido pronto para retirada #77')
+    expect(markup).toContain('Seu pedido está aguardando retirada.')
     expect(markup).toContain('Ver pedido')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -742,6 +742,12 @@ describe('public menu helpers', () => {
     })).toBe('Pedido pronto para retirada #42')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'ready',
+      delivery_status: null,
+    })).toBe('Seu pedido está aguardando retirada.')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Seu pedido está sendo preparado.')
     expect(getPublicOrderStatusCardTitle({


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de retirada tenham uma mensagem mais específica quando ficam prontos.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardMessage` para tratar o caso de `counter + ready`
- adiciona cobertura unitária do helper e do `PublicOrderStatusCard` nesse cenário
- mantém as mensagens já existentes para delivery, preparo e demais estados

## Impacto esperado
- pedidos de retirada deixam de usar uma mensagem genérica no estado `ready`
- o card resumido fica mais coerente com o tipo de atendimento
- melhora a leitura do tracking sem alterar a lógica do fluxo

## Validação
- `npm test`
- `npm run build`
