### PR TITLE
test: lock delivered delivery card styling in public tracking

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -181,6 +181,8 @@ describe('menu components', () => {
     expect(markup).toContain('Pedido entregue #90')
     expect(markup).toContain('Seu pedido foi entregue.')
     expect(markup).toContain('Ver entrega')
+    expect(markup).toContain('border-emerald-200')
+    expect(markup).toContain('bg-emerald-50')
   })
 
   it('renderiza card de status com ação contextual para retirada concluída', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que pedidos de delivery concluídos continuem usando o tom final de sucesso no card resumido do tracking público.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `delivery + delivered` renderiza com:
  - `border-emerald-200`
  - `bg-emerald-50`
- mantém a cobertura funcional existente de título, mensagem e CTA

## Impacto esperado
- evita regressão visual em que entrega concluída herde o tom do estado em rota
- reforça a consistência do tracking público no fechamento do delivery

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
