### PR TITLE
feat: add pickup-specific headline to public order tracking

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -521,6 +521,10 @@ export function getPublicOrderHeadline(
 ) {
   if (!publicOrderStatus) return null
 
+  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
+    return 'pronto para retirada'
+  }
+
   return orderSteps.find((step) => step.key === publicOrderStatus.status)?.label.toLowerCase() ?? 'andamento'
 }
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -682,6 +682,12 @@ describe('public menu helpers', () => {
     })).toBe('Número do pedido')
 
     expect(getPublicOrderHeadline(publicOrderStatus, orderSteps)).toBe('pronto')
+    expect(getPublicOrderHeadline({
+      ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'ready',
+      delivery_status: null,
+    }, getOrderSteps(null, 'counter'))).toBe('pronto para retirada')
     expect(getCancelledOrderMessage(publicOrderStatus)).toBe('Cliente desistiu')
     expect(getCancelledOrderMessage(null)).toBe('O pedido foi cancelado.')
     expect(getCancelSuccessNotice('refunded')).toContain('reembolso')


### PR DESCRIPTION
## Resumo
Este PR melhora o headline interno do tracking público para que pedidos de retirada também tenham linguagem contextual no estado `ready`.

## O que foi ajustado
- atualiza `getPublicOrderHeadline` para tratar o caso de `counter + ready`
- adiciona cobertura unitária desse cenário
- mantém o comportamento atual para delivery e demais fluxos

## Impacto esperado
- o fallback de textos do tracking fica coerente com pedidos de retirada
- completa o alinhamento entre headline, banner, card resumido e mensagem detalhada
- melhora a consistência sem alterar a lógica do fluxo

## Validação
- `npm test`
- `npm run build`
