### PR TITLE
feat: add delivery ready labels to public order timeline

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -320,7 +320,7 @@ export function getOrderSteps(
     : paymentMethod === 'delivery'
       ? 'Pedido entregue com sucesso.'
       : 'Pedido retirado com sucesso.'
-  const readyLabel = tableInfo ? 'Servir' : paymentMethod === 'counter' ? 'Retirar' : 'Pronto'
+  const readyLabel = tableInfo ? 'Servir' : paymentMethod === 'counter' ? 'Retirar' : paymentMethod === 'delivery' ? 'Despachar' : 'Pronto'
   const deliveredLabel = tableInfo ? 'Servido' : paymentMethod === 'counter' ? 'Retirado' : 'Entregue'
 
   return [

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -587,7 +587,7 @@ describe('public menu helpers', () => {
 
     expect(getOrderSteps(null, 'delivery')[3]).toEqual({
       key: 'ready',
-      label: 'Pronto',
+      label: 'Despachar',
       description: 'Seu pedido está pronto para sair para entrega.',
     })
     expect(getOrderSteps(null, 'delivery')[4]).toEqual({
@@ -681,7 +681,7 @@ describe('public menu helpers', () => {
       paymentMethod: 'delivery',
     })).toBe('Número do pedido')
 
-    expect(getPublicOrderHeadline(publicOrderStatus, orderSteps)).toBe('pronto')
+    expect(getPublicOrderHeadline(publicOrderStatus, orderSteps)).toBe('despachar')
     expect(getPublicOrderHeadline({
       ...publicOrderStatus,
       payment_method: 'counter',


### PR DESCRIPTION
## Resumo
Este PR melhora a timeline pública para que pedidos de delivery usem um rótulo mais contextual na etapa `ready`.

## O que foi ajustado
- atualiza `getOrderSteps` para usar `Despachar` em `delivery + ready`
- mantém `Retirar` para retirada e `Servir` para mesa
- alinha a expectativa do `headline` derivado desse label
- adiciona cobertura unitária do cenário

## Impacto esperado
- a timeline pública fica mais clara no momento em que o pedido está pronto para sair
- a etapa `ready` deixa de usar um rótulo genérico em delivery
- melhora a coerência da jornada sem alterar a lógica do fluxo

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
