### PR TITLE
fix: normalize tenant entitlements during billing plan transitions

### DIFF
--- a/app/api/plan/route.ts
+++ b/app/api/plan/route.ts
@@ -1,11 +1,7 @@
 import { createClient } from '@/lib/supabase/server'
-import { PLAN_INCLUDED_FEATURES, PLAN_RESOURCE_LIMITS, type Plan } from '@/features/plans/types'
+import type { Plan } from '@/features/plans/types'
 import { ensureTenantBillingAccessState } from '@/lib/saas-billing'
-import {
-  getAvailableRolesForPlan,
-  PLAN_MAX_USERS,
-  PLAN_ROLE_LIMITS,
-} from '@/lib/rbac'
+import { getTenantPlanSnapshot } from '@/lib/tenant-plan'
 import { NextResponse } from 'next/server'
 
 export async function GET() {
@@ -31,7 +27,7 @@ export async function GET() {
 
     const { data: tenant, error } = await supabase
       .from('tenants')
-      .select('plan, max_users, max_tables, max_products, features, trial_ends_at, plan_ends_at')
+      .select('plan, trial_ends_at, plan_ends_at')
       .eq('id', profile.tenant_id)
       .single()
 
@@ -42,12 +38,7 @@ export async function GET() {
     return NextResponse.json({
       data: {
         ...tenant,
-        plan,
-        max_users: PLAN_MAX_USERS[plan],
-        features: PLAN_INCLUDED_FEATURES[plan],
-        resource_limits: PLAN_RESOURCE_LIMITS[plan],
-        role_limits: PLAN_ROLE_LIMITS[plan],
-        available_roles: getAvailableRolesForPlan(plan),
+        ...getTenantPlanSnapshot(plan),
       },
     })
   } catch (error) {

--- a/lib/saas-billing.ts
+++ b/lib/saas-billing.ts
@@ -1,4 +1,5 @@
 import { PLAN_LABELS, PLAN_PRICES, type Plan } from '@/features/plans/types'
+import { getPersistedTenantPlanSnapshot } from '@/lib/tenant-plan'
 import { createAdminClient } from '@/lib/supabase/admin'
 
 export type BillingPlan = Extract<Plan, 'basic' | 'pro'>
@@ -130,7 +131,7 @@ export async function ensureTenantBillingAccessState(tenantId: string) {
   const { error: tenantError } = await admin
     .from('tenants')
     .update({
-      plan: 'free',
+      ...getPersistedTenantPlanSnapshot('free'),
       next_billing_at: null,
       plan_ends_at: new Date().toISOString(),
     })
@@ -223,7 +224,7 @@ export async function syncTenantFromSaasSubscription(preapproval: MercadoPagoPre
     const { error } = await admin
       .from('tenants')
       .update({
-        plan: effectivePlan,
+        ...getPersistedTenantPlanSnapshot(effectivePlan),
         next_billing_at: preapproval.next_payment_date ?? null,
         plan_ends_at: null,
       })

--- a/lib/tenant-plan.ts
+++ b/lib/tenant-plan.ts
@@ -1,0 +1,43 @@
+import { PLAN_INCLUDED_FEATURES, type Plan } from '@/features/plans/types'
+import { getAvailableRolesForPlan, PLAN_MAX_USERS, PLAN_ROLE_LIMITS } from '@/lib/rbac'
+
+export const PLAN_MAX_TABLES: Record<Plan, number> = {
+  free: 0,
+  basic: 10,
+  pro: -1,
+}
+
+export const PLAN_MAX_PRODUCTS: Record<Plan, number> = {
+  free: 20,
+  basic: -1,
+  pro: -1,
+}
+
+export function getPersistedTenantPlanSnapshot(plan: Plan) {
+  return {
+    plan,
+    max_users: PLAN_MAX_USERS[plan],
+    max_tables: PLAN_MAX_TABLES[plan],
+    max_products: PLAN_MAX_PRODUCTS[plan],
+    features: PLAN_INCLUDED_FEATURES[plan],
+  }
+}
+
+export function getTenantPlanSnapshot(plan: Plan) {
+  return {
+    ...getPersistedTenantPlanSnapshot(plan),
+    resource_limits: plan === 'free'
+      ? {
+          categories: 10,
+          extras: 20,
+          menu_items: 30,
+        }
+      : {
+          categories: -1,
+          extras: -1,
+          menu_items: -1,
+        },
+    role_limits: PLAN_ROLE_LIMITS[plan],
+    available_roles: getAvailableRolesForPlan(plan),
+  }
+}

--- a/tests/integration/api-core-routes.test.ts
+++ b/tests/integration/api-core-routes.test.ts
@@ -112,6 +112,10 @@ describe('api core routes', () => {
     expect(response.status).toBe(200)
     expect(ensureTenantBillingAccessState).toHaveBeenCalledWith('tenant-1')
     expect(json.data.plan).toBe('pro')
+    expect(json.data.max_users).toBe(27)
+    expect(json.data.max_tables).toBe(-1)
+    expect(json.data.max_products).toBe(-1)
+    expect(json.data.features).toContain('reports')
     expect(json.data.available_roles).toContain('owner')
 
     vi.mocked(createClient).mockResolvedValueOnce({

--- a/tests/unit/saas-billing.test.ts
+++ b/tests/unit/saas-billing.test.ts
@@ -212,6 +212,10 @@ describe('saas billing', () => {
 
     expect(tenantUpdate).toMatchObject({
       plan: 'free',
+      max_users: 2,
+      max_tables: 0,
+      max_products: 20,
+      features: ['orders', 'menu', 'payments', 'team'],
       next_billing_at: null,
     })
     expect(subscriptionUpdate).toHaveProperty('metadata')
@@ -369,6 +373,10 @@ describe('saas billing', () => {
     })
     expect(tenantUpdate).toMatchObject({
       plan: 'pro',
+      max_users: 27,
+      max_tables: -1,
+      max_products: -1,
+      features: ['orders', 'menu', 'tables', 'kds', 'stock', 'stock_automation', 'sales', 'payments', 'whatsapp_notifications', 'team', 'reports', 'white_label'],
       next_billing_at: '2026-04-21T00:00:00.000Z',
       plan_ends_at: null,
     })


### PR DESCRIPTION
## Resumo
Este PR inicia o Bloco 3 corrigindo a coerência entre billing, downgrade e limites operacionais persistidos do tenant.

## O que foi ajustado
- centraliza os entitlements por plano em um snapshot único
- aplica esse snapshot ao fazer downgrade automático por fim de período
- aplica esse snapshot ao sincronizar assinatura SaaS autorizada
- ajusta `/api/plan` para sempre responder com limites normalizados do plano

## Impacto esperado
- evita tenants com plano downgraded mas limites antigos ainda ativos
- mantém UI e enforcement server-side alinhados
- reduz inconsistências entre billing state e acesso operacional

## Validação
- `npm test -- tests/unit/saas-billing.test.ts`
- `npm test -- tests/integration/api-core-routes.test.ts`
- `npm run build`
