### PR TITLE
test: lock redundant out-for-delivery notice suppression

### DIFF
--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1050,6 +1050,16 @@ describe('public menu helpers', () => {
       cartOpen: false,
     })).toBe(false)
     expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Seu pedido saiu para entrega.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'ready',
+        payment_method: 'delivery',
+        delivery_status: 'out_for_delivery',
+      },
+      cartOpen: false,
+    })).toBe(false)
+    expect(shouldShowCheckoutNoticeBanner({
       checkoutNotice: 'Pedido cancelado.',
       publicOrderStatus: {
         ...publicOrderStatus,


### PR DESCRIPTION
## Resumo
Este PR adiciona cobertura para garantir que o banner principal continue oculto quando o delivery já saiu para entrega e o aviso só repete a mesma informação do card resumido.

## O que foi ajustado
- adiciona caso dedicado em `shouldShowCheckoutNoticeBanner`
- garante que `delivery + ready + out_for_delivery` com o aviso:
  - `Seu pedido saiu para entrega.`
  resulta em `false`
- mantém a cobertura já existente para preparo, pré-despacho, pagamento pendente e cancelamento

## Impacto esperado
- evita regressão visual em que o painel público volte a duplicar a mesma mensagem operacional
- reforça a consistência do tracking durante a entrega em rota

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm run build`
