### PR TITLE
test: lock redundant pre-dispatch delivery notice suppression

### DIFF
--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1040,6 +1040,16 @@ describe('public menu helpers', () => {
       cartOpen: false,
     })).toBe(true)
     expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Seu pedido está pronto para sair para entrega.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'ready',
+        payment_method: 'delivery',
+        delivery_status: 'waiting_dispatch',
+      },
+      cartOpen: false,
+    })).toBe(false)
+    expect(shouldShowCheckoutNoticeBanner({
       checkoutNotice: 'Pedido cancelado.',
       publicOrderStatus: {
         ...publicOrderStatus,


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura para garantir que o banner principal continue oculto quando o delivery já está pronto para despacho e o aviso só repete a mesma informação do card resumido.

## O que foi ajustado
- adiciona caso dedicado em `shouldShowCheckoutNoticeBanner`
- garante que `delivery + ready + waiting_dispatch` com o aviso:
  - `Seu pedido está pronto para sair para entrega.`
  resulta em `false`
- mantém a cobertura já existente para preparo, pagamento pendente e cancelamento

## Impacto esperado
- evita regressão visual em que o painel público volte a duplicar a mesma mensagem operacional
- reforça a consistência do tracking na transição entre preparo e entrega

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
