### PR TITLE
feat: add dine-in delivered tracking message to public order flow

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -567,7 +567,13 @@ export function getPublicOrderTrackingMessage(
   if (publicOrderStatus.status === 'pending') return 'Seu pedido foi recebido.'
   if (publicOrderStatus.status === 'confirmed') return 'Seu pedido foi confirmado.'
   if (publicOrderStatus.status === 'preparing') return 'Seu pedido está em preparo.'
-  if (publicOrderStatus.status === 'delivered') return 'Seu pedido foi entregue.'
+  if (publicOrderStatus.status === 'delivered') {
+    if (publicOrderStatus.payment_method === 'table') {
+      return 'Seu pedido foi servido na mesa.'
+    }
+
+    return 'Seu pedido foi entregue.'
+  }
   if (publicOrderStatus.status === 'cancelled') {
     return publicOrderStatus.payment_status === 'refunded'
       ? 'Seu pedido foi cancelado e o reembolso foi solicitado.'

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -726,6 +726,12 @@ describe('public menu helpers', () => {
     }, 'entregue')).toBe('Seu pedido foi entregue.')
     expect(getPublicOrderTrackingMessage({
       ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'delivered',
+      delivery_status: null,
+    }, 'entregue')).toBe('Seu pedido foi servido na mesa.')
+    expect(getPublicOrderTrackingMessage({
+      ...publicOrderStatus,
       status: 'cancelled',
       payment_status: 'pending',
     }, 'cancelado')).toBe('Seu pedido foi cancelado.')


### PR DESCRIPTION
## Resumo
Este PR melhora a mensagem detalhada do tracking público para que pedidos de mesa também tenham linguagem contextual no estado final `delivered`.

## O que foi ajustado
- atualiza `getPublicOrderTrackingMessage` para tratar o caso de `table + delivered`
- adiciona cobertura unitária desse cenário
- mantém o comportamento atual para delivery, retirada e demais fluxos

## Impacto esperado
- pedidos de mesa deixam de usar o texto genérico de entrega na mensagem detalhada
- o tracking público fica mais coerente com a operação presencial
- melhora a clareza sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
