### PR TITLE
fix: enforce effective billing plan in user-by-id management route

### DIFF
--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
+import { ensureTenantBillingAccessState } from '@/lib/saas-billing'
 import {
   canAssignRole,
   EstablishmentRole,
@@ -29,6 +30,10 @@ async function getCurrentProfile() {
 
   if (!profile) return null
 
+  const billingState = profile.tenant_id
+    ? await ensureTenantBillingAccessState(profile.tenant_id)
+    : null
+
   const tenant = Array.isArray(profile.tenants)
     ? profile.tenants[0]
     : profile.tenants
@@ -37,7 +42,7 @@ async function getCurrentProfile() {
     id: user.id,
     tenant_id: profile.tenant_id,
     role: profile.role as EstablishmentRole,
-    plan: tenant?.plan as 'free' | 'basic' | 'pro',
+    plan: ((billingState?.downgraded ? 'free' : tenant?.plan) ?? 'free') as 'free' | 'basic' | 'pro',
   }
 }
 

--- a/tests/integration/api-crud-routes.test.ts
+++ b/tests/integration/api-crud-routes.test.ts
@@ -1409,6 +1409,23 @@ describe('api crud routes', () => {
         single: vi.fn().mockResolvedValue({ data: { id: 'owner-1', tenant_id: 'tenant-1', role: 'owner', tenants: { plan: 'basic' } } }),
       })),
     } as never)
+    vi.mocked(ensureTenantBillingAccessState).mockResolvedValueOnce({ downgraded: true } as never)
+    expect((await userByIdRoute.PATCH(
+      new Request('https://chefops.test/api/users/user-2', {
+        method: 'PATCH',
+        body: JSON.stringify({ role: 'owner' }),
+      }) as never,
+      { params: Promise.resolve({ id: 'user-2' }) },
+    )).status).toBe(422)
+
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'owner-1' } } }) },
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { id: 'owner-1', tenant_id: 'tenant-1', role: 'owner', tenants: { plan: 'basic' } } }),
+      })),
+    } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({
       from: vi.fn(() => ({
         select: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Resumo
Este PR fecha a última brecha principal do Bloco 3 na gestão de equipe, alinhando a rota de usuário por id ao plano efetivo do tenant após downgrade.

## O que foi ajustado
- integra `ensureTenantBillingAccessState` ao `getCurrentProfile` local de `/api/users/[id]`
- faz `PATCH` e `DELETE` usarem o plano efetivo ao validar regras de equipe
- adiciona cobertura de integração para downgrade efetivo antes da alteração de role

## Impacto esperado
- evita edição de usuários com permissões incompatíveis logo após downgrade
- mantém `/api/users` e `/api/users/[id]` coerentes entre si
- fecha o enforcement principal de billing no backend de equipe

## Validação
- `npm test -- tests/integration/api-crud-routes.test.ts`
- `npm run build`
