### PR TITLE
feat: add delivery delivered states to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -634,6 +634,9 @@ export function getPublicOrderStatusCardTitle(publicOrderStatus: PublicOrderStat
     return `Pedido saiu para entrega #${publicOrderStatus.order_number}`
   }
   if (publicOrderStatus.status === 'ready') return `Pedido pronto #${publicOrderStatus.order_number}`
+  if (publicOrderStatus.payment_method === 'delivery' && publicOrderStatus.status === 'delivered') {
+    return `Pedido entregue #${publicOrderStatus.order_number}`
+  }
   return `Pedido #${publicOrderStatus.order_number}`
 }
 
@@ -668,6 +671,10 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
 
   if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'delivered') {
     return 'Seu pedido foi retirado.'
+  }
+
+  if (publicOrderStatus.payment_method === 'delivery' && publicOrderStatus.status === 'delivered') {
+    return 'Seu pedido foi entregue.'
   }
 
   if (publicOrderStatus.status === 'ready') {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -806,6 +806,12 @@ describe('public menu helpers', () => {
       status: 'delivered',
       delivery_status: null,
     })).toBe('Pedido retirado #42')
+    expect(getPublicOrderStatusCardTitle({
+      ...publicOrderStatus,
+      payment_method: 'delivery',
+      status: 'delivered',
+      delivery_status: 'delivered',
+    })).toBe('Pedido entregue #42')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
       payment_method: 'counter',
@@ -830,6 +836,12 @@ describe('public menu helpers', () => {
       status: 'delivered',
       delivery_status: null,
     })).toBe('Seu pedido foi servido na mesa.')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
+      payment_method: 'delivery',
+      status: 'delivered',
+      delivery_status: 'delivered',
+    })).toBe('Seu pedido foi entregue.')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
       status: 'preparing',


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de delivery tenham título e mensagem específicos também no estado final `delivered`.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardTitle` para tratar `delivery + delivered`
- atualiza `getPublicOrderStatusCardMessage` para tratar `delivery + delivered`
- mantém os estados contextuais já existentes para retirada e mesa
- adiciona cobertura unitária desses cenários

## Impacto esperado
- pedidos de delivery deixam de cair em textos genéricos no card resumido ao final do fluxo
- o resumo do tracking fica coerente do início ao fim
- melhora a leitura sem alterar a lógica do pedido

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
