### PR TITLE
feat: add dine-in ready messages to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -625,6 +625,10 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
     return 'Acompanhe o deslocamento da entrega.'
   }
 
+  if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
+    return 'Seu pedido está pronto para servir.'
+  }
+
   if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
     return 'Seu pedido está aguardando retirada.'
   }

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -695,6 +695,10 @@ export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus 
       return 'Seu pedido está pronto para retirada.'
     }
 
+    if (publicOrderStatus.payment_method === 'table') {
+      return 'Seu pedido está pronto para servir.'
+    }
+
     return 'Seu pedido está pronto.'
   }
   if (publicOrderStatus.status === 'delivered') return 'Pedido entregue com sucesso.'

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -153,6 +153,7 @@ describe('menu components', () => {
     )
 
     expect(markup).toContain('Pedido pronto para servir #88')
+    expect(markup).toContain('Seu pedido está pronto para servir.')
     expect(markup).toContain('Ver pedido')
   })
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -836,6 +836,12 @@ describe('public menu helpers', () => {
     })).toBe('Seu pedido está pronto para retirada.')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'ready',
+      delivery_status: null,
+    })).toBe('Seu pedido está pronto para servir.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
       status: 'delivered',
       delivery_status: 'delivered',
     })).toBe('Pedido entregue com sucesso.')

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -766,6 +766,12 @@ describe('public menu helpers', () => {
     })).toBe('Seu pedido está aguardando retirada.')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'ready',
+      delivery_status: null,
+    })).toBe('Seu pedido está pronto para servir.')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Seu pedido está sendo preparado.')
     expect(getPublicOrderStatusCardTitle({


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de mesa tenham uma mensagem mais específica quando ficam prontos.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardMessage` para tratar o caso de `table + ready`
- adiciona cobertura unitária do helper e do `PublicOrderStatusCard` nesse cenário
- mantém as mensagens já existentes para retirada, delivery e demais estados

## Impacto esperado
- pedidos de mesa deixam de usar uma mensagem genérica no estado `ready`
- o card resumido fica mais coerente com o tipo de atendimento
- melhora a leitura do tracking sem alterar a lógica do fluxo

## Validação
- `npm test`
- `npm run build`
