### PR TITLE
fix: enforce effective billing plan for whatsapp order notifications

### DIFF
--- a/lib/order-whatsapp.ts
+++ b/lib/order-whatsapp.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from '@/lib/supabase/admin'
+import { ensureTenantBillingAccessState } from '@/lib/saas-billing'
 import { hasPlanFeature } from '@/features/plans/types'
 
 type OrderWhatsappEventKey =
@@ -224,7 +225,10 @@ export async function sendOrderWhatsappNotification(params: {
     .eq('id', order.tenant_id)
     .single()
 
-  if (!hasPlanFeature((tenant?.plan as 'free' | 'basic' | 'pro') ?? 'free', 'whatsapp_notifications')) {
+  const billingState = await ensureTenantBillingAccessState(order.tenant_id)
+  const effectivePlan = ((billingState?.downgraded ? 'free' : tenant?.plan) ?? 'free') as 'free' | 'basic' | 'pro'
+
+  if (!hasPlanFeature(effectivePlan, 'whatsapp_notifications')) {
     await createNotificationLog({
       orderId: order.id,
       tenantId: order.tenant_id,

--- a/tests/integration/order-whatsapp-send.test.ts
+++ b/tests/integration/order-whatsapp-send.test.ts
@@ -6,7 +6,12 @@ vi.mock('@/lib/supabase/admin', () => ({
   createAdminClient: vi.fn(),
 }))
 
+vi.mock('@/lib/saas-billing', () => ({
+  ensureTenantBillingAccessState: vi.fn().mockResolvedValue({ downgraded: false }),
+}))
+
 const { createAdminClient } = await import('@/lib/supabase/admin')
+const { ensureTenantBillingAccessState } = await import('@/lib/saas-billing')
 const { sendOrderWhatsappNotification } = await import('@/lib/order-whatsapp')
 
 describe('sendOrderWhatsappNotification', () => {
@@ -521,6 +526,61 @@ describe('sendOrderWhatsappNotification', () => {
     await expect(
       sendOrderWhatsappNotification({
         orderId: 'order-tenant-null',
+        eventKey: 'order_confirmed',
+      })
+    ).resolves.toEqual({
+      sent: false,
+      reason: 'feature-not-available',
+    })
+
+    expect(insertedLogs.at(-1)).toMatchObject({
+      status: 'skipped',
+      error_message: 'feature-not-available-for-plan',
+    })
+  })
+
+  it('registra skip quando o billing efetivo já rebaixou o tenant mesmo com plano persistido mais alto', async () => {
+    const insertedLogs: Record<string, unknown>[] = []
+
+    vi.mocked(createAdminClient).mockReturnValue(
+      createMockSupabaseClient({
+        order_notifications: (state) => {
+          if (state.operation === 'select') {
+            return { data: null, error: null }
+          }
+
+          insertedLogs.push(state.rows?.[0] as Record<string, unknown>)
+          return { data: null, error: null }
+        },
+        orders: () => ({
+          data: {
+            id: 'order-downgraded',
+            tenant_id: 'tenant-1',
+            order_number: 22,
+            customer_name: 'Felipe',
+            customer_phone: '(11) 91234-5678',
+            status: 'confirmed',
+            payment_status: 'paid',
+            refunded_at: null,
+            cancelled_reason: null,
+            total: 50,
+          },
+          error: null,
+        }),
+        tenants: () => ({
+          data: {
+            name: 'ChefOps Pizza',
+            plan: 'basic',
+          },
+          error: null,
+        }),
+      }) as never
+    )
+    vi.mocked(ensureTenantBillingAccessState).mockResolvedValueOnce({ downgraded: true } as never)
+
+    await expect(
+      sendOrderWhatsappNotification({
+        orderId: 'order-downgraded',
         eventKey: 'order_confirmed',
       })
     ).resolves.toEqual({


### PR DESCRIPTION
## Resumo
Este PR alinha o envio de notificações WhatsApp ao plano efetivo do tenant após downgrade.

## O que foi ajustado
- integra `ensureTenantBillingAccessState` ao helper de envio de WhatsApp
- faz a checagem de `whatsapp_notifications` usar o plano efetivo
- adiciona cobertura para o cenário em que o tenant ainda está persistido como `basic`, mas o billing já rebaixou para `free`

## Impacto esperado
- evita envio de WhatsApp indevido após downgrade
- mantém o feature gating coerente com o restante do enforcement server-side do Bloco 3

## Validação
- `npm test -- tests/integration/order-whatsapp-send.test.ts`
- `npm run build`
