### PR TITLE
test: lock redundant pickup-ready notice suppression

### DIFF
--- a/app/api/public/orders/[id]/cancel/route.ts
+++ b/app/api/public/orders/[id]/cancel/route.ts
@@ -65,7 +65,7 @@ export async function cancelPublicOrder(
 
     const { data: updatedOrder, error: updatedOrderError } = await admin
       .from('orders')
-      .select('id, order_number, status, payment_status, refunded_at, created_at, updated_at')
+      .select('id, order_number, status, payment_status, payment_method, delivery_status, cancelled_reason, refunded_at, created_at, updated_at')
       .eq('id', orderId)
       .single()
 

--- a/features/menu/MenuDoneStep.tsx
+++ b/features/menu/MenuDoneStep.tsx
@@ -75,7 +75,9 @@ export function MenuDoneStep({
           <p className="mt-1 text-sm text-red-600">{getCancelledOrderMessage(publicOrderStatus)}</p>
           {publicOrderStatus.payment_status === 'refunded' && (
             <p className="mt-2 text-xs text-red-500">
-              Reembolso solicitado com sucesso no pagamento online.
+              {publicOrderStatus.payment_method === 'online'
+                ? 'Reembolso solicitado com sucesso no pagamento online.'
+                : 'Reembolso solicitado com sucesso.'}
             </p>
           )}
         </div>

--- a/tests/integration/public-cancel-route.test.ts
+++ b/tests/integration/public-cancel-route.test.ts
@@ -77,6 +77,9 @@ describe('public cancel route', () => {
             order_number: 77,
             status: 'cancelled',
             payment_status: 'refunded',
+            payment_method: 'delivery',
+            delivery_status: 'waiting_dispatch',
+            cancelled_reason: 'Cliente desistiu',
             refunded_at: '2026-03-20T12:00:00.000Z',
             created_at: '2026-03-20T10:00:00.000Z',
             updated_at: '2026-03-20T12:00:00.000Z',
@@ -113,7 +116,14 @@ describe('public cancel route', () => {
     })
     expect(refundOrderId).toBe('order-1')
     expect(notifiedOrderId).toBe('order-1')
-    expect((await response.json()).data.status).toBe('cancelled')
+    expect(await response.json()).toEqual({
+      data: expect.objectContaining({
+        status: 'cancelled',
+        payment_method: 'delivery',
+        delivery_status: 'waiting_dispatch',
+        cancelled_reason: 'Cliente desistiu',
+      }),
+    })
   })
 
   it('cancelPublicOrder devolve 404 quando pedido não existe', async () => {
@@ -341,6 +351,9 @@ describe('public cancel route', () => {
             order_number: 88,
             status: 'cancelled',
             payment_status: 'paid',
+            payment_method: 'counter',
+            delivery_status: null,
+            cancelled_reason: 'Cancelado pelo cliente',
             refunded_at: null,
             created_at: '2026-03-20T10:00:00.000Z',
             updated_at: '2026-03-20T12:00:00.000Z',
@@ -393,6 +406,9 @@ describe('public cancel route', () => {
             order_number: 55,
             status: 'cancelled',
             payment_status: 'pending',
+            payment_method: 'table',
+            delivery_status: null,
+            cancelled_reason: 'Cancelado pelo cliente',
             refunded_at: null,
             created_at: '2026-03-20T10:00:00.000Z',
             updated_at: '2026-03-20T12:00:00.000Z',

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -198,6 +198,9 @@ describe('MenuClient component', () => {
               id: 'order-1',
               status: 'cancelled',
               payment_status: 'refunded',
+              payment_method: 'table',
+              delivery_status: null,
+              cancelled_reason: 'Cliente desistiu',
             }),
           }),
         }
@@ -474,7 +477,15 @@ describe('MenuClient component', () => {
     expect(stateSetters[13]).toHaveBeenCalledWith(false)
     expect(stateSetters[17]).toHaveBeenCalledWith('order-created')
     expect(stateSetters[16]).toHaveBeenCalledWith(77)
-    expect(stateSetters[22]).toHaveBeenCalled()
+    expect(stateSetters[22]).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'order-1',
+        status: 'cancelled',
+        payment_status: 'refunded',
+        payment_method: 'table',
+        cancelled_reason: 'Cliente desistiu',
+      }),
+    )
     expect(stateSetters[2]).toHaveBeenCalledWith('done')
     expect(stateSetters[0]).toHaveBeenCalledWith([])
     expect(stateSetters[23]).toHaveBeenCalledWith(true)

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1463,6 +1463,41 @@ describe('menu components', () => {
     expect(cancelledMarkup).not.toContain('Reembolso solicitado com sucesso')
   })
 
+
+  it('renderiza carregamento no cancelamento do passo final com botão desabilitado', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 557,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-cancel-loading',
+          order_number: 557,
+          status: 'pending',
+          payment_status: 'pending',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [{ key: 'pending', label: 'Recebido', description: 'Entrou na fila.' }],
+        getStepState: () => 'current',
+        cancelOrderLoading: true,
+        confirmDeliveryLoading: false,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose: vi.fn(),
+      }),
+    )
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(2)
+    expect(getTextContent(buttons[0])).toContain('Cancelando...')
+    expect(buttons[0].props.disabled).toBe(true)
+  })
+
   it('renderiza filtro de categorias com estado ativo', async () => {
     const { MenuCategoryFilter } = await import('@/features/menu/MenuCategoryFilter')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1322,6 +1322,7 @@ describe('menu components', () => {
     expect(markup).toContain('Saiu para entrega')
     expect(markup).toContain('Seu pedido vai aparecer aqui quando sair para entrega.')
     expect(markup).toContain('border-slate-300 bg-white text-slate-400')
+    expect(markup).not.toContain('Confirmar recebimento')
     expect(markup).not.toContain('com João')
   })
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1172,6 +1172,50 @@ describe('menu components', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
+
+  it('mantém o CTA final funcional no fluxo padrão de mesa', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 222,
+        tableInfo: { id: 'table-9', number: '9' },
+        publicOrderStatus: {
+          id: 'order-table-default',
+          order_number: 222,
+          status: 'confirmed',
+          payment_status: 'pending',
+          payment_method: 'table',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [
+          { key: 'pending', label: 'Recebido', description: 'Entrou na fila.' },
+          { key: 'confirmed', label: 'Confirmado', description: 'Confirmado.' },
+        ],
+        getStepState: () => 'current',
+        cancelOrderLoading: false,
+        onCancelOrder: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Comanda aberta!')
+    expect(getTextContent(elements)).toContain('Número da comanda')
+    expect(getTextContent(elements)).toContain('Pagamento no local')
+    expect(getTextContent(elements)).toContain('Voltar ao cardápio')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(2)
+    expect(getTextContent(buttons[1])).toContain('Voltar ao cardápio')
+    buttons[1].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('renderiza rótulo de retirada no passo final de balcão', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1707,6 +1707,50 @@ describe('menu components', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
+  it('não renderiza bloco de pagamento no fluxo de retirada cancelado sem reembolso', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 561,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-counter-cancelled',
+          order_number: 561,
+          status: 'cancelled',
+          payment_status: 'pending',
+          payment_method: 'counter',
+          cancelled_reason: 'Retirada indisponivel no momento',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [],
+        getStepState: () => 'upcoming',
+        cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pedido cancelado')
+    expect(getTextContent(elements)).toContain('Retirada indisponivel no momento')
+    expect(getTextContent(elements)).not.toContain('Pagamento na retirada')
+    expect(getTextContent(elements)).not.toContain('No local')
+    expect(getTextContent(elements)).not.toContain('Reembolso solicitado com sucesso')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Voltar ao cardápio')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('mantém o CTA final funcional no fluxo cancelado com reembolso fora da mesa', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1128,6 +1128,46 @@ describe('menu components', () => {
   })
 
 
+
+  it('renderiza bloco de pagamento online aprovado no passo final', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 78,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-online-paid',
+          order_number: 78,
+          status: 'confirmed',
+          payment_status: 'paid',
+          payment_method: 'online',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [{ key: 'confirmed', label: 'Confirmado', description: 'Confirmado.' }],
+        getStepState: () => 'current',
+        cancelOrderLoading: false,
+        onCancelOrder: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pagamento online')
+    expect(getTextContent(elements)).toContain('Aprovado')
+    expect(getTextContent(elements)).toContain('Acompanhar depois')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(2)
+    expect(getTextContent(buttons[1])).toContain('Acompanhar depois')
+    buttons[1].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('renderiza bloco de pagamento online pendente no passo final', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1130,6 +1130,49 @@ describe('menu components', () => {
 
 
 
+
+  it('mantém o estado final correto no fluxo online cancelado sem reembolso', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 80,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-online-cancelled',
+          order_number: 80,
+          status: 'cancelled',
+          payment_status: 'pending',
+          payment_method: 'online',
+          cancelled_reason: 'Pagamento não concluído',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [],
+        getStepState: () => 'upcoming',
+        cancelOrderLoading: false,
+        onCancelOrder: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pedido cancelado')
+    expect(getTextContent(elements)).toContain('Pagamento não concluído')
+    expect(getTextContent(elements)).not.toContain('Pagamento online')
+    expect(getTextContent(elements)).not.toContain('Pendente')
+    expect(getTextContent(elements)).toContain('Acompanhar depois')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Acompanhar depois')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('renderiza bloco de pagamento online reembolsado no passo final', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1248,6 +1248,7 @@ describe('menu components', () => {
   it('renderiza carregamento na confirmação de recebimento no passo final', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 
+    const onClose = vi.fn()
     const elements = flattenElements(
       React.createElement(MenuDoneStep, {
         orderNumber: 223,
@@ -1273,7 +1274,7 @@ describe('menu components', () => {
         confirmDeliveryLoading: true,
         onCancelOrder: vi.fn(),
         onConfirmDelivery: vi.fn(),
-        onClose: vi.fn(),
+        onClose,
       }),
     )
 
@@ -1285,6 +1286,9 @@ describe('menu components', () => {
     expect(getTextContent(buttons[0])).toContain('Confirmando...')
     expect(buttons[0].props.disabled).toBe(true)
     expect(getTextContent(buttons[1])).toContain('Acompanhar depois')
+
+    buttons[1].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('renderiza etapa de entrega pendente sem marcar como concluída', async () => {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1204,6 +1204,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Comanda aberta!')
     expect(getTextContent(elements)).toContain('Número da comanda')
     expect(getTextContent(elements)).toContain('Pagamento no local')
+    expect(getTextContent(elements)).toContain('No local')
     expect(getTextContent(elements)).toContain('Voltar ao cardápio')
 
     const buttons = elements.filter(

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1120,7 +1120,8 @@ describe('menu components', () => {
   it('renderiza passo final cancelado com mensagem de reembolso', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 
-    const markup = renderToStaticMarkup(
+    const onClose = vi.fn()
+    const elements = flattenElements(
       React.createElement(MenuDoneStep, {
         orderNumber: 99,
         tableInfo: { id: 'table-1', number: '8' },
@@ -1137,19 +1138,28 @@ describe('menu components', () => {
         getStepState: () => 'upcoming',
         cancelOrderLoading: false,
         onCancelOrder: vi.fn(),
-        onClose: vi.fn(),
-      })
+        onClose,
+      }),
     )
 
-    expect(markup).toContain('Pedido cancelado')
-    expect(markup).toContain('Comanda aberta!')
-    expect(markup).toContain('Acompanhe a comanda da sua mesa.')
-    expect(markup).toContain('Número da comanda')
-    expect(markup).toContain('Acompanhe a comanda')
-    expect(markup).toContain('Estoque indisponível')
-    expect(markup).not.toContain('Cancelar pedido')
-    expect(markup).toContain('Reembolso solicitado com sucesso')
-    expect(markup).toContain('Mesa 8')
+    expect(getTextContent(elements)).toContain('Pedido cancelado')
+    expect(getTextContent(elements)).toContain('Comanda aberta!')
+    expect(getTextContent(elements)).toContain('Acompanhe a comanda da sua mesa.')
+    expect(getTextContent(elements)).toContain('Número da comanda')
+    expect(getTextContent(elements)).toContain('Acompanhe a comanda')
+    expect(getTextContent(elements)).toContain('Estoque indisponível')
+    expect(getTextContent(elements)).not.toContain('Cancelar pedido')
+    expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso')
+    expect(getTextContent(elements)).toContain('Mesa 8')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Voltar ao cardápio')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('renderiza rótulo de retirada no passo final de balcão', async () => {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1521,6 +1521,7 @@ describe('menu components', () => {
       }),
     )
 
+    expect(getTextContent(elements)).toContain('Pagamento na entrega')
     expect(getTextContent(elements)).toContain('Reembolsado')
     expect(getTextContent(elements)).toContain('Cancelar pedido')
     expect(getTextContent(elements)).not.toContain('Saiu para entrega')

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1839,6 +1839,50 @@ describe('menu components', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
+  it('não renderiza bloco de pagamento no fluxo de delivery cancelado sem reembolso', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 557,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-delivery-cancelled',
+          order_number: 557,
+          status: 'cancelled',
+          payment_status: 'pending',
+          payment_method: 'delivery',
+          cancelled_reason: 'Entregador indisponivel',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [],
+        getStepState: () => 'upcoming',
+        cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pedido cancelado')
+    expect(getTextContent(elements)).toContain('Entregador indisponivel')
+    expect(getTextContent(elements)).not.toContain('Pagamento na entrega')
+    expect(getTextContent(elements)).not.toContain('Na entrega')
+    expect(getTextContent(elements)).not.toContain('Reembolso solicitado com sucesso')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Acompanhar depois')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('mantém o CTA final funcional no fluxo cancelado sem reembolso', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1340,6 +1340,52 @@ describe('menu components', () => {
   })
 
 
+  it('não renderiza bloco de pagamento no fluxo de mesa cancelado sem reembolso', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 100,
+        tableInfo: { id: 'table-2', number: '11' },
+        publicOrderStatus: {
+          id: 'order-table-cancelled',
+          order_number: 100,
+          status: 'cancelled',
+          payment_status: 'pending',
+          payment_method: 'table',
+          cancelled_reason: 'Atendimento encerrado',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [],
+        getStepState: () => 'upcoming',
+        cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pedido cancelado')
+    expect(getTextContent(elements)).toContain('Comanda aberta!')
+    expect(getTextContent(elements)).toContain('Atendimento encerrado')
+    expect(getTextContent(elements)).not.toContain('Pagamento no local')
+    expect(getTextContent(elements)).not.toContain('No local')
+    expect(getTextContent(elements)).not.toContain('Reembolso solicitado com sucesso')
+    expect(getTextContent(elements)).toContain('Mesa 11')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Voltar ao cardápio')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('mantém o CTA final funcional no fluxo padrão de mesa', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1827,6 +1827,8 @@ describe('menu components', () => {
 
     expect(getTextContent(elements)).toContain('Pedido cancelado')
     expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso')
+    expect(getTextContent(elements)).not.toContain('Pagamento na entrega')
+    expect(getTextContent(elements)).not.toContain('Reembolsado')
     expect(getTextContent(elements)).toContain('Acompanhar depois')
 
     const buttons = elements.filter(

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1741,7 +1741,7 @@ describe('menu components', () => {
     )
 
     expect(getTextContent(elements)).toContain('Pedido cancelado')
-    expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso no pagamento online.')
+    expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso.')
     expect(getTextContent(elements)).not.toContain('Pagamento na retirada')
     expect(getTextContent(elements)).not.toContain('No local')
     expect(getTextContent(elements)).not.toContain('Reembolsado')

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1875,6 +1875,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Entregador indisponivel')
     expect(getTextContent(elements)).not.toContain('Pagamento na entrega')
     expect(getTextContent(elements)).not.toContain('Na entrega')
+    expect(getTextContent(elements)).not.toContain('Pendente')
     expect(getTextContent(elements)).not.toContain('Reembolso solicitado com sucesso')
 
     const buttons = elements.filter(

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1743,6 +1743,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso no pagamento online.')
     expect(getTextContent(elements)).not.toContain('Pagamento na retirada')
     expect(getTextContent(elements)).not.toContain('No local')
+    expect(getTextContent(elements)).not.toContain('Reembolsado')
 
     const buttons = elements.filter(
       (element) => element.type === 'button' && typeof element.props.onClick === 'function',

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1082,7 +1082,8 @@ describe('menu components', () => {
   it('renderiza passo final com status em andamento e cancelamento disponível', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 
-    const markup = renderToStaticMarkup(
+    const onClose = vi.fn()
+    const elements = flattenElements(
       React.createElement(MenuDoneStep, {
         orderNumber: 42,
         tableInfo: null,
@@ -1103,18 +1104,27 @@ describe('menu components', () => {
         getStepState: (key: 'pending' | 'confirmed') => (key === 'pending' ? 'done' : 'current'),
         cancelOrderLoading: false,
         onCancelOrder: vi.fn(),
-        onClose: vi.fn(),
-      })
+        onClose,
+      }),
     )
 
-    expect(markup).toContain('Pedido realizado!')
-    expect(markup).toContain('Acompanhe o andamento do pedido até a entrega.')
-    expect(markup).toContain('Número do pedido')
-    expect(markup).toContain('#42')
-    expect(markup).toContain('Acompanhe o status do pedido')
-    expect(markup).toContain('Pagamento na entrega')
-    expect(markup).toContain('Cancelar pedido')
-    expect(markup).toContain('Aprovado')
+    expect(getTextContent(elements)).toContain('Pedido realizado!')
+    expect(getTextContent(elements)).toContain('Acompanhe o andamento do pedido até a entrega.')
+    expect(getTextContent(elements)).toContain('Número do pedido')
+    expect(getTextContent(elements)).toContain('#42')
+    expect(getTextContent(elements)).toContain('Acompanhe o status do pedido')
+    expect(getTextContent(elements)).toContain('Pagamento na entrega')
+    expect(getTextContent(elements)).toContain('Cancelar pedido')
+    expect(getTextContent(elements)).toContain('Aprovado')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(2)
+    expect(getTextContent(buttons[1])).toContain('Acompanhar depois')
+    buttons[1].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('renderiza passo final cancelado com mensagem de reembolso', async () => {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1787,6 +1787,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Retirada indisponivel no momento')
     expect(getTextContent(elements)).not.toContain('Pagamento na retirada')
     expect(getTextContent(elements)).not.toContain('No local')
+    expect(getTextContent(elements)).not.toContain('Pendente')
     expect(getTextContent(elements)).not.toContain('Reembolso solicitado com sucesso')
 
     const buttons = elements.filter(

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1492,6 +1492,49 @@ describe('menu components', () => {
   })
 
 
+
+  it('mantém o CTA final funcional no fluxo cancelado com reembolso fora da mesa', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 559,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-cancel-refunded-default',
+          order_number: 559,
+          status: 'cancelled',
+          payment_status: 'refunded',
+          payment_method: 'delivery',
+          cancelled_reason: 'Pagamento estornado',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [],
+        getStepState: () => 'upcoming',
+        cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pedido cancelado')
+    expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso')
+    expect(getTextContent(elements)).toContain('Acompanhar depois')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Acompanhar depois')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('mantém o CTA final funcional no fluxo cancelado sem reembolso', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1473,6 +1473,7 @@ describe('menu components', () => {
   it('renderiza carregamento no cancelamento do passo final com botão desabilitado', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 
+    const onClose = vi.fn()
     const elements = flattenElements(
       React.createElement(MenuDoneStep, {
         orderNumber: 557,
@@ -1491,7 +1492,7 @@ describe('menu components', () => {
         confirmDeliveryLoading: false,
         onCancelOrder: vi.fn(),
         onConfirmDelivery: vi.fn(),
-        onClose: vi.fn(),
+        onClose,
       }),
     )
 
@@ -1502,6 +1503,10 @@ describe('menu components', () => {
     expect(buttons).toHaveLength(2)
     expect(getTextContent(buttons[0])).toContain('Cancelando...')
     expect(buttons[0].props.disabled).toBe(true)
+    expect(getTextContent(buttons[1])).toContain('Acompanhar depois')
+
+    buttons[1].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('renderiza filtro de categorias com estado ativo', async () => {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1165,7 +1165,8 @@ describe('menu components', () => {
   it('renderiza rótulo de retirada no passo final de balcão', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 
-    const markup = renderToStaticMarkup(
+    const onClose = vi.fn()
+    const elements = flattenElements(
       React.createElement(MenuDoneStep, {
         orderNumber: 321,
         tableInfo: null,
@@ -1185,17 +1186,26 @@ describe('menu components', () => {
         getStepState: () => 'current',
         cancelOrderLoading: false,
         onCancelOrder: vi.fn(),
-        onClose: vi.fn(),
+        onClose,
       }),
     )
 
-    expect(markup).toContain('Número para retirada')
-    expect(markup).toContain('Pedido pronto para retirada!')
-    expect(markup).toContain('Use este número para retirar o pedido.')
-    expect(markup).toContain('Voltar ao cardápio')
-    expect(markup).toContain('Acompanhe a retirada')
-    expect(markup).toContain('Pagamento na retirada')
-    expect(markup).toContain('#321')
+    expect(getTextContent(elements)).toContain('Número para retirada')
+    expect(getTextContent(elements)).toContain('Pedido pronto para retirada!')
+    expect(getTextContent(elements)).toContain('Use este número para retirar o pedido.')
+    expect(getTextContent(elements)).toContain('Voltar ao cardápio')
+    expect(getTextContent(elements)).toContain('Acompanhe a retirada')
+    expect(getTextContent(elements)).toContain('Pagamento na retirada')
+    expect(getTextContent(elements)).toContain('#321')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(2)
+    expect(getTextContent(buttons[1])).toContain('Voltar ao cardápio')
+    buttons[1].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('aciona handlers e renderiza etapa de entrega no passo final', async () => {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1129,6 +1129,48 @@ describe('menu components', () => {
 
 
 
+
+  it('renderiza bloco de pagamento online reembolsado no passo final', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 79,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-online-refunded',
+          order_number: 79,
+          status: 'cancelled',
+          payment_status: 'refunded',
+          payment_method: 'online',
+          cancelled_reason: 'Pagamento estornado',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [],
+        getStepState: () => 'upcoming',
+        cancelOrderLoading: false,
+        onCancelOrder: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).not.toContain('Pagamento online')
+    expect(getTextContent(elements)).not.toContain('Reembolsado')
+    expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso no pagamento online.')
+    expect(getTextContent(elements)).toContain('Acompanhar depois')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Acompanhar depois')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('renderiza bloco de pagamento online aprovado no passo final', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1663,6 +1663,50 @@ describe('menu components', () => {
 
 
 
+
+  it('não renderiza bloco de pagamento no fluxo de retirada cancelado com reembolso', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 560,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-counter-refunded',
+          order_number: 560,
+          status: 'cancelled',
+          payment_status: 'refunded',
+          payment_method: 'counter',
+          cancelled_reason: 'Estorno manual',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [],
+        getStepState: () => 'upcoming',
+        cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pedido cancelado')
+    expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso no pagamento online.')
+    expect(getTextContent(elements)).not.toContain('Pagamento na retirada')
+    expect(getTextContent(elements)).not.toContain('No local')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Voltar ao cardápio')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('mantém o CTA final funcional no fluxo cancelado com reembolso fora da mesa', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1251,6 +1251,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Voltar ao cardápio')
     expect(getTextContent(elements)).toContain('Acompanhe a retirada')
     expect(getTextContent(elements)).toContain('Pagamento na retirada')
+    expect(getTextContent(elements)).toContain('No local')
     expect(getTextContent(elements)).toContain('#321')
 
     const buttons = elements.filter(

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1147,6 +1147,7 @@ describe('menu components', () => {
     expect(markup).toContain('Número da comanda')
     expect(markup).toContain('Acompanhe a comanda')
     expect(markup).toContain('Estoque indisponível')
+    expect(markup).not.toContain('Cancelar pedido')
     expect(markup).toContain('Reembolso solicitado com sucesso')
     expect(markup).toContain('Mesa 8')
   })

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1325,6 +1325,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Estoque indisponível')
     expect(getTextContent(elements)).not.toContain('Pagamento no local')
     expect(getTextContent(elements)).not.toContain('No local')
+    expect(getTextContent(elements)).not.toContain('Reembolsado')
     expect(getTextContent(elements)).not.toContain('Cancelar pedido')
     expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso')
     expect(getTextContent(elements)).toContain('Mesa 8')

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1244,6 +1244,49 @@ describe('menu components', () => {
     expect(onCancelOrder).not.toHaveBeenCalled()
   })
 
+
+  it('renderiza carregamento na confirmação de recebimento no passo final', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 223,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-confirm-loading',
+          order_number: 223,
+          status: 'ready',
+          payment_status: 'paid',
+          payment_method: 'delivery',
+          delivery_status: 'out_for_delivery',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [
+          { key: 'pending', label: 'Recebido', description: 'Entrou na fila.' },
+          { key: 'confirmed', label: 'Confirmado', description: 'Confirmado.' },
+          { key: 'ready', label: 'Pronto', description: 'Pronto para sair.' },
+        ],
+        getStepState: (key: 'pending' | 'confirmed' | 'ready') =>
+          key === 'ready' ? 'current' : 'done',
+        cancelOrderLoading: false,
+        confirmDeliveryLoading: true,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose: vi.fn(),
+      }),
+    )
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(2)
+    expect(getTextContent(buttons[0])).toContain('Confirmando...')
+    expect(buttons[0].props.disabled).toBe(true)
+    expect(getTextContent(buttons[1])).toContain('Acompanhar depois')
+  })
+
   it('renderiza etapa de entrega pendente sem marcar como concluída', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1323,6 +1323,8 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Número da comanda')
     expect(getTextContent(elements)).toContain('Acompanhe a comanda')
     expect(getTextContent(elements)).toContain('Estoque indisponível')
+    expect(getTextContent(elements)).not.toContain('Pagamento no local')
+    expect(getTextContent(elements)).not.toContain('No local')
     expect(getTextContent(elements)).not.toContain('Cancelar pedido')
     expect(getTextContent(elements)).toContain('Reembolso solicitado com sucesso')
     expect(getTextContent(elements)).toContain('Mesa 8')

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1374,6 +1374,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Atendimento encerrado')
     expect(getTextContent(elements)).not.toContain('Pagamento no local')
     expect(getTextContent(elements)).not.toContain('No local')
+    expect(getTextContent(elements)).not.toContain('Pendente')
     expect(getTextContent(elements)).not.toContain('Reembolso solicitado com sucesso')
     expect(getTextContent(elements)).toContain('Mesa 11')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1461,6 +1461,7 @@ describe('menu components', () => {
 
     expect(loadingMarkup).toContain('Cancelando...')
     expect(cancelledMarkup).toContain('Pedido cancelado')
+    expect(cancelledMarkup).not.toContain('Cancelar pedido')
     expect(cancelledMarkup).not.toContain('Reembolso solicitado com sucesso')
   })
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1127,6 +1127,46 @@ describe('menu components', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
+
+  it('renderiza bloco de pagamento online pendente no passo final', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 77,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-online-pending',
+          order_number: 77,
+          status: 'pending',
+          payment_status: 'pending',
+          payment_method: 'online',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [{ key: 'pending', label: 'Recebido', description: 'Entrou na fila.' }],
+        getStepState: () => 'current',
+        cancelOrderLoading: false,
+        onCancelOrder: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pagamento online')
+    expect(getTextContent(elements)).toContain('Pendente')
+    expect(getTextContent(elements)).toContain('Acompanhar depois')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(2)
+    expect(getTextContent(buttons[1])).toContain('Acompanhar depois')
+    buttons[1].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('renderiza passo final cancelado com mensagem de reembolso', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1491,6 +1491,47 @@ describe('menu components', () => {
     expect(markup).not.toContain('Confirmar recebimento')
   })
 
+
+  it('mantém o CTA final funcional no fluxo cancelado sem reembolso', async () => {
+    const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
+
+    const onClose = vi.fn()
+    const elements = flattenElements(
+      React.createElement(MenuDoneStep, {
+        orderNumber: 558,
+        tableInfo: null,
+        publicOrderStatus: {
+          id: 'order-cancel-default',
+          order_number: 558,
+          status: 'cancelled',
+          payment_status: 'pending',
+          payment_method: 'delivery',
+          created_at: '2026-03-21T00:00:00.000Z',
+          updated_at: '2026-03-21T00:00:00.000Z',
+        },
+        orderSteps: [],
+        getStepState: () => 'upcoming',
+        cancelOrderLoading: false,
+        confirmDeliveryLoading: false,
+        onCancelOrder: vi.fn(),
+        onConfirmDelivery: vi.fn(),
+        onClose,
+      }),
+    )
+
+    expect(getTextContent(elements)).toContain('Pedido cancelado')
+    expect(getTextContent(elements)).not.toContain('Reembolso solicitado com sucesso')
+
+    const buttons = elements.filter(
+      (element) => element.type === 'button' && typeof element.props.onClick === 'function',
+    )
+
+    expect(buttons).toHaveLength(1)
+    expect(getTextContent(buttons[0])).toContain('Acompanhar depois')
+    buttons[0].props.onClick()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it('renderiza cancelamento em andamento e cancelado sem mensagem de reembolso', async () => {
     const { MenuDoneStep } = await import('@/features/menu/MenuDoneStep')
 

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -345,6 +345,17 @@ describe('public menu helpers', () => {
       created_at: '2026-03-21T00:00:00.000Z',
       updated_at: '2026-03-21T00:00:00.000Z',
     })).toBe(false)
+    expect(getDeliveryStepMessage({
+      id: 'order-1',
+      order_number: 42,
+      status: 'ready',
+      payment_status: 'paid',
+      payment_method: 'delivery',
+      delivery_status: 'waiting_dispatch',
+      delivery_driver: null,
+      created_at: '2026-03-21T00:00:00.000Z',
+      updated_at: '2026-03-21T00:00:00.000Z',
+    })).toBe('Seu pedido vai aparecer aqui quando sair para entrega.')
     expect(isDeliveryStepCompleted({
       id: 'order-1',
       order_number: 42,

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -335,6 +335,16 @@ describe('public menu helpers', () => {
     expect(getCustomerBannerState(true, null, false)).toBeNull()
     expect(getAddressSubmitLabel('delivery', true)).toBe('Processando...')
     expect(shouldShowDeliveryStep(null)).toBe(false)
+    expect(shouldShowDeliveryStep({
+      id: 'order-1',
+      order_number: 42,
+      status: 'delivered',
+      payment_status: 'paid',
+      payment_method: 'delivery',
+      delivery_status: 'delivered',
+      created_at: '2026-03-21T00:00:00.000Z',
+      updated_at: '2026-03-21T00:00:00.000Z',
+    })).toBe(false)
     expect(isDeliveryStepCompleted({
       id: 'order-1',
       order_number: 42,

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1126,6 +1126,15 @@ describe('public menu helpers', () => {
       },
       cartOpen: false,
     })).toBe(true)
+    expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Pedido cancelado.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'cancelled',
+        payment_status: 'pending',
+      },
+      cartOpen: false,
+    })).toBe(true)
     expect(isDeliveryStepCompleted(publicOrderStatus)).toBe(true)
     expect(getDeliveryStepMessage(publicOrderStatus)).toContain('com Carlos')
     expect(getDeliveryStepMessage({

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -741,6 +741,7 @@ describe('public menu helpers', () => {
     expect(getCancelledOrderMessage(null)).toBe('O pedido foi cancelado.')
     expect(getCancelSuccessNotice('refunded')).toContain('reembolso')
     expect(getCancelSuccessNotice('paid')).toBe('Pedido cancelado com sucesso.')
+    expect(getCancelSuccessNotice('pending')).toBe('Pedido cancelado com sucesso.')
     expect(buildPublicOrderCancelPayload(' Motivo teste ')).toEqual({
       cancelled_reason: 'Motivo teste',
     })

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -351,6 +351,16 @@ describe('public menu helpers', () => {
       status: 'ready',
       payment_status: 'paid',
       payment_method: 'delivery',
+      delivery_status: 'waiting_dispatch',
+      created_at: '2026-03-21T00:00:00.000Z',
+      updated_at: '2026-03-21T00:00:00.000Z',
+    })).toBe(false)
+    expect(isDeliveryStepCompleted({
+      id: 'order-1',
+      order_number: 42,
+      status: 'ready',
+      payment_status: 'paid',
+      payment_method: 'delivery',
       delivery_status: 'delivered',
       created_at: '2026-03-21T00:00:00.000Z',
       updated_at: '2026-03-21T00:00:00.000Z',

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -721,6 +721,7 @@ describe('public menu helpers', () => {
     expect(getPaymentStatusLabel('pending')).toBe('Pendente')
     expect(getPaymentStatusLabel('pending', 'delivery')).toBe('Na entrega')
     expect(getPaymentStatusLabel('pending', 'counter')).toBe('No local')
+    expect(getPaymentStatusLabel('pending', 'table')).toBe('No local')
     expect(getPublicOrderTrackingMessage({
       ...publicOrderStatus,
       status: 'confirmed',

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1117,6 +1117,15 @@ describe('public menu helpers', () => {
       },
       cartOpen: false,
     })).toBe(true)
+    expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Pedido cancelado e reembolso solicitado com sucesso.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'cancelled',
+        payment_status: 'refunded',
+      },
+      cartOpen: false,
+    })).toBe(true)
     expect(isDeliveryStepCompleted(publicOrderStatus)).toBe(true)
     expect(getDeliveryStepMessage(publicOrderStatus)).toContain('com Carlos')
     expect(getDeliveryStepMessage({

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1087,6 +1087,16 @@ describe('public menu helpers', () => {
       },
       cartOpen: false,
     })).toBe(true)
+    expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Pedido entregue com sucesso.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'delivered',
+        payment_method: 'delivery',
+        delivery_status: 'delivered',
+      },
+      cartOpen: false,
+    })).toBe(true)
     expect(isDeliveryStepCompleted(publicOrderStatus)).toBe(true)
     expect(getDeliveryStepMessage(publicOrderStatus)).toContain('com Carlos')
     expect(getDeliveryStepMessage({

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1060,6 +1060,16 @@ describe('public menu helpers', () => {
       cartOpen: false,
     })).toBe(false)
     expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Seu pedido está pronto para retirada.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'ready',
+        payment_method: 'counter',
+        delivery_status: null,
+      },
+      cartOpen: false,
+    })).toBe(false)
+    expect(shouldShowCheckoutNoticeBanner({
       checkoutNotice: 'Pedido cancelado.',
       publicOrderStatus: {
         ...publicOrderStatus,

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1040,6 +1040,7 @@ describe('public menu helpers', () => {
     expect(shouldShowCancelOrderButton('confirmed')).toBe(true)
     expect(shouldShowCancelOrderButton(undefined)).toBe(false)
     expect(shouldShowCancelOrderButton('ready')).toBe(false)
+    expect(shouldShowCancelOrderButton('cancelled')).toBe(false)
     expect(shouldShowDeliveryStep(publicOrderStatus)).toBe(true)
     expect(shouldShowPublicDeliveryConfirmButton(publicOrderStatus)).toBe(true)
     expect(shouldShowPublicDeliveryConfirmButton({

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1107,6 +1107,16 @@ describe('public menu helpers', () => {
       },
       cartOpen: false,
     })).toBe(true)
+    expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Pedido servido na mesa com sucesso.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'delivered',
+        payment_method: 'table',
+        delivery_status: null,
+      },
+      cartOpen: false,
+    })).toBe(true)
     expect(isDeliveryStepCompleted(publicOrderStatus)).toBe(true)
     expect(getDeliveryStepMessage(publicOrderStatus)).toContain('com Carlos')
     expect(getDeliveryStepMessage({

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1070,6 +1070,16 @@ describe('public menu helpers', () => {
       cartOpen: false,
     })).toBe(false)
     expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Seu pedido está pronto para servir.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'ready',
+        payment_method: 'table',
+        delivery_status: null,
+      },
+      cartOpen: false,
+    })).toBe(false)
+    expect(shouldShowCheckoutNoticeBanner({
       checkoutNotice: 'Pedido cancelado.',
       publicOrderStatus: {
         ...publicOrderStatus,

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1097,6 +1097,16 @@ describe('public menu helpers', () => {
       },
       cartOpen: false,
     })).toBe(true)
+    expect(shouldShowCheckoutNoticeBanner({
+      checkoutNotice: 'Pedido retirado com sucesso.',
+      publicOrderStatus: {
+        ...publicOrderStatus,
+        status: 'delivered',
+        payment_method: 'counter',
+        delivery_status: null,
+      },
+      cartOpen: false,
+    })).toBe(true)
     expect(isDeliveryStepCompleted(publicOrderStatus)).toBe(true)
     expect(getDeliveryStepMessage(publicOrderStatus)).toContain('com Carlos')
     expect(getDeliveryStepMessage({

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -1013,6 +1013,10 @@ describe('public menu helpers', () => {
     expect(shouldShowPublicDeliveryConfirmButton(publicOrderStatus)).toBe(true)
     expect(shouldShowPublicDeliveryConfirmButton({
       ...publicOrderStatus,
+      delivery_status: 'waiting_dispatch',
+    })).toBe(false)
+    expect(shouldShowPublicDeliveryConfirmButton({
+      ...publicOrderStatus,
       status: 'delivered',
     })).toBe(false)
     expect(getCheckoutNoticeTone(publicOrderStatus)).toBe('info')


### PR DESCRIPTION
## Resumo
Este PR consolida os ajustes do Bloco 2 no fluxo público de pedidos, fechando a contextualização do tracking, do passo final e do cancelamento público para delivery, retirada e mesa.

## O que foi ajustado
- contextualiza textos, títulos, mensagens e CTAs do tracking público por tipo de atendimento
- ajusta timeline, card resumido e passo final para estados `ready`, `delivered` e `cancelled`
- evita banners redundantes quando o aviso principal só repete o mesmo estado já mostrado no card resumido
- preserva banners em estados finais relevantes, como entrega concluída e cancelamento
- fortalece o `MenuDoneStep` com cobertura para:
  - loading
  - visibilidade correta de ações
  - bloco de pagamento
  - estados cancelados e reembolsados
- reforça helpers públicos de status, pagamento, timeline e acompanhamento
- corrige a rota pública de cancelamento para devolver o pedido com contexto completo
- ajusta a copy de reembolso no passo final para não falar “pagamento online” em fluxos presenciais

## Impacto esperado
- o tracking público fica coerente do início ao fim da jornada
- delivery, retirada e mesa passam a ter comunicação contextual em todos os estados principais
- o cliente deixa de ver duplicações e mensagens semanticamente incorretas
- o fluxo público mantém o contexto correto após cancelamento

## Validação
- `npm test -- tests/unit/public-menu.test.tsx`
- `npm test -- tests/unit/menu-components.test.tsx`
- `npm test -- tests/unit/menu-client-component.test.tsx`
- `npm test -- tests/integration/public-cancel-route.test.ts`
- `npm run build`
