### PR TITLE
fix: enforce billing downgrade state in tenant auth guards

### DIFF
--- a/lib/auth-guards.ts
+++ b/lib/auth-guards.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { ensureTenantBillingAccessState } from '@/lib/saas-billing'
 import type { EstablishmentRole } from '@/lib/rbac'
 import type { PlanFeature } from '@/features/plans/types'
 import { hasPlanFeature } from '@/features/plans/types'
@@ -24,6 +25,10 @@ export async function getCurrentProfile() {
     return { supabase, user, profile: null }
   }
 
+  const billingState = profile.tenant_id
+    ? await ensureTenantBillingAccessState(profile.tenant_id)
+    : null
+
   const tenant = Array.isArray(profile.tenants)
     ? profile.tenants[0]
     : profile.tenants
@@ -38,7 +43,7 @@ export async function getCurrentProfile() {
       full_name: profile.full_name,
       tenant: tenant
         ? {
-            plan: tenant.plan as 'free' | 'basic' | 'pro',
+            plan: ((billingState?.downgraded ? 'free' : tenant.plan) as 'free' | 'basic' | 'pro'),
             name: tenant.name,
             slug: tenant.slug,
           }

--- a/tests/unit/auth-guards.test.ts
+++ b/tests/unit/auth-guards.test.ts
@@ -4,7 +4,12 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }))
 
+vi.mock('@/lib/saas-billing', () => ({
+  ensureTenantBillingAccessState: vi.fn().mockResolvedValue({ downgraded: false }),
+}))
+
 const { createClient } = await import('@/lib/supabase/server')
+const { ensureTenantBillingAccessState } = await import('@/lib/saas-billing')
 const authGuards = await import('@/lib/auth-guards')
 
 describe('auth guards', () => {
@@ -59,6 +64,36 @@ describe('auth guards', () => {
         slug: 'chefops',
       },
     })
+  })
+
+  it('getCurrentProfile força plano free quando o downgrade acabou de ser aplicado', async () => {
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-downgraded', email: 'downgraded@test.com' } },
+        }),
+      },
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: {
+            id: 'user-downgraded',
+            tenant_id: 'tenant-downgraded',
+            role: 'owner',
+            full_name: 'Owner',
+            tenants: { plan: 'basic', name: 'ChefOps', slug: 'chefops' },
+          },
+        }),
+      })),
+    }
+    vi.mocked(createClient).mockResolvedValue(supabase as never)
+    vi.mocked(ensureTenantBillingAccessState).mockResolvedValueOnce({ downgraded: true } as never)
+
+    const result = await authGuards.getCurrentProfile()
+
+    expect(ensureTenantBillingAccessState).toHaveBeenCalledWith('tenant-downgraded')
+    expect(result.profile?.tenant?.plan).toBe('free')
   })
 
   it('getCurrentProfile trata tenants vazio como tenant nulo', async () => {


### PR DESCRIPTION
## Resumo
Este PR corrige um gap de billing no backend protegido, garantindo que os guards de tenant apliquem o estado efetivo do downgrade antes de avaliar plano e features.

## O que foi ajustado
- integra `ensureTenantBillingAccessState` ao fluxo de `getCurrentProfile`
- força o contexto do tenant para `free` quando o downgrade acabou de ser aplicado
- mantém `requireTenantRoles` e `requireTenantFeature` alinhados com o plano efetivo

## Impacto esperado
- evita rotas protegidas operando com plano antigo até que `/api/plan` seja chamado
- melhora a coerência entre billing state e enforcement server-side
- reduz brechas de acesso após fim do período pago

## Validação
- `npm test -- tests/unit/auth-guards.test.ts`
- `npm test -- tests/unit/saas-billing.test.ts`
- `npm run build`
