### PR TITLE
test: lock pre-dispatch delivery action button styling

### DIFF
--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -219,6 +219,8 @@ describe('menu components', () => {
     expect(markup).toContain('Ver entrega')
     expect(markup).toContain('border-violet-200')
     expect(markup).toContain('bg-violet-50')
+    expect(markup).toContain('bg-violet-600')
+    expect(markup).toContain('hover:bg-violet-700')
   })
 
   it('renderiza card de status com ação contextual para entrega em rota', async () => {


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura visual para garantir que o botão do card resumido continue usando o tom de entrega quando o pedido de delivery já está pronto para despacho, mas ainda não saiu.

## O que foi ajustado
- adiciona asserções de classe no teste do `PublicOrderStatusCard`
- garante que `delivery + ready + waiting_dispatch` renderiza o botão com:
  - `bg-violet-600`
  - `hover:bg-violet-700`
- mantém a cobertura funcional e visual já existente de título, mensagem, CTA e container

## Impacto esperado
- evita regressão visual em que o CTA do pré-despacho perca o estilo contextual de entrega
- reforça a consistência do tracking público na transição entre preparo e saída para entrega

## Validação
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm run build`
