### PR TITLE
feat: add pickup-specific action labels to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -710,6 +710,10 @@ export function getPublicOrderStatusCardActionLabel(publicOrderStatus: PublicOrd
     return 'Ver entrega'
   }
 
+  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
+    return 'Ver retirada'
+  }
+
   return 'Ver pedido'
 }
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -130,7 +130,7 @@ describe('menu components', () => {
 
     expect(markup).toContain('Pedido pronto para retirada #77')
     expect(markup).toContain('Seu pedido está aguardando retirada.')
-    expect(markup).toContain('Ver pedido')
+    expect(markup).toContain('Ver retirada')
   })
 
   it('renderiza card de status com título contextual para mesa pronta', async () => {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -881,6 +881,12 @@ describe('public menu helpers', () => {
     })).toBe('Ver entrega')
     expect(getPublicOrderStatusCardActionLabel({
       ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'ready',
+      delivery_status: null,
+    })).toBe('Ver retirada')
+    expect(getPublicOrderStatusCardActionLabel({
+      ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Ver pedido')
     expect(getPublicOrderStatusCardTone({


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de retirada tenham um CTA mais contextual quando já estão prontos.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardActionLabel` para tratar `counter + ready`
- mantém `Ver entrega` apenas para delivery já em rota
- preserva `Ver pedido` nos demais estados
- atualiza os testes unitários do helper e do componente

## Impacto esperado
- pedidos de retirada deixam de usar CTA genérico no card resumido
- o card fica mais claro sobre a próxima ação esperada do cliente
- melhora a leitura do tracking sem alterar a lógica do pedido

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
