### PR TITLE
feat: add dine-in delivered labels to public order timeline

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -320,6 +320,7 @@ export function getOrderSteps(
     : paymentMethod === 'delivery'
       ? 'Pedido entregue com sucesso.'
       : 'Pedido retirado com sucesso.'
+  const deliveredLabel = tableInfo ? 'Servido' : 'Entregue'
 
   return [
     { key: 'pending', label: 'Recebido', description: 'Seu pedido entrou na fila do estabelecimento.' },
@@ -330,7 +331,7 @@ export function getOrderSteps(
       label: 'Pronto',
       description: readyDescription,
     },
-    { key: 'delivered', label: 'Entregue', description: deliveredDescription },
+    { key: 'delivered', label: deliveredLabel, description: deliveredDescription },
   ] as const satisfies Array<{
     key: PublicOrderStatus['status']
     label: string

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -570,7 +570,7 @@ describe('public menu helpers', () => {
     })
     expect(getOrderSteps({ id: 'table-1', number: '10' }, 'table')[4]).toEqual({
       key: 'delivered',
-      label: 'Entregue',
+      label: 'Servido',
       description: 'Pedido servido na mesa com sucesso.',
     })
 


### PR DESCRIPTION
## Resumo
Este PR melhora a timeline pública para que pedidos de mesa usem um rótulo mais contextual na etapa final.

## O que foi ajustado
- atualiza `getOrderSteps` para usar `Servido` em `table + delivered`
- mantém `Entregue` para retirada e delivery
- adiciona cobertura unitária desse cenário

## Impacto esperado
- a timeline pública fica mais natural para pedidos presenciais
- a etapa final deixa de usar um rótulo genérico para mesa
- melhora a coerência da jornada sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`

## Observação
- `npm run build` segue bloqueado nesta cópia por env ausente do Supabase (`supabaseUrl is required`)
