### PR TITLE
test: lock delivered dine-in card styling in public tracking

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -233,6 +233,8 @@ describe('menu components', () => {
     expect(markup).toContain('Pedido servido na mesa #89')
     expect(markup).toContain('Seu pedido foi servido na mesa.')
     expect(markup).toContain('Ver comanda')
+    expect(markup).toContain('border-emerald-200')
+    expect(markup).toContain('bg-emerald-50')
   })
 
   it('renderiza card de status com título contextual para mesa pronta', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que pedidos de mesa concluídos continuem usando o tom final de sucesso no card resumido do tracking público.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `table + delivered` renderiza com:
  - `border-emerald-200`
  - `bg-emerald-50`
- mantém a cobertura funcional existente de título, mensagem e CTA

## Impacto esperado
- evita regressão visual em que mesa concluída herde um tom incorreto
- reforça a consistência do tracking público no fechamento do fluxo presencial

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
