### PR TITLE
test: lock delivery card styling for pre-dispatch public orders

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -155,6 +155,8 @@ describe('menu components', () => {
     expect(markup).toContain('Pedido pronto para entrega #91')
     expect(markup).toContain('Seu pedido está pronto para sair para entrega.')
     expect(markup).toContain('Ver entrega')
+    expect(markup).toContain('border-violet-200')
+    expect(markup).toContain('bg-violet-50')
   })
 
   it('renderiza card de status com ação contextual para entrega concluída', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que pedidos de delivery prontos para despacho continuem usando o tom de entrega no card resumido do tracking público.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `delivery + ready + waiting_dispatch` renderiza com:
  - `border-violet-200`
  - `bg-violet-50`
- mantém a cobertura funcional existente de título, mensagem e CTA

## Impacto esperado
- evita regressão visual em que esse estado volte a parecer um sucesso genérico
- reforça a consistência do tracking público para delivery antes do despacho

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
