### PR TITLE
feat: add pickup ready labels to public order timeline

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -320,7 +320,7 @@ export function getOrderSteps(
     : paymentMethod === 'delivery'
       ? 'Pedido entregue com sucesso.'
       : 'Pedido retirado com sucesso.'
-  const readyLabel = tableInfo ? 'Servir' : 'Pronto'
+  const readyLabel = tableInfo ? 'Servir' : paymentMethod === 'counter' ? 'Retirar' : 'Pronto'
   const deliveredLabel = tableInfo ? 'Servido' : paymentMethod === 'counter' ? 'Retirado' : 'Entregue'
 
   return [

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -576,7 +576,7 @@ describe('public menu helpers', () => {
 
     expect(getOrderSteps(null, 'counter')[3]).toEqual({
       key: 'ready',
-      label: 'Pronto',
+      label: 'Retirar',
       description: 'Seu pedido está pronto para retirada.',
     })
     expect(getOrderSteps(null, 'counter')[4]).toEqual({


### PR DESCRIPTION
## Resumo
Este PR melhora a timeline pública para que pedidos de retirada usem um rótulo mais contextual também na etapa `ready`.

## O que foi ajustado
- atualiza `getOrderSteps` para usar `Retirar` em `counter + ready`
- mantém `Retirado` para a etapa final de retirada
- preserva os rótulos contextuais já existentes para mesa e delivery
- adiciona cobertura unitária desse cenário

## Impacto esperado
- a timeline pública fica mais natural para pedidos de retirada
- a etapa anterior à retirada deixa de usar um rótulo genérico
- melhora a coerência da jornada sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
