### PR TITLE
feat: add pickup delivered tracking message to public order flow

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -578,6 +578,10 @@ export function getPublicOrderTrackingMessage(
       return 'Seu pedido foi servido na mesa.'
     }
 
+    if (publicOrderStatus.payment_method === 'counter') {
+      return 'Seu pedido foi retirado.'
+    }
+
     return 'Seu pedido foi entregue.'
   }
   if (publicOrderStatus.status === 'cancelled') {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -738,6 +738,12 @@ describe('public menu helpers', () => {
     }, 'entregue')).toBe('Seu pedido foi servido na mesa.')
     expect(getPublicOrderTrackingMessage({
       ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'delivered',
+      delivery_status: null,
+    }, 'entregue')).toBe('Seu pedido foi retirado.')
+    expect(getPublicOrderTrackingMessage({
+      ...publicOrderStatus,
       status: 'cancelled',
       payment_status: 'pending',
     }, 'cancelado')).toBe('Seu pedido foi cancelado.')


### PR DESCRIPTION
## Resumo
Este PR melhora a mensagem detalhada do tracking público para que pedidos de retirada tenham uma comunicação mais específica no estado final `delivered`.

## O que foi ajustado
- atualiza `getPublicOrderTrackingMessage` para tratar o caso de `counter + delivered`
- mantém as mensagens contextuais já existentes para mesa e delivery
- adiciona cobertura unitária desse cenário

## Impacto esperado
- pedidos de retirada deixam de usar o texto genérico de entrega na mensagem detalhada
- o tracking público fica mais coerente com a operação de retirada
- melhora a clareza sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
