### PR TITLE
test: lock delivered delivery action button styling

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -185,6 +185,8 @@ describe('menu components', () => {
     expect(markup).toContain('Ver retirada')
     expect(markup).toContain('border-emerald-200')
     expect(markup).toContain('bg-emerald-50')
+    expect(markup).toContain('bg-emerald-600')
+    expect(markup).toContain('hover:bg-emerald-700')
   })
 
   it('renderiza card de status com ação contextual para entrega pronta para despacho', async () => {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -265,6 +265,8 @@ describe('menu components', () => {
     expect(markup).toContain('Ver entrega')
     expect(markup).toContain('border-emerald-200')
     expect(markup).toContain('bg-emerald-50')
+    expect(markup).toContain('bg-emerald-600')
+    expect(markup).toContain('hover:bg-emerald-700')
   })
 
   it('renderiza card de status com ação contextual para retirada concluída', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que o botão do card resumido continue usando o tom final de sucesso quando o pedido de delivery já foi concluído.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `delivery + delivered` renderiza o botão com:
  - `bg-emerald-600`
  - `hover:bg-emerald-700`
- mantém a cobertura funcional e visual já existente de título, mensagem, CTA e container

## Impacto esperado
- evita regressão visual em que o CTA do delivery concluído perca o estilo contextual final
- reforça a consistência do tracking público no fechamento da entrega

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`