### PR TITLE
fix: use effective tenant plan in dashboard access guard

### DIFF
--- a/features/auth/components/DashboardAccessGuard.tsx
+++ b/features/auth/components/DashboardAccessGuard.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useUser } from '@/features/auth/hooks/useUser'
+import { usePlan } from '@/features/plans/hooks/usePlan'
 import { canAccessDashboardPath } from '@/lib/rbac'
 import type { Plan } from '@/features/plans/types'
 
@@ -14,17 +15,19 @@ export default function DashboardAccessGuard({
   const pathname = usePathname()
   const router = useRouter()
   const { user, loading } = useUser()
-  const plan = (user?.profile.tenant?.plan as Plan | null | undefined) ?? null
+  const { data: planData, isLoading: planLoading } = usePlan()
+  const plan = (planData?.plan as Plan | null | undefined) ?? null
+  const permissionsLoading = loading || (!!user && planLoading)
 
   const canAccess = canAccessDashboardPath(user?.profile.role, pathname, plan)
 
   useEffect(() => {
-    if (!loading && !canAccess) {
+    if (!permissionsLoading && !canAccess) {
       router.replace('/dashboard')
     }
-  }, [canAccess, loading, router])
+  }, [canAccess, permissionsLoading, router])
 
-  if (loading) {
+  if (permissionsLoading) {
     return <div className="p-8 text-sm text-slate-400">Carregando permissões...</div>
   }
 

--- a/tests/unit/dashboard-access-guard.test.tsx
+++ b/tests/unit/dashboard-access-guard.test.tsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 const replaceMock = vi.fn()
 const usePathnameMock = vi.fn()
 const useUserMock = vi.fn()
+const usePlanMock = vi.fn()
 
 vi.mock('react', async () => {
   const actualReact = await vi.importActual<typeof import('react')>('react')
@@ -29,6 +30,10 @@ vi.mock('@/features/auth/hooks/useUser', () => ({
   useUser: () => useUserMock(),
 }))
 
+vi.mock('@/features/plans/hooks/usePlan', () => ({
+  usePlan: () => usePlanMock(),
+}))
+
 describe('DashboardAccessGuard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -42,6 +47,7 @@ describe('DashboardAccessGuard', () => {
       user: null,
       loading: true,
     })
+    usePlanMock.mockReturnValue({ data: null, isLoading: false })
 
     const markup = renderToStaticMarkup(
       React.createElement(DashboardAccessGuard, null, 'guard-child')
@@ -63,6 +69,7 @@ describe('DashboardAccessGuard', () => {
       },
       loading: false,
     })
+    usePlanMock.mockReturnValue({ data: { plan: 'basic' }, isLoading: false })
 
     const markup = renderToStaticMarkup(
       React.createElement(DashboardAccessGuard, null, 'guard-child')
@@ -87,6 +94,7 @@ describe('DashboardAccessGuard', () => {
       },
       loading: false,
     })
+    usePlanMock.mockReturnValue({ data: { plan: 'basic' }, isLoading: false })
 
     const markup = renderToStaticMarkup(
       React.createElement(DashboardAccessGuard, null, 'guard-child')
@@ -111,6 +119,7 @@ describe('DashboardAccessGuard', () => {
       },
       loading: false,
     })
+    usePlanMock.mockReturnValue({ data: { plan: 'free' }, isLoading: false })
 
     const markup = renderToStaticMarkup(
       React.createElement(DashboardAccessGuard, null, 'guard-child')
@@ -120,7 +129,7 @@ describe('DashboardAccessGuard', () => {
     expect(replaceMock).toHaveBeenCalledWith('/dashboard')
   })
 
-  it('redireciona quando a rota exige feature e o plano ainda não carregou', async () => {
+  it('mantém loading enquanto o plano efetivo ainda está carregando', async () => {
     const { default: DashboardAccessGuard } = await import('@/features/auth/components/DashboardAccessGuard')
 
     usePathnameMock.mockReturnValue('/comandas')
@@ -133,12 +142,13 @@ describe('DashboardAccessGuard', () => {
       },
       loading: false,
     })
+    usePlanMock.mockReturnValue({ data: null, isLoading: true })
 
     const markup = renderToStaticMarkup(
       React.createElement(DashboardAccessGuard, null, 'guard-child')
     )
 
-    expect(markup).toContain('Redirecionando')
-    expect(replaceMock).toHaveBeenCalledWith('/dashboard')
+    expect(markup).toContain('Carregando permissões')
+    expect(replaceMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Resumo
Este PR alinha o guard de acesso do dashboard ao plano efetivo do tenant, usando a mesma fonte normalizada já adotada no restante do Bloco 3.

## O que foi ajustado
- troca o `DashboardAccessGuard` para usar `usePlan()` em vez do `plan` vindo de `useUser()`
- evita redirecionamento prematuro enquanto o plano ainda está carregando
- atualiza a cobertura unitária e a smoke das páginas

## Impacto esperado
- evita inconsistência visual pós-downgrade no dashboard
- mantém a navegação e o guard alinhados ao plano efetivo
- melhora a UX ao não redirecionar cedo demais

## Validação
- `npm test -- tests/unit/dashboard-access-guard.test.tsx`
- `npm test -- tests/unit/page-smoke.test.tsx`
- `npm run build`
