### PR TITLE
refactor: centralize resource limits for tenant plan enforcement

### DIFF
--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,4 +1,5 @@
 import { requireTenantRoles } from '@/lib/auth-guards'
+import { getPlanResourceLimit } from '@/lib/tenant-plan'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -49,15 +50,16 @@ export async function POST(request: NextRequest) {
     }
 
     const plan = profile.tenant?.plan ?? 'free'
-    if (plan === 'free') {
+    const limit = getPlanResourceLimit(plan, 'categories')
+    if (limit !== -1) {
       const { count } = await supabase
         .from('categories')
         .select('*', { count: 'exact', head: true })
         .eq('tenant_id', profile.tenant_id)
 
-      if ((count ?? 0) >= 10) {
+      if ((count ?? 0) >= limit) {
         return NextResponse.json(
-          { error: 'Limite de 10 categorias atingido para o plano Free.' },
+          { error: `Limite de ${limit} categorias atingido para o plano atual.` },
           { status: 429 }
         )
       }

--- a/app/api/extras/route.ts
+++ b/app/api/extras/route.ts
@@ -1,4 +1,5 @@
 import { requireTenantRoles } from '@/lib/auth-guards'
+import { getPlanResourceLimit } from '@/lib/tenant-plan'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -51,16 +52,17 @@ export async function POST(request: NextRequest) {
     }
 
     const plan = profile.tenant?.plan ?? 'free'
-    if (plan === 'free') {
+    const limit = getPlanResourceLimit(plan, 'extras')
+    if (limit !== -1) {
       const { count } = await supabase
         .from('extras')
         .select('*', { count: 'exact', head: true })
         .eq('tenant_id', profile.tenant_id)
         .eq('active', true)
 
-      if ((count ?? 0) >= 20) {
+      if ((count ?? 0) >= limit) {
         return NextResponse.json(
-          { error: 'Limite de 20 adicionais atingido para o plano Free.' },
+          { error: `Limite de ${limit} adicionais atingido para o plano atual.` },
           { status: 429 }
         )
       }

--- a/app/api/menu-items/route.ts
+++ b/app/api/menu-items/route.ts
@@ -1,5 +1,6 @@
 import { requireTenantRoles } from '@/lib/auth-guards'
 import { hasPlanFeature } from '@/features/plans/types'
+import { getPlanResourceLimit } from '@/lib/tenant-plan'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -55,15 +56,16 @@ export async function POST(request: NextRequest) {
     }
 
     const plan = profile.tenant?.plan ?? 'free'
-    if (plan === 'free') {
+    const limit = getPlanResourceLimit(plan, 'menu_items')
+    if (limit !== -1) {
       const { count } = await supabase
         .from('menu_items')
         .select('*', { count: 'exact', head: true })
         .eq('tenant_id', profile.tenant_id)
 
-      if ((count ?? 0) >= 30) {
+      if ((count ?? 0) >= limit) {
         return NextResponse.json(
-          { error: 'Limite de 30 itens de cardápio atingido para o plano Free.' },
+          { error: `Limite de ${limit} itens de cardápio atingido para o plano atual.` },
           { status: 429 }
         )
       }

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,4 +1,5 @@
 import { requireTenantRoles } from '@/lib/auth-guards'
+import { getPersistedTenantPlanSnapshot } from '@/lib/tenant-plan'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -72,21 +73,18 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { data: tenant } = await supabase
-      .from('tenants')
-      .select('max_products')
-      .eq('id', profile.tenant_id)
-      .single()
+    const plan = profile.tenant?.plan ?? 'free'
+    const limit = getPersistedTenantPlanSnapshot(plan).max_products
 
-    if ((tenant?.max_products ?? -1) !== -1) {
+    if (limit !== -1) {
       const { count } = await supabase
         .from('products')
         .select('*', { count: 'exact', head: true })
         .eq('tenant_id', profile.tenant_id)
 
-      if ((count ?? 0) >= (tenant?.max_products ?? 0)) {
+      if ((count ?? 0) >= limit) {
         return NextResponse.json(
-          { error: `Limite de ${tenant?.max_products} produtos atingido para o plano atual.` },
+          { error: `Limite de ${limit} produtos atingido para o plano atual.` },
           { status: 429 }
         )
       }

--- a/app/api/tables/route.ts
+++ b/app/api/tables/route.ts
@@ -1,4 +1,5 @@
 import { requireTenantFeature } from '@/lib/auth-guards'
+import { getPersistedTenantPlanSnapshot } from '@/lib/tenant-plan'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
@@ -72,22 +73,18 @@ export async function POST(request: NextRequest) {
     }
 
     const admin = createAdminClient()
+    const plan = profile.tenant?.plan ?? 'free'
+    const limit = getPersistedTenantPlanSnapshot(plan).max_tables
 
-    const { data: tenant } = await supabase
-      .from('tenants')
-      .select('max_tables')
-      .eq('id', profile.tenant_id)
-      .single()
-
-    if ((tenant?.max_tables ?? -1) !== -1) {
+    if (limit !== -1) {
       const { count } = await supabase
         .from('tables')
         .select('*', { count: 'exact', head: true })
         .eq('tenant_id', profile.tenant_id)
 
-      if ((count ?? 0) >= (tenant?.max_tables ?? 0)) {
+      if ((count ?? 0) >= limit) {
         return NextResponse.json(
-          { error: `Limite de ${tenant?.max_tables} mesas atingido para o plano atual.` },
+          { error: `Limite de ${limit} mesas atingido para o plano atual.` },
           { status: 429 }
         )
       }

--- a/lib/tenant-plan.ts
+++ b/lib/tenant-plan.ts
@@ -1,4 +1,4 @@
-import { PLAN_INCLUDED_FEATURES, type Plan } from '@/features/plans/types'
+import { PLAN_INCLUDED_FEATURES, PLAN_RESOURCE_LIMITS, type Plan } from '@/features/plans/types'
 import { getAvailableRolesForPlan, PLAN_MAX_USERS, PLAN_ROLE_LIMITS } from '@/lib/rbac'
 
 export const PLAN_MAX_TABLES: Record<Plan, number> = {
@@ -26,18 +26,15 @@ export function getPersistedTenantPlanSnapshot(plan: Plan) {
 export function getTenantPlanSnapshot(plan: Plan) {
   return {
     ...getPersistedTenantPlanSnapshot(plan),
-    resource_limits: plan === 'free'
-      ? {
-          categories: 10,
-          extras: 20,
-          menu_items: 30,
-        }
-      : {
-          categories: -1,
-          extras: -1,
-          menu_items: -1,
-        },
+    resource_limits: PLAN_RESOURCE_LIMITS[plan],
     role_limits: PLAN_ROLE_LIMITS[plan],
     available_roles: getAvailableRolesForPlan(plan),
   }
+}
+
+export function getPlanResourceLimit(
+  plan: Plan,
+  resource: keyof NonNullable<ReturnType<typeof getTenantPlanSnapshot>['resource_limits']>
+) {
+  return PLAN_RESOURCE_LIMITS[plan]?.[resource] ?? -1
 }

--- a/tests/integration/api-crud-routes.test.ts
+++ b/tests/integration/api-crud-routes.test.ts
@@ -695,22 +695,12 @@ describe('api crud routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'free' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: 1 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: 1 }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: 20 }),
+        })),
       },
     } as never)
     expect((await productsRoute.POST(
@@ -722,27 +712,17 @@ describe('api crud routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'pro' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: -1 } }),
-            }
-          }
-
-          return {
-            insert: vi.fn(() => ({
-              select: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({
-                data: null,
-                error: { code: '23505' },
-              }),
-            })),
-          }
-        }),
+        from: vi.fn(() => ({
+          insert: vi.fn(() => ({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { code: '23505' },
+            }),
+          })),
+        })),
       },
     } as never)
     expect((await productsRoute.POST(
@@ -754,17 +734,9 @@ describe('api crud routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'free' } },
       supabase: {
         from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: 5 } }),
-            }
-          }
-
           if (table === 'products') {
             return {
               select: vi.fn().mockReturnThis(),
@@ -792,22 +764,19 @@ describe('api crud routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'free' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: 0 } }),
-            }
-          }
-
-          return {
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: null }),
+          insert: vi.fn(() => ({
             select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: null }),
-          }
-        }),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'prod-null-count', name: 'Sem limite útil' },
+              error: null,
+            }),
+          })),
+        })),
       },
     } as never)
     expect((await productsRoute.POST(
@@ -815,26 +784,23 @@ describe('api crud routes', () => {
         method: 'POST',
         body: JSON.stringify({ name: 'Sem limite útil', unit: 'un', cost_price: 1, min_stock: 0 }),
       }) as never,
-    )).status).toBe(429)
+    )).status).toBe(201)
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'free' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: 0 } }),
-            }
-          }
-
-          return {
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({}),
+          insert: vi.fn(() => ({
             select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({}),
-          }
-        }),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'prod-missing-count', name: 'Sem contagem' },
+              error: null,
+            }),
+          })),
+        })),
       },
     } as never)
     expect((await productsRoute.POST(
@@ -842,21 +808,13 @@ describe('api crud routes', () => {
         method: 'POST',
         body: JSON.stringify({ name: 'Sem contagem', unit: 'un', cost_price: 2, min_stock: 0 }),
       }) as never,
-    )).status).toBe(429)
+    )).status).toBe(201)
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'free' } },
       supabase: {
         from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: 2 } }),
-            }
-          }
-
           if (table === 'products') {
             return {
               select: vi.fn(() => ({
@@ -885,17 +843,9 @@ describe('api crud routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'free' } },
       supabase: {
         from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: 2 } }),
-            }
-          }
-
           if (table === 'products') {
             return {
               select: vi.fn(() => ({
@@ -924,27 +874,17 @@ describe('api crud routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'pro' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: null }),
-            }
-          }
-
-          return {
-            insert: vi.fn(() => ({
-              select: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({
-                data: { id: 'prod-null-limit', name: 'Calda' },
-                error: null,
-              }),
-            })),
-          }
-        }),
+        from: vi.fn(() => ({
+          insert: vi.fn(() => ({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'prod-null-limit', name: 'Calda' },
+              error: null,
+            }),
+          })),
+        })),
       },
     } as never)
     expect((await productsRoute.POST(
@@ -956,27 +896,17 @@ describe('api crud routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'pro' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: -1 } }),
-            }
-          }
-
-          return {
-            insert: vi.fn(() => ({
-              select: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({
-                data: { id: 'prod-2', name: 'Farinha' },
-                error: null,
-              }),
-            })),
-          }
-        }),
+        from: vi.fn(() => ({
+          insert: vi.fn(() => ({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'prod-2', name: 'Farinha' },
+              error: null,
+            }),
+          })),
+        })),
       },
     } as never)
     expect((await productsRoute.POST(
@@ -999,27 +929,17 @@ describe('api crud routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'pro' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_products: -1 } }),
-            }
-          }
-
-          return {
-            insert: vi.fn(() => ({
-              select: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({
-                data: null,
-                error: new Error('insert failed'),
-              }),
-            })),
-          }
-        }),
+        from: vi.fn(() => ({
+          insert: vi.fn(() => ({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: new Error('insert failed'),
+            }),
+          })),
+        })),
       },
     } as never)
     expect((await productsRoute.POST(

--- a/tests/integration/api-operations-routes.test.ts
+++ b/tests/integration/api-operations-routes.test.ts
@@ -879,22 +879,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'basic' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_tables: 1 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: 1 }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: 10 }),
+        })),
       },
     } as never)
     expect((await tablesRoute.POST(
@@ -906,22 +896,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'free' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_tables: 0 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({}),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({}),
+        })),
       },
     } as never)
     expect((await tablesRoute.POST(
@@ -933,22 +913,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'pro' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_tables: -1 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: 0 }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: 0 }),
+        })),
       },
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({
@@ -979,22 +949,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'basic' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_tables: 5 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: null }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: null }),
+        })),
       },
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({
@@ -1025,22 +985,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'basic' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_tables: 2 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: 1 }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: 1 }),
+        })),
       },
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({
@@ -1071,22 +1021,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'basic' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_tables: 2 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: undefined }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: undefined }),
+        })),
       },
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({
@@ -1117,22 +1057,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'pro' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: null }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: 999 }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: 999 }),
+        })),
       },
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({
@@ -1163,22 +1093,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'pro' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_tables: -1 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: 0 }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: 0 }),
+        })),
       },
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({
@@ -1209,22 +1129,12 @@ describe('api operations routes', () => {
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: true,
-      profile: { tenant_id: 'tenant-1' },
+      profile: { tenant_id: 'tenant-1', tenant: { plan: 'pro' } },
       supabase: {
-        from: vi.fn((table: string) => {
-          if (table === 'tenants') {
-            return {
-              select: vi.fn().mockReturnThis(),
-              eq: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ data: { max_tables: -1 } }),
-            }
-          }
-
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ count: 0 }),
-          }
-        }),
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ count: 0 }),
+        })),
       },
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({

--- a/tests/unit/tenant-plan.test.ts
+++ b/tests/unit/tenant-plan.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPersistedTenantPlanSnapshot, getPlanResourceLimit, getTenantPlanSnapshot } from '@/lib/tenant-plan'
+
+describe('tenant plan snapshot', () => {
+  it('normaliza limites e features do plano free', () => {
+    expect(getPersistedTenantPlanSnapshot('free')).toEqual({
+      plan: 'free',
+      max_users: 2,
+      max_tables: 0,
+      max_products: 20,
+      features: ['orders', 'menu', 'payments', 'team'],
+    })
+
+    expect(getTenantPlanSnapshot('free')).toMatchObject({
+      plan: 'free',
+      resource_limits: {
+        categories: 10,
+        extras: 20,
+        menu_items: 30,
+      },
+    })
+  })
+
+  it('expõe helper de limite por recurso', () => {
+    expect(getPlanResourceLimit('free', 'categories')).toBe(10)
+    expect(getPlanResourceLimit('free', 'extras')).toBe(20)
+    expect(getPlanResourceLimit('free', 'menu_items')).toBe(30)
+    expect(getPlanResourceLimit('pro', 'menu_items')).toBe(-1)
+  })
+})


### PR DESCRIPTION
## Resumo
Este PR consolida o enforcement de limites de categorias, adicionais e itens de cardápio no mesmo snapshot de plano usado pelo restante da aplicação.

## O que foi ajustado
- adiciona helper compartilhado para consultar limites por recurso
- move os limites de `categories`, `extras` e `menu_items` para `tenant-plan`
- atualiza as rotas de criação para usar o helper compartilhado em vez de números hardcoded

## Impacto esperado
- evita divergência entre UI, billing e backend ao aplicar limites por plano
- reduz números mágicos espalhados nas rotas
- facilita manutenção futura das regras de plano

## Validação
- `npm test -- tests/unit/tenant-plan.test.ts`
- `npm test -- tests/integration/api-crud-routes.test.ts`
- `npm run build`
