### PR TITLE
feat: add dine-in ready tracking message to public order flow

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -579,6 +579,9 @@ export function getPublicOrderTrackingMessage(
   if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
     return 'Seu pedido está pronto para retirada.'
   }
+  if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
+    return 'Seu pedido está pronto para servir.'
+  }
   if (publicOrderStatus.status === 'ready') return 'Seu pedido está pronto.'
   return `Seu pedido está em ${headline}.`
 }

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -734,6 +734,12 @@ describe('public menu helpers', () => {
       status: 'ready',
       delivery_status: null,
     }, 'pronto')).toBe('Seu pedido está pronto para retirada.')
+    expect(getPublicOrderTrackingMessage({
+      ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'ready',
+      delivery_status: null,
+    }, 'pronto')).toBe('Seu pedido está pronto para servir.')
     expect(getPublicOrderStatusCardTitle({
       ...publicOrderStatus,
       status: 'pending',


### PR DESCRIPTION
## Resumo
Este PR melhora a mensagem detalhada do tracking público para que pedidos de mesa tenham uma comunicação mais específica quando ficam prontos.

## O que foi ajustado
- atualiza `getPublicOrderTrackingMessage` para tratar o caso de `table + ready`
- adiciona cobertura unitária desse cenário
- mantém as mensagens já existentes para retirada, delivery e demais estados

## Impacto esperado
- pedidos de mesa deixam de usar uma mensagem genérica no estado `ready`
- o banner, o card resumido e a mensagem detalhada passam a ficar alinhados
- melhora a clareza do tracking sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
