### PR TITLE
test: lock ready dine-in action button styling

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -349,6 +349,8 @@ describe('menu components', () => {
     expect(markup).toContain('Ver comanda')
     expect(markup).toContain('border-emerald-200')
     expect(markup).toContain('bg-emerald-50')
+    expect(markup).toContain('bg-emerald-600')
+    expect(markup).toContain('hover:bg-emerald-700')
   })
 
   it('renderiza modal de meia a meia com sabores elegíveis', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que o botão do card resumido continue usando o tom final de sucesso quando o pedido de mesa está pronto para servir.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `table + ready` renderiza o botão com:
  - `bg-emerald-600`
  - `hover:bg-emerald-700`
- mantém a cobertura funcional e visual já existente de título, mensagem, CTA e container

## Impacto esperado
- evita regressão visual em que o CTA da mesa pronta perca o estilo contextual final
- reforça a consistência do tracking público no estado pronto do fluxo presencial

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
