### PR TITLE
feat: use delivery tone for pre-dispatch public order cards

### DIFF
--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -725,8 +725,7 @@ export function getPublicOrderStatusCardTone(publicOrderStatus: PublicOrderStatu
 
   if (
     publicOrderStatus.payment_method === 'delivery' &&
-    publicOrderStatus.status === 'ready' &&
-    publicOrderStatus.delivery_status === 'out_for_delivery'
+    publicOrderStatus.status === 'ready'
   ) {
     return 'delivery'
   }

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -938,7 +938,7 @@ describe('public menu helpers', () => {
       ...publicOrderStatus,
       status: 'ready',
       delivery_status: 'waiting_dispatch',
-    })).toBe('success')
+    })).toBe('delivery')
     expect(getPublicOrderStatusNotice({
       ...publicOrderStatus,
       status: 'confirmed',


### PR DESCRIPTION
## Resumo
Este PR melhora o card resumido do tracking público para que pedidos de delivery já prontos para despacho usem o mesmo tom visual do fluxo de entrega.

## O que foi ajustado
- atualiza `getPublicOrderStatusCardTone` para tratar `delivery + ready + waiting_dispatch` como `delivery`
- mantém o mesmo tom para delivery em rota
- preserva os tons já existentes para pending, progress e demais estados
- adiciona cobertura unitária no helper e valida a renderização do componente

## Impacto esperado
- pedidos de delivery prontos para despacho deixam de parecer um estado genérico de sucesso
- o card fica visualmente mais consistente ao longo de toda a jornada de entrega
- melhora a comunicação sem alterar a lógica do pedido

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
