### PR TITLE
test: lock confirmed public order action button styling

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -109,6 +109,8 @@ describe('menu components', () => {
     expect(markup).toContain('Ver pedido')
     expect(markup).toContain('border-sky-200')
     expect(markup).toContain('bg-sky-50')
+    expect(markup).toContain('bg-sky-600')
+    expect(markup).toContain('hover:bg-sky-700')
   })
 
   it('renderiza card de status do pedido com título contextual', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que o botão do card resumido continue usando o tom de progresso quando o pedido já foi confirmado pelo estabelecimento.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `confirmed` renderiza o botão com:
  - `bg-sky-600`
  - `hover:bg-sky-700`
- mantém a cobertura funcional e visual já existente de título, mensagem, CTA e container

## Impacto esperado
- evita regressão visual em que o CTA do pedido confirmado perca o estilo contextual de progresso
- reforça a consistência do tracking público na transição entre confirmação e preparo

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
