### PR TITLE
test: lock delivered pickup card styling in public tracking

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -207,6 +207,8 @@ describe('menu components', () => {
     expect(markup).toContain('Pedido retirado #78')
     expect(markup).toContain('Seu pedido foi retirado.')
     expect(markup).toContain('Ver retirada')
+    expect(markup).toContain('border-emerald-200')
+    expect(markup).toContain('bg-emerald-50')
   })
 
   it('renderiza card de status com ação contextual para mesa concluída', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que pedidos de retirada concluídos continuem usando o tom final de sucesso no card resumido do tracking público.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `counter + delivered` renderiza com:
  - `border-emerald-200`
  - `bg-emerald-50`
- mantém a cobertura funcional existente de título, mensagem e CTA

## Impacto esperado
- evita regressão visual em que retirada concluída herde um tom incorreto
- reforça a consistência do tracking público no fechamento do pickup

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
