### PR TITLE
feat: add dine-in delivered notice to public order tracking

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -708,7 +708,13 @@ export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus 
 
     return 'Seu pedido está pronto.'
   }
-  if (publicOrderStatus.status === 'delivered') return 'Pedido entregue com sucesso.'
+  if (publicOrderStatus.status === 'delivered') {
+    if (publicOrderStatus.payment_method === 'table') {
+      return 'Pedido servido na mesa com sucesso.'
+    }
+
+    return 'Pedido entregue com sucesso.'
+  }
 
   return null
 }

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -854,6 +854,12 @@ describe('public menu helpers', () => {
     })).toBe('Seu pedido está pronto para servir.')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'delivered',
+      delivery_status: null,
+    })).toBe('Pedido servido na mesa com sucesso.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
       status: 'delivered',
       delivery_status: 'delivered',
     })).toBe('Pedido entregue com sucesso.')


### PR DESCRIPTION
## Resumo
Este PR melhora o aviso principal do tracking público para que pedidos de mesa também tenham uma mensagem contextual no estado final `delivered`.

## O que foi ajustado
- atualiza `getPublicOrderStatusNotice` para tratar o caso de `table + delivered`
- adiciona cobertura unitária desse cenário
- mantém o comportamento atual para delivery, retirada e demais fluxos

## Impacto esperado
- pedidos de mesa deixam de usar o texto genérico de entrega no estado final
- o banner principal fica mais coerente com a operação presencial
- melhora a clareza do tracking sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
