### PR TITLE
test: lock out-for-delivery action button styling

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -237,6 +237,8 @@ describe('menu components', () => {
     expect(markup).toContain('Ver entrega')
     expect(markup).toContain('border-violet-200')
     expect(markup).toContain('bg-violet-50')
+    expect(markup).toContain('bg-violet-600')
+    expect(markup).toContain('hover:bg-violet-700')
   })
 
   it('renderiza card de status com ação contextual para entrega concluída', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que o botão do card resumido continue usando o tom de entrega quando o pedido já está em rota.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `delivery + ready + out_for_delivery` renderiza o botão com:
  - `bg-violet-600`
  - `hover:bg-violet-700`
- mantém a cobertura funcional existente de título, mensagem, CTA e container

## Impacto esperado
- evita regressão visual em que o CTA de entrega em rota perca o estilo contextual
- reforça a consistência do tracking público no estado de entrega ativa

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`