### PR TITLE
feat: add pickup delivered headline to public order tracking

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -527,6 +527,10 @@ export function getPublicOrderHeadline(
     return 'pronto para retirada'
   }
 
+  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'delivered') {
+    return 'retirado'
+  }
+
   if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
     return 'pronto para servir'
   }

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -700,6 +700,12 @@ describe('public menu helpers', () => {
       status: 'delivered',
       delivery_status: null,
     }, getOrderSteps({ id: 'table-1', number: '10' }, 'table'))).toBe('servido na mesa')
+    expect(getPublicOrderHeadline({
+      ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'delivered',
+      delivery_status: null,
+    }, getOrderSteps(null, 'counter'))).toBe('retirado')
     expect(getCancelledOrderMessage(publicOrderStatus)).toBe('Cliente desistiu')
     expect(getCancelledOrderMessage(null)).toBe('O pedido foi cancelado.')
     expect(getCancelSuccessNotice('refunded')).toContain('reembolso')


### PR DESCRIPTION
## Resumo
Este PR melhora o headline interno do tracking público para que pedidos de retirada também tenham linguagem contextual no estado final `delivered`.

## O que foi ajustado
- atualiza `getPublicOrderHeadline` para tratar o caso de `counter + delivered`
- mantém os headlines contextuais já existentes para retirada em `ready` e para mesa
- adiciona cobertura unitária desse cenário

## Impacto esperado
- o fallback de textos do tracking fica coerente também no fechamento do pedido de retirada
- completa o alinhamento entre headline, banner e mensagem detalhada para esse fluxo
- melhora a consistência sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
