### PR TITLE
feat: add pickup-specific tracking message to public order flow

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -572,6 +572,9 @@ export function getPublicOrderTrackingMessage(
   ) {
     return 'Seu pedido saiu para entrega.'
   }
+  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
+    return 'Seu pedido está pronto para retirada.'
+  }
   if (publicOrderStatus.status === 'ready') return 'Seu pedido está pronto.'
   return `Seu pedido está em ${headline}.`
 }

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -722,6 +722,12 @@ describe('public menu helpers', () => {
       status: 'cancelled',
       payment_status: 'refunded',
     }, 'cancelado')).toBe('Seu pedido foi cancelado e o reembolso foi solicitado.')
+    expect(getPublicOrderTrackingMessage({
+      ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'ready',
+      delivery_status: null,
+    }, 'pronto')).toBe('Seu pedido está pronto para retirada.')
     expect(getPublicOrderStatusCardTitle({
       ...publicOrderStatus,
       status: 'pending',


### PR DESCRIPTION
## Resumo
Este PR melhora a mensagem detalhada do tracking público para que pedidos de retirada tenham uma comunicação mais específica quando ficam prontos.

## O que foi ajustado
- atualiza `getPublicOrderTrackingMessage` para tratar o caso de `counter + ready`
- adiciona cobertura unitária desse cenário
- mantém as mensagens já existentes para delivery, entrega e demais estados

## Impacto esperado
- pedidos de retirada deixam de usar uma mensagem genérica no estado `ready`
- o banner, o card resumido e a mensagem detalhada passam a ficar alinhados
- melhora a clareza do tracking sem alterar a lógica do fluxo

## Validação
- `npm test`
- `npm run build`
