### PR TITLE
feat: keep delivery action labels contextual before dispatch

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -704,7 +704,7 @@ export function getPublicOrderStatusCardMessage(publicOrderStatus: PublicOrderSt
 export function getPublicOrderStatusCardActionLabel(publicOrderStatus: PublicOrderStatus) {
   if (
     publicOrderStatus.payment_method === 'delivery' &&
-    ((publicOrderStatus.status === 'ready' && publicOrderStatus.delivery_status === 'out_for_delivery') || publicOrderStatus.status === 'delivered')
+    (publicOrderStatus.status === 'ready' || publicOrderStatus.status === 'delivered')
   ) {
     return 'Ver entrega'
   }

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -133,6 +133,30 @@ describe('menu components', () => {
     expect(markup).toContain('Ver retirada')
   })
 
+  it('renderiza card de status com ação contextual para entrega pronta para despacho', async () => {
+    const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(PublicOrderStatusCard, {
+        publicOrderStatus: {
+          id: 'order-delivery-ready',
+          order_number: 91,
+          status: 'ready',
+          payment_status: 'pending',
+          payment_method: 'delivery',
+          delivery_status: 'waiting_dispatch',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        onTrack: vi.fn(),
+      })
+    )
+
+    expect(markup).toContain('Pedido pronto para entrega #91')
+    expect(markup).toContain('Seu pedido está pronto para sair para entrega.')
+    expect(markup).toContain('Ver entrega')
+  })
+
   it('renderiza card de status com ação contextual para entrega concluída', async () => {
     const { PublicOrderStatusCard } = await import('@/features/menu/PublicOrderStatusCard')
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -882,6 +882,12 @@ describe('public menu helpers', () => {
     expect(getPublicOrderStatusCardActionLabel({
       ...publicOrderStatus,
       payment_method: 'delivery',
+      status: 'ready',
+      delivery_status: 'waiting_dispatch',
+    })).toBe('Ver entrega')
+    expect(getPublicOrderStatusCardActionLabel({
+      ...publicOrderStatus,
+      payment_method: 'delivery',
       status: 'delivered',
       delivery_status: 'delivered',
     })).toBe('Ver entrega')


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de delivery mantenham um CTA contextual também quando já estão prontos, mas ainda não saíram para entrega.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardActionLabel` para tratar `delivery + ready + waiting_dispatch`
- mantém `Ver entrega` para delivery pronto, em rota e concluído
- preserva os CTAs contextuais já existentes para retirada e mesa
- adiciona cobertura unitária no helper e no componente

## Impacto esperado
- pedidos de delivery não caem mais em CTA genérico antes do despacho
- o card fica consistente ao longo de todo o fluxo de entrega
- melhora a clareza sem alterar a lógica do pedido

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
