### PR TITLE
feat: add dine-in action labels to public order status cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -714,6 +714,10 @@ export function getPublicOrderStatusCardActionLabel(publicOrderStatus: PublicOrd
     return 'Ver retirada'
   }
 
+  if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
+    return 'Ver comanda'
+  }
+
   return 'Ver pedido'
 }
 

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -710,7 +710,7 @@ export function getPublicOrderStatusCardActionLabel(publicOrderStatus: PublicOrd
     return 'Ver entrega'
   }
 
-  if (publicOrderStatus.payment_method === 'counter' && publicOrderStatus.status === 'ready') {
+  if (publicOrderStatus.payment_method === 'counter' && (publicOrderStatus.status === 'ready' || publicOrderStatus.status === 'delivered')) {
     return 'Ver retirada'
   }
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -154,7 +154,7 @@ describe('menu components', () => {
 
     expect(markup).toContain('Pedido pronto para servir #88')
     expect(markup).toContain('Seu pedido está pronto para servir.')
-    expect(markup).toContain('Ver pedido')
+    expect(markup).toContain('Ver comanda')
   })
 
   it('renderiza modal de meia a meia com sabores elegíveis', async () => {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -133,6 +133,30 @@ describe('menu components', () => {
     expect(markup).toContain('Ver retirada')
   })
 
+  it('renderiza card de status com ação contextual para retirada concluída', async () => {
+    const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(PublicOrderStatusCard, {
+        publicOrderStatus: {
+          id: 'order-counter-delivered',
+          order_number: 78,
+          status: 'delivered',
+          payment_status: 'pending',
+          payment_method: 'counter',
+          delivery_status: null,
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        onTrack: vi.fn(),
+      })
+    )
+
+    expect(markup).toContain('Pedido retirado #78')
+    expect(markup).toContain('Seu pedido foi retirado.')
+    expect(markup).toContain('Ver retirada')
+  })
+
   it('renderiza card de status com título contextual para mesa pronta', async () => {
     const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -887,6 +887,12 @@ describe('public menu helpers', () => {
     })).toBe('Ver retirada')
     expect(getPublicOrderStatusCardActionLabel({
       ...publicOrderStatus,
+      payment_method: 'counter',
+      status: 'delivered',
+      delivery_status: null,
+    })).toBe('Ver retirada')
+    expect(getPublicOrderStatusCardActionLabel({
+      ...publicOrderStatus,
       payment_method: 'table',
       status: 'ready',
       delivery_status: null,

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -887,6 +887,12 @@ describe('public menu helpers', () => {
     })).toBe('Ver retirada')
     expect(getPublicOrderStatusCardActionLabel({
       ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'ready',
+      delivery_status: null,
+    })).toBe('Ver comanda')
+    expect(getPublicOrderStatusCardActionLabel({
+      ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Ver pedido')
     expect(getPublicOrderStatusCardTone({


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de mesa tenham um CTA mais contextual quando já estão prontos.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardActionLabel` para tratar `table + ready`
- mantém `Ver entrega` para delivery em rota
- mantém `Ver retirada` para retirada pronta
- preserva `Ver pedido` nos demais estados
- atualiza os testes unitários do helper e do componente

## Impacto esperado
- pedidos de mesa deixam de usar CTA genérico no card resumido
- o card fica mais claro sobre a próxima ação esperada no fluxo presencial
- melhora a leitura do tracking sem alterar a lógica do pedido

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
