### PR TITLE
feat: add pickup delivered states to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -623,6 +623,9 @@ export function getPublicOrderStatusCardTitle(publicOrderStatus: PublicOrderStat
   if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
     return `Pedido pronto para retirada #${publicOrderStatus.order_number}`
   }
+  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'delivered') {
+    return `Pedido retirado #${publicOrderStatus.order_number}`
+  }
   if (
     publicOrderStatus.payment_method === 'delivery' &&
     publicOrderStatus.status === 'ready' &&
@@ -661,6 +664,10 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
 
   if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
     return 'Seu pedido está aguardando retirada.'
+  }
+
+  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'delivered') {
+    return 'Seu pedido foi retirado.'
   }
 
   if (publicOrderStatus.status === 'ready') {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -800,6 +800,12 @@ describe('public menu helpers', () => {
       status: 'delivered',
       delivery_status: null,
     })).toBe('Pedido servido na mesa #42')
+    expect(getPublicOrderStatusCardTitle({
+      ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'delivered',
+      delivery_status: null,
+    })).toBe('Pedido retirado #42')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
       payment_method: 'counter',
@@ -812,6 +818,12 @@ describe('public menu helpers', () => {
       status: 'ready',
       delivery_status: null,
     })).toBe('Seu pedido está pronto para servir.')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'delivered',
+      delivery_status: null,
+    })).toBe('Seu pedido foi retirado.')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
       payment_method: 'table',


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de retirada tenham título e mensagem específicos também no estado final `delivered`.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardTitle` para tratar `counter + delivered`
- atualiza `getPublicOrderStatusCardMessage` para tratar `counter + delivered`
- mantém os estados contextuais já existentes para mesa e delivery
- adiciona cobertura unitária desses cenários

## Impacto esperado
- pedidos de retirada deixam de cair em textos genéricos no card resumido
- o resumo do tracking fica coerente do início ao fim desse fluxo
- melhora a leitura sem alterar a lógica do pedido

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
