### PR TITLE
feat: add dine-in delivered messages to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -657,6 +657,10 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
     return 'Seu pedido está pronto para a próxima etapa.'
   }
 
+  if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'delivered') {
+    return 'Seu pedido foi servido na mesa.'
+  }
+
   return 'Acompanhe o andamento do seu pedido.'
 }
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -802,6 +802,12 @@ describe('public menu helpers', () => {
     })).toBe('Seu pedido está pronto para servir.')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'delivered',
+      delivery_status: null,
+    })).toBe('Seu pedido foi servido na mesa.')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Seu pedido está sendo preparado.')
     expect(getPublicOrderStatusCardTitle({


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de mesa tenham uma mensagem específica também no estado final `delivered`.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardMessage` para tratar o caso de `table + delivered`
- adiciona cobertura unitária desse cenário
- mantém as mensagens já existentes para ready de mesa, retirada, delivery e demais estados

## Impacto esperado
- pedidos de mesa deixam de cair no texto genérico no estado final
- o card resumido fica coerente do início ao fim da jornada presencial
- melhora a leitura do tracking sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`

## Observação
- `npm run build` segue bloqueado nesta cópia por env ausente do Supabase (`supabaseUrl is required`)
