### PR TITLE
feat: add pickup-specific notice to public order tracking

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -677,6 +677,10 @@ export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus 
       return 'Seu pedido saiu para entrega.'
     }
 
+    if (publicOrderStatus.payment_method === 'counter') {
+      return 'Seu pedido está pronto para retirada.'
+    }
+
     return 'Seu pedido está pronto.'
   }
   if (publicOrderStatus.status === 'delivered') return 'Pedido entregue com sucesso.'

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -806,6 +806,12 @@ describe('public menu helpers', () => {
     })).toBe('Seu pedido está pronto.')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'ready',
+      delivery_status: null,
+    })).toBe('Seu pedido está pronto para retirada.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
       status: 'delivered',
       delivery_status: 'delivered',
     })).toBe('Pedido entregue com sucesso.')


### PR DESCRIPTION
## Resumo
Este PR melhora o aviso principal do tracking público para que pedidos de retirada tenham uma mensagem mais específica quando ficam prontos.

## O que foi ajustado
- atualiza `getPublicOrderStatusNotice` para tratar o caso de `counter + ready`
- adiciona cobertura unitária desse cenário
- mantém os avisos já existentes para delivery, entrega e demais estados

## Impacto esperado
- pedidos de retirada deixam de usar um aviso genérico no estado `ready`
- o banner principal e o card resumido passam a falar a mesma linguagem
- melhora a clareza do tracking sem alterar a lógica do fluxo

## Validação
- `npm test`
- `npm run build`
