### PR TITLE
feat: add pre-dispatch delivery states to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -531,6 +531,10 @@ export function getPublicOrderHeadline(
     return 'retirado'
   }
 
+  if (publicOrderStatus.payment_method === 'delivery' && publicOrderStatus.status === 'ready') {
+    return 'despachar'
+  }
+
   if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
     return 'pronto para servir'
   }
@@ -606,38 +610,41 @@ export function getPublicOrderTrackingMessage(
   if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
     return 'Seu pedido está pronto para servir.'
   }
-  if (publicOrderStatus.status === 'ready') return 'Seu pedido está pronto.'
-  return `Seu pedido está em ${headline}.`
+  if (publicOrderStatus.status === 'ready') return 'Seu pedido está ' + headline + '.'
+  return 'Acompanhe o andamento do seu pedido.'
 }
 
 export function getPublicOrderStatusCardTitle(publicOrderStatus: PublicOrderStatus) {
-  if (publicOrderStatus.status === 'pending') return `Pedido recebido #${publicOrderStatus.order_number}`
-  if (publicOrderStatus.status === 'confirmed') return `Pedido confirmado #${publicOrderStatus.order_number}`
-  if (publicOrderStatus.status === 'preparing') return `Pedido em preparo #${publicOrderStatus.order_number}`
+  if (publicOrderStatus.status === 'pending') return 'Pedido recebido #' + publicOrderStatus.order_number
+  if (publicOrderStatus.status === 'confirmed') return 'Pedido confirmado #' + publicOrderStatus.order_number
+  if (publicOrderStatus.status === 'preparing') return 'Pedido em preparo #' + publicOrderStatus.order_number
   if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
-    return `Pedido pronto para servir #${publicOrderStatus.order_number}`
+    return 'Pedido pronto para servir #' + publicOrderStatus.order_number
   }
   if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'delivered') {
-    return `Pedido servido na mesa #${publicOrderStatus.order_number}`
+    return 'Pedido servido na mesa #' + publicOrderStatus.order_number
   }
   if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
-    return `Pedido pronto para retirada #${publicOrderStatus.order_number}`
+    return 'Pedido pronto para retirada #' + publicOrderStatus.order_number
   }
   if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'delivered') {
-    return `Pedido retirado #${publicOrderStatus.order_number}`
+    return 'Pedido retirado #' + publicOrderStatus.order_number
   }
   if (
     publicOrderStatus.payment_method === 'delivery' &&
     publicOrderStatus.status === 'ready' &&
     publicOrderStatus.delivery_status === 'out_for_delivery'
   ) {
-    return `Pedido saiu para entrega #${publicOrderStatus.order_number}`
+    return 'Pedido saiu para entrega #' + publicOrderStatus.order_number
   }
-  if (publicOrderStatus.status === 'ready') return `Pedido pronto #${publicOrderStatus.order_number}`
+  if (publicOrderStatus.payment_method === 'delivery' && publicOrderStatus.status === 'ready') {
+    return 'Pedido pronto para entrega #' + publicOrderStatus.order_number
+  }
+  if (publicOrderStatus.status === 'ready') return 'Pedido pronto #' + publicOrderStatus.order_number
   if (publicOrderStatus.payment_method === 'delivery' && publicOrderStatus.status === 'delivered') {
-    return `Pedido entregue #${publicOrderStatus.order_number}`
+    return 'Pedido entregue #' + publicOrderStatus.order_number
   }
-  return `Pedido #${publicOrderStatus.order_number}`
+  return 'Pedido #' + publicOrderStatus.order_number
 }
 
 export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderStatus) {
@@ -659,6 +666,10 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
     publicOrderStatus.delivery_status === 'out_for_delivery'
   ) {
     return 'Acompanhe o deslocamento da entrega.'
+  }
+
+  if (publicOrderStatus.payment_method === 'delivery' && publicOrderStatus.status === 'ready') {
+    return 'Seu pedido está pronto para sair para entrega.'
   }
 
   if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
@@ -687,7 +698,6 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
 
   return 'Acompanhe o andamento do seu pedido.'
 }
-
 export function getPublicOrderStatusCardActionLabel(publicOrderStatus: PublicOrderStatus) {
   if (
     publicOrderStatus.payment_method === 'delivery' &&
@@ -1008,5 +1018,6 @@ export function normalizePublicMenuItems(rawItems: RawItem[]) {
 export function normalizeTenantDeliverySettings(
   value: { delivery_enabled: boolean; flat_fee: number } | { delivery_enabled: boolean; flat_fee: number }[] | null
 ) {
+
   return Array.isArray(value) ? (value[0] ?? null) : (value ?? null)
 }

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -809,6 +809,12 @@ describe('public menu helpers', () => {
     expect(getPublicOrderStatusCardTitle({
       ...publicOrderStatus,
       payment_method: 'delivery',
+      status: 'ready',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('Pedido pronto para entrega #42')
+    expect(getPublicOrderStatusCardTitle({
+      ...publicOrderStatus,
+      payment_method: 'delivery',
       status: 'delivered',
       delivery_status: 'delivered',
     })).toBe('Pedido entregue #42')
@@ -836,6 +842,12 @@ describe('public menu helpers', () => {
       status: 'delivered',
       delivery_status: null,
     })).toBe('Seu pedido foi servido na mesa.')
+    expect(getPublicOrderStatusCardMessage({
+      ...publicOrderStatus,
+      payment_method: 'delivery',
+      status: 'ready',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('Seu pedido está pronto para sair para entrega.')
     expect(getPublicOrderStatusCardMessage({
       ...publicOrderStatus,
       payment_method: 'delivery',


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de delivery tenham estado contextual também quando já estão prontos, mas ainda não saíram para entrega.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardTitle` para tratar `delivery + ready + waiting_dispatch`
- atualiza `getPublicOrderStatusCardMessage` para tratar `delivery + ready + waiting_dispatch`
- mantém o caso especial de `out_for_delivery` com título e mensagem próprios
- restaura a integridade do arquivo `public-menu.ts`, removendo duplicações acidentais de helpers durante a refatoração

## Impacto esperado
- pedidos de delivery deixam de cair no texto genérico de `pronto` antes do despacho
- o card resumido comunica melhor a transição entre preparo e saída para entrega
- a base volta a ficar estável com `test + build` verdes

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
