### PR TITLE
test: lock pending public order action button styling

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -159,6 +159,8 @@ describe('menu components', () => {
     expect(markup).toContain('Ver pedido')
     expect(markup).toContain('border-amber-200')
     expect(markup).toContain('bg-amber-50')
+    expect(markup).toContain('bg-amber-600')
+    expect(markup).toContain('hover:bg-amber-700')
   })
 
   it('renderiza card de status com título contextual para retirada', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que o botão do card resumido continue usando o tom de alerta quando o pedido ainda está pendente.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `pending` renderiza o botão com:
  - `bg-amber-600`
  - `hover:bg-amber-700`
- mantém a cobertura funcional e visual já existente de título, mensagem, CTA e container

## Impacto esperado
- evita regressão visual em que o CTA do pedido pendente perca o estilo contextual de alerta
- reforça a consistência do tracking público no estado inicial do pedido

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
