### PR TITLE
feat: add pickup delivered notice to public order tracking

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -732,6 +732,10 @@ export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus 
       return 'Pedido servido na mesa com sucesso.'
     }
 
+    if (publicOrderStatus.payment_method === 'counter') {
+      return 'Pedido retirado com sucesso.'
+    }
+
     return 'Pedido entregue com sucesso.'
   }
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -884,6 +884,12 @@ describe('public menu helpers', () => {
     })).toBe('Pedido servido na mesa com sucesso.')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'delivered',
+      delivery_status: null,
+    })).toBe('Pedido retirado com sucesso.')
+    expect(getPublicOrderStatusNotice({
+      ...publicOrderStatus,
       status: 'delivered',
       delivery_status: 'delivered',
     })).toBe('Pedido entregue com sucesso.')


### PR DESCRIPTION
## Resumo
Este PR melhora o aviso principal do tracking público para que pedidos de retirada tenham uma mensagem mais específica no estado final `delivered`.

## O que foi ajustado
- atualiza `getPublicOrderStatusNotice` para tratar o caso de `counter + delivered`
- mantém os avisos contextuais já existentes para mesa e delivery
- adiciona cobertura unitária desse cenário

## Impacto esperado
- pedidos de retirada deixam de usar o texto genérico de entrega no estado final
- o banner principal fica coerente com a operação de retirada
- melhora a clareza do tracking sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
