### PR TITLE
feat: add dine-in ready headline to public order tracking

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -525,6 +525,10 @@ export function getPublicOrderHeadline(
     return 'pronto para retirada'
   }
 
+  if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
+    return 'pronto para servir'
+  }
+
   return orderSteps.find((step) => step.key === publicOrderStatus.status)?.label.toLowerCase() ?? 'andamento'
 }
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -688,6 +688,12 @@ describe('public menu helpers', () => {
       status: 'ready',
       delivery_status: null,
     }, getOrderSteps(null, 'counter'))).toBe('pronto para retirada')
+    expect(getPublicOrderHeadline({
+      ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'ready',
+      delivery_status: null,
+    }, getOrderSteps({ id: 'table-1', number: '10' }, 'table'))).toBe('pronto para servir')
     expect(getCancelledOrderMessage(publicOrderStatus)).toBe('Cliente desistiu')
     expect(getCancelledOrderMessage(null)).toBe('O pedido foi cancelado.')
     expect(getCancelSuccessNotice('refunded')).toContain('reembolso')


### PR DESCRIPTION
## Resumo
Este PR melhora o headline interno do tracking público para que pedidos de mesa também tenham linguagem contextual no estado `ready`.

## O que foi ajustado
- atualiza `getPublicOrderHeadline` para tratar o caso de `table + ready`
- adiciona cobertura unitária desse cenário
- mantém o comportamento atual para retirada, delivery e demais fluxos

## Impacto esperado
- o fallback de textos do tracking fica coerente com pedidos de mesa
- completa o alinhamento entre headline, banner, card resumido e mensagem detalhada
- melhora a consistência sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
