### PR TITLE
feat: keep dine-in action labels contextual after order completion

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -704,8 +704,7 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
 export function getPublicOrderStatusCardActionLabel(publicOrderStatus: PublicOrderStatus) {
   if (
     publicOrderStatus.payment_method === 'delivery' &&
-    publicOrderStatus.status === 'ready' &&
-    publicOrderStatus.delivery_status === 'out_for_delivery'
+    ((publicOrderStatus.status === 'ready' && publicOrderStatus.delivery_status === 'out_for_delivery') || publicOrderStatus.status === 'delivered')
   ) {
     return 'Ver entrega'
   }

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -714,7 +714,7 @@ export function getPublicOrderStatusCardActionLabel(publicOrderStatus: PublicOrd
     return 'Ver retirada'
   }
 
-  if (publicOrderStatus.payment_method === 'table' && publicOrderStatus.status === 'ready') {
+  if (publicOrderStatus.payment_method === 'table' && (publicOrderStatus.status === 'ready' || publicOrderStatus.status === 'delivered')) {
     return 'Ver comanda'
   }
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -157,6 +157,30 @@ describe('menu components', () => {
     expect(markup).toContain('Ver retirada')
   })
 
+  it('renderiza card de status com ação contextual para mesa concluída', async () => {
+    const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(PublicOrderStatusCard, {
+        publicOrderStatus: {
+          id: 'order-table-delivered',
+          order_number: 89,
+          status: 'delivered',
+          payment_status: 'pending',
+          payment_method: 'table',
+          delivery_status: null,
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        onTrack: vi.fn(),
+      })
+    )
+
+    expect(markup).toContain('Pedido servido na mesa #89')
+    expect(markup).toContain('Seu pedido foi servido na mesa.')
+    expect(markup).toContain('Ver comanda')
+  })
+
   it('renderiza card de status com título contextual para mesa pronta', async () => {
     const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -133,6 +133,30 @@ describe('menu components', () => {
     expect(markup).toContain('Ver retirada')
   })
 
+  it('renderiza card de status com ação contextual para entrega concluída', async () => {
+    const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(PublicOrderStatusCard, {
+        publicOrderStatus: {
+          id: 'order-delivery-delivered',
+          order_number: 90,
+          status: 'delivered',
+          payment_status: 'paid',
+          payment_method: 'delivery',
+          delivery_status: 'delivered',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        onTrack: vi.fn(),
+      })
+    )
+
+    expect(markup).toContain('Pedido entregue #90')
+    expect(markup).toContain('Seu pedido foi entregue.')
+    expect(markup).toContain('Ver entrega')
+  })
+
   it('renderiza card de status com ação contextual para retirada concluída', async () => {
     const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -881,6 +881,12 @@ describe('public menu helpers', () => {
     })).toBe('Ver entrega')
     expect(getPublicOrderStatusCardActionLabel({
       ...publicOrderStatus,
+      payment_method: 'delivery',
+      status: 'delivered',
+      delivery_status: 'delivered',
+    })).toBe('Ver entrega')
+    expect(getPublicOrderStatusCardActionLabel({
+      ...publicOrderStatus,
       payment_method: 'counter',
       status: 'ready',
       delivery_status: null,

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -899,6 +899,12 @@ describe('public menu helpers', () => {
     })).toBe('Ver comanda')
     expect(getPublicOrderStatusCardActionLabel({
       ...publicOrderStatus,
+      payment_method: 'table',
+      status: 'delivered',
+      delivery_status: null,
+    })).toBe('Ver comanda')
+    expect(getPublicOrderStatusCardActionLabel({
+      ...publicOrderStatus,
       status: 'preparing',
     })).toBe('Ver pedido')
     expect(getPublicOrderStatusCardTone({


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de mesa mantenham um CTA contextual também depois da conclusão.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardActionLabel` para tratar `table + delivered`
- mantém `Ver comanda` para mesa pronta e mesa concluída
- preserva os CTAs contextuais já existentes para retirada e delivery
- adiciona cobertura unitária no helper e no componente

## Impacto esperado
- pedidos de mesa não voltam para CTA genérico após a conclusão
- o card fica mais consistente ao longo de todo o fluxo presencial
- melhora a clareza sem alterar a lógica do pedido

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
