### PR TITLE
feat: align pre-dispatch delivery notices across public order tracking

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -604,6 +604,9 @@ export function getPublicOrderTrackingMessage(
   ) {
     return 'Seu pedido saiu para entrega.'
   }
+  if (publicOrderStatus.payment_method === 'delivery' && publicOrderStatus.status === 'ready') {
+    return 'Seu pedido está pronto para sair para entrega.'
+  }
   if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
     return 'Seu pedido está pronto para retirada.'
   }
@@ -747,6 +750,10 @@ export function getPublicOrderStatusNotice(publicOrderStatus: PublicOrderStatus 
       publicOrderStatus.delivery_status === 'out_for_delivery'
     ) {
       return 'Seu pedido saiu para entrega.'
+    }
+
+    if (publicOrderStatus.payment_method === 'delivery') {
+      return 'Seu pedido está pronto para sair para entrega.'
     }
 
     if (publicOrderStatus.payment_method === 'counter') {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -760,6 +760,12 @@ describe('public menu helpers', () => {
     }, 'cancelado')).toBe('Seu pedido foi cancelado e o reembolso foi solicitado.')
     expect(getPublicOrderTrackingMessage({
       ...publicOrderStatus,
+      payment_method: 'delivery',
+      status: 'ready',
+      delivery_status: 'waiting_dispatch',
+    }, 'despachar')).toBe('Seu pedido está pronto para sair para entrega.')
+    expect(getPublicOrderTrackingMessage({
+      ...publicOrderStatus,
       payment_method: 'counter',
       status: 'ready',
       delivery_status: null,
@@ -911,7 +917,7 @@ describe('public menu helpers', () => {
       ...publicOrderStatus,
       status: 'ready',
       delivery_status: 'waiting_dispatch',
-    })).toBe('Seu pedido está pronto.')
+    })).toBe('Seu pedido está pronto para sair para entrega.')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
       payment_method: 'counter',


### PR DESCRIPTION
## Resumo
Este PR melhora o tracking público para que pedidos de delivery prontos, mas ainda não despachados, usem mensagens contextuais também no aviso principal e na mensagem detalhada.

## O que foi ajustado
- atualiza `getPublicOrderTrackingMessage` para tratar `delivery + ready + waiting_dispatch`
- atualiza `getPublicOrderStatusNotice` para tratar `delivery + ready + waiting_dispatch`
- mantém o caso especial de `out_for_delivery` com mensagens próprias
- alinha os testes unitários com a nova semântica

## Impacto esperado
- o tracking público deixa de usar texto genérico de `pronto` antes do despacho do delivery
- banner, mensagem detalhada e card resumido passam a falar a mesma linguagem
- melhora a coerência da jornada sem alterar a lógica do pedido

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
