### PR TITLE
test: lock delivered dine-in action button styling

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -321,6 +321,8 @@ describe('menu components', () => {
     expect(markup).toContain('Ver comanda')
     expect(markup).toContain('border-emerald-200')
     expect(markup).toContain('bg-emerald-50')
+    expect(markup).toContain('bg-emerald-600')
+    expect(markup).toContain('hover:bg-emerald-700')
   })
 
   it('renderiza card de status com título contextual para mesa pronta', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que o botão do card resumido continue usando o tom final de sucesso quando o pedido de mesa já foi concluído.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `table + delivered` renderiza o botão com:
  - `bg-emerald-600`
  - `hover:bg-emerald-700`
- mantém a cobertura funcional e visual já existente de título, mensagem, CTA e container

## Impacto esperado
- evita regressão visual em que o CTA da mesa concluída perca o estilo contextual final
- reforça a consistência do tracking público no fechamento do fluxo presencial

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
