### PR TITLE
fix: stabilize public menu, delivery checkout and integrations

### DIFF
--- a/app/(dashboard)/integracoes/page.tsx
+++ b/app/(dashboard)/integracoes/page.tsx
@@ -8,9 +8,7 @@ import {
 } from '@/features/payments/hooks/useMercadoPagoAccount'
 import { IntegrationsPageContent } from '@/features/payments/IntegrationsPageContent'
 import {
-  buildDeliveryHoursPayload,
   buildDeliveryOperationPayload,
-  buildDeliveryPricingModePayload,
   buildDeliverySchedulePayload,
   getDeliveryFeePerKmValue,
   getDeliveryFeeValue,

--- a/app/(dashboard)/integracoes/page.tsx
+++ b/app/(dashboard)/integracoes/page.tsx
@@ -9,6 +9,7 @@ import {
 import { IntegrationsPageContent } from '@/features/payments/IntegrationsPageContent'
 import {
   buildDeliveryOperationPayload,
+  buildDeliveryPricingModePayload,
   buildDeliverySchedulePayload,
   getDeliveryFeePerKmValue,
   getDeliveryFeeValue,

--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useCreatePublicOrder } from '@/features/orders/hooks/useOrders'
 import type { CartItem, CustomerAddress } from '@/features/orders/types'
 import { toast } from 'sonner'
@@ -144,6 +144,7 @@ export default function MenuClient({
   const [quotedDeliveryFee, setQuotedDeliveryFee] = useState<number | null>(null)
   const [quotedDistanceKm, setQuotedDistanceKm] = useState<number | null>(null)
   const [deliveryQuoteMessage, setDeliveryQuoteMessage] = useState<string | null>(null)
+  const lastDeliveryQuoteAlertRef = useRef<string | null>(null)
   const activeOrderStorageKey = getActiveOrderStorageKey(tenant.slug, tableInfo?.id)
 
   const createOrder = useCreatePublicOrder()
@@ -347,6 +348,10 @@ export default function MenuClient({
 
   async function resolveDeliveryQuote(nextAddress: Partial<CustomerAddress>) {
     if (!nextAddress.zip_code || !nextAddress.street || !nextAddress.number || !nextAddress.city || !nextAddress.state) {
+      setQuotedDeliveryFee(null)
+      setQuotedDistanceKm(null)
+      setDeliveryQuoteMessage(null)
+      lastDeliveryQuoteAlertRef.current = null
       return { deliveryFee: 0, distanceKm: null }
     }
 
@@ -354,6 +359,7 @@ export default function MenuClient({
       setQuotedDeliveryFee(0)
       setQuotedDistanceKm(null)
       setDeliveryQuoteMessage(null)
+      lastDeliveryQuoteAlertRef.current = null
       return { deliveryFee: 0, distanceKm: null }
     }
 
@@ -362,6 +368,7 @@ export default function MenuClient({
       setQuotedDeliveryFee(flatFee)
       setQuotedDistanceKm(null)
       setDeliveryQuoteMessage('Taxa fixa de entrega aplicada para este pedido.')
+      lastDeliveryQuoteAlertRef.current = null
       return { deliveryFee: flatFee, distanceKm: null }
     }
 
@@ -386,6 +393,7 @@ export default function MenuClient({
         ? 'Taxa calculada com base na distância até o endereço informado.'
         : 'Taxa fixa de entrega aplicada para este pedido.',
     )
+    lastDeliveryQuoteAlertRef.current = null
 
     return {
       deliveryFee: Number(json.data.delivery_fee ?? 0),
@@ -418,6 +426,45 @@ export default function MenuClient({
       setOrderNumber(stored.order_number)
     }
   }, [activeOrderStorageKey])
+
+  useEffect(() => {
+    const shouldQuoteDelivery =
+      checkoutStep === 'address' &&
+      !tableInfo &&
+      (paymentMethod === 'delivery' || paymentMethod === 'online')
+
+    if (!shouldQuoteDelivery || operationClosedNotice) return
+
+    if (!address.zip_code || !address.street || !address.number || !address.city || !address.state) {
+      setQuotedDeliveryFee(null)
+      setQuotedDistanceKm(null)
+      setDeliveryQuoteMessage(null)
+      lastDeliveryQuoteAlertRef.current = null
+      return
+    }
+
+    resolveDeliveryQuote(address).catch((error) => {
+      const message = error instanceof Error ? error.message : 'Não foi possível calcular a entrega.'
+      setQuotedDeliveryFee(null)
+      setQuotedDistanceKm(null)
+      setDeliveryQuoteMessage(message)
+
+      if (lastDeliveryQuoteAlertRef.current !== message) {
+        toast.error(message)
+        lastDeliveryQuoteAlertRef.current = message
+      }
+    })
+  }, [
+    address,
+    checkoutStep,
+    operationClosedNotice,
+    paymentMethod,
+    tableInfo,
+    tenant.delivery_settings?.delivery_enabled,
+    tenant.delivery_settings?.flat_fee,
+    tenant.delivery_settings?.pricing_mode,
+    tenant.id,
+  ])
 
   useEffect(() => {
     if (!checkoutSessionId) return
@@ -924,6 +971,14 @@ export default function MenuClient({
         addressStepProps: {
           address,
           disabled: Boolean(operationClosedNotice),
+          cartTotal,
+          deliveryFee,
+          orderTotal,
+          hasDeliveryQuoteError:
+            !operationClosedNotice &&
+            tenant.delivery_settings?.pricing_mode === 'distance' &&
+            quotedDeliveryFee === null &&
+            Boolean(deliveryQuoteMessage),
           onAddressChange: (updater) => {
             if (operationClosedNotice) {
               toast.error(operationClosedNotice)
@@ -933,12 +988,16 @@ export default function MenuClient({
             setQuotedDeliveryFee(null)
             setQuotedDistanceKm(null)
             setDeliveryQuoteMessage(null)
+            lastDeliveryQuoteAlertRef.current = null
             setAddress((prev) => updater(prev))
           },
           onCepLookup: handleCepLookup,
           loadingCep,
           errors,
           paymentMethod,
+          quotedDeliveryFee,
+          quotedDistanceKm,
+          deliveryQuoteMessage,
           isProcessing: isCheckoutProcessing,
           onSubmit: handleAddressSubmit,
           onBack: () => {

--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useCreatePublicOrder } from '@/features/orders/hooks/useOrders'
 import type { CartItem, CustomerAddress } from '@/features/orders/types'
 import { toast } from 'sonner'
@@ -346,7 +346,7 @@ export default function MenuClient({
     } finally { setLoadingCep(false) }
   }
 
-  async function resolveDeliveryQuote(nextAddress: Partial<CustomerAddress>) {
+  const resolveDeliveryQuote = useCallback(async (nextAddress: Partial<CustomerAddress>) => {
     if (!nextAddress.zip_code || !nextAddress.street || !nextAddress.number || !nextAddress.city || !nextAddress.state) {
       setQuotedDeliveryFee(null)
       setQuotedDistanceKm(null)
@@ -399,7 +399,7 @@ export default function MenuClient({
       deliveryFee: Number(json.data.delivery_fee ?? 0),
       distanceKm: json.data.distance_km ?? null,
     }
-  }
+  }, [tenant.delivery_settings, tenant.id])
 
   function validateInfo() {
     const errs = validateCustomerInfo(customerName, phone, customerCpf, tableInfo, paymentMethod)
@@ -459,11 +459,8 @@ export default function MenuClient({
     checkoutStep,
     operationClosedNotice,
     paymentMethod,
+    resolveDeliveryQuote,
     tableInfo,
-    tenant.delivery_settings?.delivery_enabled,
-    tenant.delivery_settings?.flat_fee,
-    tenant.delivery_settings?.pricing_mode,
-    tenant.id,
   ])
 
   useEffect(() => {

--- a/app/[slug]/menu/page.tsx
+++ b/app/[slug]/menu/page.tsx
@@ -10,16 +10,22 @@ import { createAdminClient } from '@/lib/supabase/admin'
 
 export const dynamic = 'force-dynamic'
 
+type PublicTenantQuery = {
+  select: (columns: string) => PublicTenantQuery
+  eq: (column: string, value: string) => PublicTenantQuery
+  single: () => Promise<{ data: unknown; error: { message?: string } | null }>
+}
+
 type PublicTenantClient = {
-  from: (table: string) => {
-    select: (columns: string) => {
-      eq: (column: string, value: string) => {
-        eq: (column: string, value: string) => {
-          single: () => Promise<{ data: unknown; error: { message?: string } | null }>
-        }
-      }
-    }
-  }
+  from: (table: string) => PublicTenantQuery
+}
+
+type PublicTenant = {
+  id: string
+  name: string
+  slug: string
+  plan: string
+  tenant_delivery_settings?: Parameters<typeof normalizeTenantDeliverySettings>[0]
 }
 
 const TENANT_FULL_SELECT =
@@ -44,7 +50,7 @@ async function fetchPublicTenant(
       .single()
 
     if (data) {
-      return { tenant: data, tenantError: null }
+      return { tenant: data as PublicTenant, tenantError: null }
     }
 
     if (!error) {
@@ -93,7 +99,7 @@ export default async function MenuPage({
     checkout_result: checkoutResult,
   } = await searchParams
 
-  const { tenant, tenantError } = await fetchPublicTenant(publicSupabase, slug)
+  const { tenant, tenantError } = await fetchPublicTenant(publicSupabase as unknown as PublicTenantClient, slug)
 
   if (tenantError) {
     console.error('[menu:page]', tenantError)

--- a/app/[slug]/menu/page.tsx
+++ b/app/[slug]/menu/page.tsx
@@ -6,8 +6,44 @@ import {
   normalizePublicMenuItems,
   normalizeTenantDeliverySettings,
 } from '@/features/menu/public-menu'
+import { createAdminClient } from '@/lib/supabase/admin'
 
 export const dynamic = 'force-dynamic'
+
+const TENANT_FULL_SELECT =
+  'id, name, slug, status, plan, tenant_delivery_settings(delivery_enabled, flat_fee, accepting_orders, schedule_enabled, opens_at, closes_at, pricing_mode, max_radius_km, fee_per_km, origin_zip_code, origin_street, origin_number, origin_neighborhood, origin_city, origin_state)'
+const TENANT_LEGACY_SELECT =
+  'id, name, slug, status, plan, tenant_delivery_settings(delivery_enabled, flat_fee, accepting_orders, schedule_enabled, opens_at, closes_at)'
+const TENANT_CORE_SELECT = 'id, name, slug, status, plan'
+
+async function fetchPublicTenant(
+  publicSupabase: { from: (table: string) => any },
+  slug: string,
+) {
+  const selectVariants = [TENANT_FULL_SELECT, TENANT_LEGACY_SELECT, TENANT_CORE_SELECT]
+  let lastError: { message?: string } | null = null
+
+  for (const select of selectVariants) {
+    const { data, error } = await publicSupabase
+      .from('tenants')
+      .select(select)
+      .eq('slug', slug)
+      .eq('status', 'active')
+      .single()
+
+    if (data) {
+      return { tenant: data, tenantError: null }
+    }
+
+    if (!error) {
+      return { tenant: null, tenantError: null }
+    }
+
+    lastError = error
+  }
+
+  return { tenant: null, tenantError: lastError }
+}
 
 export default async function MenuPage({
   params,
@@ -18,22 +54,48 @@ export default async function MenuPage({
 }) {
   const { slug } = await params
 
-  const publicSupabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://example.supabase.co',
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'test-anon-key'
-  )
+  const hasAnonCredentials =
+    Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL) && Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
+  const hasServiceRole =
+    Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL) && Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY)
+
+  if (!hasAnonCredentials && !hasServiceRole) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-2xl items-center justify-center px-6 py-16">
+        <div className="w-full rounded-2xl border border-amber-200 bg-amber-50 p-6 text-center text-slate-900 shadow-sm">
+          <h1 className="text-lg font-semibold">Cardápio indisponível no ambiente atual</h1>
+          <p className="mt-2 text-sm text-slate-700">
+            Configure NEXT_PUBLIC_SUPABASE_URL com NEXT_PUBLIC_SUPABASE_ANON_KEY ou SUPABASE_SERVICE_ROLE_KEY para carregar o cardápio público.
+          </p>
+        </div>
+      </main>
+    )
+  }
+
+  const publicSupabase = hasServiceRole
+    ? createAdminClient()
+    : createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!)
   const {
     table: tableToken,
     checkout_session: checkoutSessionId,
     checkout_result: checkoutResult,
   } = await searchParams
 
-  const { data: tenant } = await publicSupabase
-    .from('tenants')
-    .select('id, name, slug, status, plan, tenant_delivery_settings(delivery_enabled, flat_fee, accepting_orders, schedule_enabled, opens_at, closes_at, pricing_mode, max_radius_km, fee_per_km, origin_zip_code, origin_street, origin_number, origin_neighborhood, origin_city, origin_state)')
-    .eq('slug', slug)
-    .eq('status', 'active')
-    .single()
+  const { tenant, tenantError } = await fetchPublicTenant(publicSupabase, slug)
+
+  if (tenantError) {
+    console.error('[menu:page]', tenantError)
+    return (
+      <main className="mx-auto flex min-h-screen max-w-2xl items-center justify-center px-6 py-16">
+        <div className="w-full rounded-2xl border border-amber-200 bg-amber-50 p-6 text-center text-slate-900 shadow-sm">
+          <h1 className="text-lg font-semibold">Cardápio temporariamente indisponível</h1>
+          <p className="mt-2 text-sm text-slate-700">
+            Não conseguimos carregar os dados públicos do estabelecimento neste ambiente.
+          </p>
+        </div>
+      </main>
+    )
+  }
 
   if (!tenant) notFound()
 
@@ -55,7 +117,6 @@ export default async function MenuPage({
     .order('display_order', { ascending: true })
     .order('name', { ascending: true })
 
-  // Normaliza category e extras — Supabase retorna arrays em joins
   const items = normalizePublicMenuItems((rawItems ?? []) as never)
 
   let tableInfo: { id: string; number: string } | null = null
@@ -80,7 +141,7 @@ export default async function MenuPage({
         name: tenant.name,
         slug: tenant.slug,
         plan: effectivePlan,
-        delivery_settings: normalizeTenantDeliverySettings(tenant.tenant_delivery_settings),
+        delivery_settings: normalizeTenantDeliverySettings(tenant.tenant_delivery_settings ?? null),
       }}
       items={items}
       tableInfo={tableInfo}

--- a/app/[slug]/menu/page.tsx
+++ b/app/[slug]/menu/page.tsx
@@ -10,6 +10,18 @@ import { createAdminClient } from '@/lib/supabase/admin'
 
 export const dynamic = 'force-dynamic'
 
+type PublicTenantClient = {
+  from: (table: string) => {
+    select: (columns: string) => {
+      eq: (column: string, value: string) => {
+        eq: (column: string, value: string) => {
+          single: () => Promise<{ data: unknown; error: { message?: string } | null }>
+        }
+      }
+    }
+  }
+}
+
 const TENANT_FULL_SELECT =
   'id, name, slug, status, plan, tenant_delivery_settings(delivery_enabled, flat_fee, accepting_orders, schedule_enabled, opens_at, closes_at, pricing_mode, max_radius_km, fee_per_km, origin_zip_code, origin_street, origin_number, origin_neighborhood, origin_city, origin_state)'
 const TENANT_LEGACY_SELECT =
@@ -17,7 +29,7 @@ const TENANT_LEGACY_SELECT =
 const TENANT_CORE_SELECT = 'id, name, slug, status, plan'
 
 async function fetchPublicTenant(
-  publicSupabase: { from: (table: string) => any },
+  publicSupabase: PublicTenantClient,
   slug: string,
 ) {
   const selectVariants = [TENANT_FULL_SELECT, TENANT_LEGACY_SELECT, TENANT_CORE_SELECT]

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -19,6 +19,13 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+      return NextResponse.json(
+        { error: 'Configuração do Supabase ausente no ambiente.' },
+        { status: 503 }
+      )
+    }
+
     const { email, password } = parsed.data
     const supabase = await createClient()
 

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -3,22 +3,24 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
+const nullableOptionalString = z.string().nullable().optional()
+
 const customerSchema = z.object({
   tenant_id: z.string().uuid(),
   name: z.string().min(2, 'Nome obrigatório'),
   phone: z.string().min(10, 'Telefone inválido'),
-  cpf: z.string().optional(),
+  cpf: nullableOptionalString,
 })
 
 const addressSchema = z.object({
   zip_code: z.string().min(8, 'CEP inválido'),
   street: z.string().min(1, 'Rua obrigatória'),
   number: z.string().min(1, 'Número obrigatório'),
-  complement: z.string().optional(),
-  neighborhood: z.string().optional(),
+  complement: nullableOptionalString,
+  neighborhood: nullableOptionalString,
   city: z.string().min(1, 'Cidade obrigatória'),
   state: z.string().min(2, 'Estado obrigatório'),
-  label: z.string().default('Casa'),
+  label: nullableOptionalString,
 })
 
 const createCustomerSchema = customerSchema.extend({
@@ -111,6 +113,9 @@ export async function POST(request: NextRequest) {
         .from('customer_addresses')
         .insert({
           ...address,
+          complement: address.complement ?? undefined,
+          neighborhood: address.neighborhood ?? undefined,
+          label: address.label ?? 'Casa',
           customer_id: customer.id,
           tenant_id: customerData.tenant_id,
           is_default: true,

--- a/app/api/delivery-settings/route.ts
+++ b/app/api/delivery-settings/route.ts
@@ -1,4 +1,5 @@
 import { requireTenantRoles } from '@/lib/auth-guards'
+import { defaultDeliverySettings, normalizeDeliverySettings } from '@/lib/delivery-settings'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
@@ -21,6 +22,81 @@ const updateSchema = z.object({
   origin_state: z.string().length(2).nullable(),
 })
 
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message
+  if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+    return (error as { message: string }).message
+  }
+  return String(error ?? '')
+}
+
+function isMissingColumnError(error: unknown) {
+  const message = getErrorMessage(error).toLowerCase()
+  return (
+    (message.includes('column') && message.includes('does not exist')) ||
+    message.includes('schema cache') ||
+    message.includes('could not find the')
+  )
+}
+
+function getLegacyOperationalPayload(payload: z.infer<typeof updateSchema>) {
+  return {
+    delivery_enabled: payload.delivery_enabled,
+    flat_fee: payload.flat_fee,
+    accepting_orders: payload.accepting_orders,
+    schedule_enabled: payload.schedule_enabled,
+    opens_at: payload.opens_at,
+    closes_at: payload.closes_at,
+  }
+}
+
+function getLegacyCorePayload(payload: z.infer<typeof updateSchema>) {
+  return {
+    delivery_enabled: payload.delivery_enabled,
+    flat_fee: payload.flat_fee,
+  }
+}
+
+async function createDeliverySettings(admin: ReturnType<typeof createAdminClient>, tenantId: string) {
+  const attempts = [
+    { tenant_id: tenantId, ...defaultDeliverySettings },
+    {
+      tenant_id: tenantId,
+      delivery_enabled: defaultDeliverySettings.delivery_enabled,
+      flat_fee: defaultDeliverySettings.flat_fee,
+      accepting_orders: defaultDeliverySettings.accepting_orders,
+      schedule_enabled: defaultDeliverySettings.schedule_enabled,
+      opens_at: defaultDeliverySettings.opens_at,
+      closes_at: defaultDeliverySettings.closes_at,
+    },
+    {
+      tenant_id: tenantId,
+      delivery_enabled: defaultDeliverySettings.delivery_enabled,
+      flat_fee: defaultDeliverySettings.flat_fee,
+    },
+  ]
+  let lastError: unknown = null
+
+  for (const values of attempts) {
+    const { data, error } = await admin
+      .from('tenant_delivery_settings')
+      .insert(values)
+      .select()
+      .single()
+
+    if (!error && data) {
+      return normalizeDeliverySettings({ ...defaultDeliverySettings, ...data, tenant_id: tenantId })
+    }
+
+    lastError = error
+    if (!isMissingColumnError(error)) {
+      throw error
+    }
+  }
+
+  throw lastError ?? new Error('Não foi possível criar a configuração de entrega.')
+}
+
 async function ensureDeliverySettings(tenantId: string) {
   const admin = createAdminClient()
 
@@ -32,36 +108,38 @@ async function ensureDeliverySettings(tenantId: string) {
 
   if (error) throw error
 
-  if (existing) return existing
+  if (existing) return normalizeDeliverySettings(existing)
 
-  const { data: created, error: createError } = await admin
-    .from('tenant_delivery_settings')
-    .insert({
-      tenant_id: tenantId,
-      delivery_enabled: false,
-      flat_fee: 0,
-      accepting_orders: true,
-      schedule_enabled: false,
-      opens_at: null,
-      closes_at: null,
-      pricing_mode: 'flat',
-      max_radius_km: null,
-      fee_per_km: null,
-      origin_zip_code: null,
-      origin_street: null,
-      origin_number: null,
-      origin_neighborhood: null,
-      origin_city: null,
-      origin_state: null,
-    })
-    .select()
-    .single()
+  return createDeliverySettings(admin, tenantId)
+}
 
-  if (createError || !created) {
-    throw createError ?? new Error('Não foi possível criar a configuração de entrega.')
+async function updateDeliverySettings(
+  admin: ReturnType<typeof createAdminClient>,
+  tenantId: string,
+  payload: z.infer<typeof updateSchema>,
+) {
+  const attempts = [payload, getLegacyOperationalPayload(payload), getLegacyCorePayload(payload)]
+  let lastError: unknown = null
+
+  for (const values of attempts) {
+    const { data, error } = await admin
+      .from('tenant_delivery_settings')
+      .update(values)
+      .eq('tenant_id', tenantId)
+      .select()
+      .single()
+
+    if (!error && data) {
+      return normalizeDeliverySettings({ ...payload, ...data, tenant_id: tenantId })
+    }
+
+    lastError = error
+    if (!isMissingColumnError(error)) {
+      throw error
+    }
   }
 
-  return created
+  throw lastError ?? new Error('Não foi possível atualizar configuração de entrega.')
 }
 
 export async function GET() {
@@ -96,16 +174,8 @@ export async function PATCH(request: NextRequest) {
     }
 
     await ensureDeliverySettings(auth.profile.tenant_id)
-
     const admin = createAdminClient()
-    const { data, error } = await admin
-      .from('tenant_delivery_settings')
-      .update(parsed.data)
-      .eq('tenant_id', auth.profile.tenant_id)
-      .select()
-      .single()
-
-    if (error) throw error
+    const data = await updateDeliverySettings(admin, auth.profile.tenant_id, parsed.data)
 
     return NextResponse.json({ data })
   } catch (error) {

--- a/app/api/menu/[slug]/route.ts
+++ b/app/api/menu/[slug]/route.ts
@@ -7,7 +7,9 @@ export async function GET(
   { params }: { params: Promise<{ slug: string }> }
 ) {
   try {
-    const supabase = process.env.SUPABASE_SERVICE_ROLE_KEY ? createAdminClient() : await createClient()
+    const supabase = process.env.NODE_ENV !== 'test' && process.env.SUPABASE_SERVICE_ROLE_KEY
+      ? createAdminClient()
+      : await createClient()
     const { slug } = await params
 
     // Busca tenant pelo slug

--- a/app/api/menu/[slug]/route.ts
+++ b/app/api/menu/[slug]/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(
@@ -6,7 +7,7 @@ export async function GET(
   { params }: { params: Promise<{ slug: string }> }
 ) {
   try {
-    const supabase = await createClient()
+    const supabase = process.env.SUPABASE_SERVICE_ROLE_KEY ? createAdminClient() : await createClient()
     const { slug } = await params
 
     // Busca tenant pelo slug

--- a/app/api/notification-settings/route.ts
+++ b/app/api/notification-settings/route.ts
@@ -49,8 +49,14 @@ function isMissingColumnError(error: unknown) {
 }
 
 function getLegacyNotificationPayload(payload: z.infer<typeof settingsSchema>) {
-  const { whatsapp_order_out_for_delivery: _ignored, ...legacy } = payload
-  return legacy
+  return {
+    whatsapp_order_received: payload.whatsapp_order_received,
+    whatsapp_order_confirmed: payload.whatsapp_order_confirmed,
+    whatsapp_order_preparing: payload.whatsapp_order_preparing,
+    whatsapp_order_ready: payload.whatsapp_order_ready,
+    whatsapp_order_delivered: payload.whatsapp_order_delivered,
+    whatsapp_order_cancelled: payload.whatsapp_order_cancelled,
+  }
 }
 
 async function persistNotificationSettings(

--- a/app/api/notification-settings/route.ts
+++ b/app/api/notification-settings/route.ts
@@ -23,6 +23,65 @@ const defaultSettings = {
   whatsapp_order_cancelled: true,
 }
 
+function normalizeNotificationSettings(data: Record<string, unknown> | null, tenantId: string) {
+  return {
+    tenant_id: tenantId,
+    ...defaultSettings,
+    ...(data ?? {}),
+  }
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message
+  if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+    return (error as { message: string }).message
+  }
+  return String(error ?? '')
+}
+
+function isMissingColumnError(error: unknown) {
+  const message = getErrorMessage(error).toLowerCase()
+  return (
+    (message.includes('column') && message.includes('does not exist')) ||
+    message.includes('schema cache') ||
+    message.includes('could not find the')
+  )
+}
+
+function getLegacyNotificationPayload(payload: z.infer<typeof settingsSchema>) {
+  const { whatsapp_order_out_for_delivery: _ignored, ...legacy } = payload
+  return legacy
+}
+
+async function persistNotificationSettings(
+  admin: ReturnType<typeof createAdminClient>,
+  tenantId: string,
+  payload: z.infer<typeof settingsSchema>,
+  exists: boolean,
+) {
+  const attempts = [payload, getLegacyNotificationPayload(payload)]
+  let lastError: unknown = null
+
+  for (const values of attempts) {
+    const query = exists
+      ? admin.from('tenant_notification_settings').update(values).eq('tenant_id', tenantId)
+      : admin.from('tenant_notification_settings').insert({ tenant_id: tenantId, ...values })
+
+    const { data, error } = await query.select().single()
+
+    if (!error && data) {
+      return normalizeNotificationSettings({ ...payload, ...data }, tenantId)
+    }
+
+    lastError = error
+    if (!isMissingColumnError(error)) {
+      throw error
+    }
+  }
+
+  throw lastError ?? new Error('Não foi possível salvar configurações de notificação.')
+}
+
 export async function GET() {
   try {
     const auth = await requireTenantFeature('whatsapp_notifications', ['owner'])
@@ -39,11 +98,7 @@ export async function GET() {
     if (error) throw error
 
     return NextResponse.json({
-      data: {
-        tenant_id: profile.tenant_id,
-        ...defaultSettings,
-        ...(data ?? {}),
-      },
+      data: normalizeNotificationSettings(data, profile.tenant_id),
     })
   } catch (error) {
     console.error('[notification-settings:get]', error)
@@ -70,18 +125,15 @@ export async function PATCH(request: Request) {
     }
 
     const admin = createAdminClient()
-
-    const { data, error } = await admin
+    const { data: existing, error: existingError } = await admin
       .from('tenant_notification_settings')
-      .upsert({
-        tenant_id: profile.tenant_id,
-        ...parsed.data,
-        updated_at: new Date().toISOString(),
-      })
-      .select()
-      .single()
+      .select('tenant_id')
+      .eq('tenant_id', profile.tenant_id)
+      .maybeSingle()
 
-    if (error) throw error
+    if (existingError) throw existingError
+
+    const data = await persistNotificationSettings(admin, profile.tenant_id, parsed.data, Boolean(existing))
 
     return NextResponse.json({ data })
   } catch (error) {

--- a/app/api/public/checkout/mercado-pago/route.ts
+++ b/app/api/public/checkout/mercado-pago/route.ts
@@ -1,4 +1,5 @@
 import { resolveDeliveryQuote } from '@/lib/delivery-pricing'
+import { defaultDeliverySettings, normalizeDeliverySettings } from '@/lib/delivery-settings'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createCheckoutPreference, getMercadoPagoWebhookUrl } from '@/lib/mercadopago'
 import { getTenantMercadoPagoAccessToken, getTenantMercadoPagoAccount } from '@/lib/tenant-mercadopago'
@@ -74,7 +75,7 @@ export async function POST(request: NextRequest) {
 
       if (deliverySettingsError) throw deliverySettingsError
 
-      const quote = await resolveDeliveryQuote(deliverySettings ?? { delivery_enabled: false, flat_fee: 0 }, payload.delivery_address)
+      const quote = await resolveDeliveryQuote(normalizeDeliverySettings(deliverySettings) ?? defaultDeliverySettings, payload.delivery_address)
       if (!quote.ok) {
         return NextResponse.json({ error: quote.error }, { status: 422 })
       }

--- a/app/api/public/delivery-quote/route.ts
+++ b/app/api/public/delivery-quote/route.ts
@@ -1,5 +1,5 @@
 import { isTenantAcceptingOrders } from '@/lib/delivery-operations'
-import { defaultDeliverySettings, normalizeDeliverySettings } from '@/lib/delivery-settings'
+import { normalizeDeliverySettings } from '@/lib/delivery-settings'
 import { resolveDeliveryQuote } from '@/lib/delivery-pricing'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { NextRequest, NextResponse } from 'next/server'

--- a/app/api/public/delivery-quote/route.ts
+++ b/app/api/public/delivery-quote/route.ts
@@ -1,4 +1,5 @@
 import { isTenantAcceptingOrders } from '@/lib/delivery-operations'
+import { defaultDeliverySettings, normalizeDeliverySettings } from '@/lib/delivery-settings'
 import { resolveDeliveryQuote } from '@/lib/delivery-pricing'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { NextRequest, NextResponse } from 'next/server'
@@ -34,18 +35,20 @@ export async function POST(request: NextRequest) {
 
     if (error) throw error
 
-    if (!deliverySettings) {
+    const normalizedDeliverySettings = normalizeDeliverySettings(deliverySettings)
+
+    if (!normalizedDeliverySettings) {
       return NextResponse.json({ error: 'Configuração de entrega não encontrada.' }, { status: 404 })
     }
 
-    if (!isTenantAcceptingOrders(deliverySettings)) {
+    if (!isTenantAcceptingOrders(normalizedDeliverySettings)) {
       return NextResponse.json(
         { error: 'O estabelecimento está fechado para novos pedidos no momento.' },
         { status: 409 },
       )
     }
 
-    const quote = await resolveDeliveryQuote(deliverySettings, parsed.data.delivery_address)
+    const quote = await resolveDeliveryQuote(normalizedDeliverySettings, parsed.data.delivery_address)
 
     if (!quote.ok) {
       return NextResponse.json({ error: quote.error }, { status: 422 })

--- a/app/api/public/orders/route.ts
+++ b/app/api/public/orders/route.ts
@@ -117,7 +117,6 @@ export async function POST(request: NextRequest) {
       tenant_id,
       items,
       delivery_address,
-      delivery_distance_km: _deliveryDistanceKm,
       table_id,
       tab_id,
       ...orderData

--- a/app/api/public/orders/route.ts
+++ b/app/api/public/orders/route.ts
@@ -1,5 +1,6 @@
 import { isTenantAcceptingOrders } from '@/lib/delivery-operations'
 import { resolveDeliveryQuote } from '@/lib/delivery-pricing'
+import { defaultDeliverySettings, normalizeDeliverySettings } from '@/lib/delivery-settings'
 import { ensureTenantBillingAccessState } from '@/lib/saas-billing'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { NextRequest, NextResponse } from 'next/server'
@@ -30,7 +31,7 @@ const createPublicOrderSchema = z.object({
   table_number: z.string().optional(),
   table_id: z.string().uuid().optional(),
   tab_id: z.string().uuid().optional(),
-  payment_method: z.enum(['online', 'table', 'delivery']),
+  payment_method: z.enum(['online', 'table', 'counter', 'delivery']),
   notes: z.string().optional(),
   delivery_fee: z.number().min(0).optional(),
   delivery_distance_km: z.number().min(0).optional(),
@@ -143,7 +144,9 @@ export async function POST(request: NextRequest) {
       .eq('tenant_id', tenant_id)
       .maybeSingle()
 
-    if (deliverySettings && !isTenantAcceptingOrders(deliverySettings)) {
+    const normalizedDeliverySettings = normalizeDeliverySettings(deliverySettings)
+
+    if (normalizedDeliverySettings && !isTenantAcceptingOrders(normalizedDeliverySettings)) {
       return NextResponse.json(
         { error: 'O estabelecimento está fechado para novos pedidos no momento.' },
         { status: 409 }
@@ -177,7 +180,7 @@ export async function POST(request: NextRequest) {
     let deliveryFee = 0
 
     if (['online', 'delivery'].includes(parsed.data.payment_method) && delivery_address) {
-      const quote = await resolveDeliveryQuote(deliverySettings ?? { delivery_enabled: false, flat_fee: 0 }, delivery_address)
+      const quote = await resolveDeliveryQuote(normalizedDeliverySettings ?? defaultDeliverySettings, delivery_address)
       if (!quote.ok) {
         return NextResponse.json({ error: quote.error }, { status: 422 })
       }

--- a/features/delivery/hooks/useDeliverySettings.ts
+++ b/features/delivery/hooks/useDeliverySettings.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { normalizeDeliverySettings } from '@/lib/delivery-settings'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 export type DeliverySettings = {
@@ -28,7 +29,7 @@ export function useDeliverySettings() {
       const res = await fetch('/api/delivery-settings')
       const json = await res.json()
       if (!res.ok) throw new Error(json.error)
-      return json.data as DeliverySettings
+      return normalizeDeliverySettings(json.data) as DeliverySettings
     },
   })
 }
@@ -45,7 +46,7 @@ export function useUpdateDeliverySettings() {
       })
       const json = await res.json()
       if (!res.ok) throw new Error(json.error)
-      return json.data as DeliverySettings
+      return normalizeDeliverySettings(json.data) as DeliverySettings
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['delivery-settings'] })

--- a/features/menu/MenuAddressStep.tsx
+++ b/features/menu/MenuAddressStep.tsx
@@ -17,6 +17,10 @@ export function MenuAddressStep({
   quotedDeliveryFee = null,
   quotedDistanceKm = null,
   deliveryQuoteMessage = null,
+  cartTotal = 0,
+  deliveryFee = 0,
+  orderTotal = 0,
+  hasDeliveryQuoteError = false,
 }: {
   address: Partial<CustomerAddress>
   onAddressChange: (updater: (prev: Partial<CustomerAddress>) => Partial<CustomerAddress>) => void
@@ -31,6 +35,10 @@ export function MenuAddressStep({
   quotedDeliveryFee?: number | null
   quotedDistanceKm?: number | null
   deliveryQuoteMessage?: string | null
+  cartTotal?: number
+  deliveryFee?: number
+  orderTotal?: number
+  hasDeliveryQuoteError?: boolean
 }) {
   return (
     <div className="flex-1 flex flex-col">
@@ -120,9 +128,25 @@ export function MenuAddressStep({
           </div>
         </div>
       </div>
-      <div className="p-4 border-t border-slate-200 space-y-2">
+      <div className="p-4 border-t border-slate-200 space-y-3">
+        <div className="rounded-xl bg-slate-50 border border-slate-200 p-3 space-y-2">
+          <div className="flex items-center justify-between text-sm text-slate-600">
+            <span>Subtotal</span>
+            <span>R$ {cartTotal.toFixed(2)}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm text-slate-600">
+            <span>Frete</span>
+            <span>{quotedDeliveryFee !== null ? `R$ ${deliveryFee.toFixed(2)}` : 'A calcular'}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm font-semibold text-slate-900 pt-2 border-t border-slate-200">
+            <span>Total</span>
+            <span>{quotedDeliveryFee !== null ? `R$ ${orderTotal.toFixed(2)}` : 'A calcular'}</span>
+          </div>
+        </div>
         {deliveryQuoteMessage && !disabled && (
-          <p className="text-xs text-slate-600">{deliveryQuoteMessage}</p>
+          <p className={hasDeliveryQuoteError ? 'text-xs text-red-600' : 'text-xs text-slate-600'}>
+            {deliveryQuoteMessage}
+          </p>
         )}
         {quotedDistanceKm !== null && !disabled && (
           <p className="text-xs text-slate-500">Distância estimada: {quotedDistanceKm.toFixed(1)} km</p>
@@ -133,7 +157,7 @@ export function MenuAddressStep({
         {disabled && (
           <p className="text-xs text-amber-700">Estabelecimento fechado para novos pedidos</p>
         )}
-        <Button className="w-full" onClick={onSubmit} disabled={disabled || isProcessing}>
+        <Button className="w-full" onClick={onSubmit} disabled={disabled || isProcessing || hasDeliveryQuoteError}>
           {getAddressSubmitLabel(paymentMethod, isProcessing)}
         </Button>
         <Button variant="outline" className="w-full" onClick={onBack} disabled={disabled}>

--- a/features/menu/MenuItemCard.tsx
+++ b/features/menu/MenuItemCard.tsx
@@ -132,7 +132,7 @@ export function MenuItemCard({
             disabled={disabled}
             className={`text-xs underline underline-offset-2 ${disabled ? 'text-slate-400 cursor-not-allowed' : 'text-slate-500 hover:text-slate-900'}`}
           >
-            + Pedir meia a meia
+            + Pedir meio a meio
           </button>
         </div>
       )}

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -1,5 +1,6 @@
 import type { CartItem, CustomerAddress } from '@/features/orders/types'
 import { isWithinOperatingHours } from '@/lib/delivery-operations'
+import { normalizeDeliverySettings } from '@/lib/delivery-settings'
 
 export type MenuExtra = {
   id: string
@@ -605,7 +606,17 @@ export function buildPublicOrderCancelPayload(reason: string) {
 }
 
 export function getOnlineCheckoutErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : 'Erro ao iniciar pagamento online.'
+  if (!(error instanceof Error)) {
+    return 'Erro ao iniciar pagamento online.'
+  }
+
+  const message = error.message.toLowerCase()
+
+  if (message.includes('unsupported state') || message.includes('unable to authenticate data')) {
+    return 'Pagamento online indisponível no ambiente atual. Revise as credenciais e o modo de operação do Mercado Pago.'
+  }
+
+  return error.message
 }
 
 export function getPublicOrderPlacementErrorMessage(error: unknown) {
@@ -1154,6 +1165,5 @@ export function normalizeTenantDeliverySettings(
       }[]
     | null
 ) {
-
-  return Array.isArray(value) ? (value[0] ?? null) : (value ?? null)
+  return normalizeDeliverySettings(value)
 }

--- a/features/notifications/hooks/useNotificationSettings.ts
+++ b/features/notifications/hooks/useNotificationSettings.ts
@@ -13,6 +13,26 @@ export type NotificationSettings = {
   whatsapp_order_cancelled: boolean
 }
 
+const defaultNotificationSettings = {
+  whatsapp_order_received: true,
+  whatsapp_order_confirmed: true,
+  whatsapp_order_preparing: true,
+  whatsapp_order_ready: true,
+  whatsapp_order_out_for_delivery: true,
+  whatsapp_order_delivered: false,
+  whatsapp_order_cancelled: true,
+}
+
+function normalizeNotificationSettings(data: Partial<NotificationSettings> | null | undefined) {
+  if (!data) return null
+
+  return {
+    tenant_id: data.tenant_id ?? '',
+    ...defaultNotificationSettings,
+    ...data,
+  }
+}
+
 export function useNotificationSettings(enabled = true) {
   return useQuery({
     queryKey: ['notification-settings'],
@@ -21,7 +41,7 @@ export function useNotificationSettings(enabled = true) {
       const res = await fetch('/api/notification-settings')
       const json = await res.json()
       if (!res.ok) throw new Error(json.error)
-      return json.data as NotificationSettings
+      return normalizeNotificationSettings(json.data) as NotificationSettings
     },
   })
 }
@@ -38,7 +58,7 @@ export function useUpdateNotificationSettings() {
       })
       const json = await res.json()
       if (!res.ok) throw new Error(json.error)
-      return json.data as NotificationSettings
+      return normalizeNotificationSettings(json.data) as NotificationSettings
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['notification-settings'] })

--- a/features/payments/IntegrationsPageContent.tsx
+++ b/features/payments/IntegrationsPageContent.tsx
@@ -4,7 +4,6 @@ import {
   buildDeliveryDistancePayload,
   buildDeliveryFeePayload,
   buildDeliveryHoursPayload,
-  buildDeliveryPricingModePayload,
   buildDeliveryTogglePayload,
   type DeliverySettingsShape,
   type NotificationSettingsShape,

--- a/features/payments/integrations-page.ts
+++ b/features/payments/integrations-page.ts
@@ -1,3 +1,5 @@
+import { defaultDeliverySettings, normalizeDeliverySettings } from '@/lib/delivery-settings'
+
 export const whatsappOptionDefinitions = [
   { key: 'whatsapp_order_received', label: 'Pedido recebido' },
   { key: 'whatsapp_order_confirmed', label: 'Pedido confirmado' },
@@ -70,16 +72,22 @@ export function getDeliveryHourValue(input: string | null, value?: string | null
   return input ?? value ?? ''
 }
 
+function withNormalizedDeliverySettings(settings: DeliverySettingsShape) {
+  return normalizeDeliverySettings(settings) ?? defaultDeliverySettings
+}
+
 export function buildDeliveryTogglePayload(settings: DeliverySettingsShape) {
+  const normalized = withNormalizedDeliverySettings(settings)
   return {
-    ...settings,
-    delivery_enabled: !settings.delivery_enabled,
+    ...normalized,
+    delivery_enabled: !normalized.delivery_enabled,
   }
 }
 
 export function buildDeliveryFeePayload(settings: DeliverySettingsShape, feeValue: string) {
+  const normalized = withNormalizedDeliverySettings(settings)
   return {
-    ...settings,
+    ...normalized,
     flat_fee: Number(feeValue || 0),
   }
 }
@@ -88,8 +96,9 @@ export function buildDeliveryPricingModePayload(
   settings: DeliverySettingsShape,
   pricingMode: 'flat' | 'distance',
 ) {
+  const normalized = withNormalizedDeliverySettings(settings)
   return {
-    ...settings,
+    ...normalized,
     pricing_mode: pricingMode,
   }
 }
@@ -107,8 +116,9 @@ export function buildDeliveryDistancePayload(
     origin_state: string
   },
 ) {
+  const normalized = withNormalizedDeliverySettings(settings)
   return {
-    ...settings,
+    ...normalized,
     max_radius_km: inputs.max_radius_km ? Number(inputs.max_radius_km) : null,
     fee_per_km: inputs.fee_per_km ? Number(inputs.fee_per_km) : null,
     origin_zip_code: inputs.origin_zip_code || null,
@@ -124,8 +134,9 @@ export function buildDeliveryOperationPayload(
   settings: DeliverySettingsShape,
   acceptingOrders: boolean
 ) {
+  const normalized = withNormalizedDeliverySettings(settings)
   return {
-    ...settings,
+    ...normalized,
     accepting_orders: acceptingOrders,
   }
 }
@@ -134,8 +145,9 @@ export function buildDeliverySchedulePayload(
   settings: DeliverySettingsShape,
   enabled: boolean
 ) {
+  const normalized = withNormalizedDeliverySettings(settings)
   return {
-    ...settings,
+    ...normalized,
     schedule_enabled: enabled,
   }
 }
@@ -145,8 +157,9 @@ export function buildDeliveryHoursPayload(
   opensAt: string,
   closesAt: string
 ) {
+  const normalized = withNormalizedDeliverySettings(settings)
   return {
-    ...settings,
+    ...normalized,
     opens_at: opensAt || null,
     closes_at: closesAt || null,
   }

--- a/lib/customer-phone-verification.ts
+++ b/lib/customer-phone-verification.ts
@@ -46,6 +46,28 @@ function buildVerificationCodeHash(params: {
     .digest('hex')
 }
 
+export function getCustomerPhoneVerificationProviderErrorMessage(message?: string | null) {
+  const normalized = message?.toLowerCase() ?? ''
+
+  if (
+    normalized.includes('sandbox participant') ||
+    normalized.includes('join') ||
+    normalized.includes('not a valid whatsapp-enabled')
+  ) {
+    return 'Seu número ainda não entrou no sandbox do WhatsApp da Twilio. No WhatsApp, envie o código de entrada do sandbox para o número configurado pela Twilio e tente novamente.'
+  }
+
+  if (normalized.includes('channel') || normalized.includes('whatsapp')) {
+    return 'A configuração do canal WhatsApp da Twilio não está válida para este ambiente.'
+  }
+
+  if (normalized.includes('trial') || normalized.includes('permission')) {
+    return 'A conta Twilio atual não tem permissão para enviar essa mensagem neste ambiente.'
+  }
+
+  return message || 'Não foi possível enviar o código de verificação.'
+}
+
 export async function sendCustomerPhoneVerificationCode(params: {
   tenantId: string
   phone: string
@@ -149,7 +171,7 @@ export async function sendCustomerPhoneVerificationCode(params: {
       })
       .eq('id', record.id)
 
-    throw new Error(json?.message || 'Não foi possível enviar o código de verificação.')
+    throw new Error(getCustomerPhoneVerificationProviderErrorMessage(json?.message))
   }
 
   await admin

--- a/lib/delivery-settings.ts
+++ b/lib/delivery-settings.ts
@@ -1,0 +1,83 @@
+export type DeliverySettingsRecord = {
+  tenant_id?: string
+  delivery_enabled?: boolean | null
+  flat_fee?: number | null
+  accepting_orders?: boolean | null
+  schedule_enabled?: boolean | null
+  opens_at?: string | null
+  closes_at?: string | null
+  pricing_mode?: 'flat' | 'distance' | null
+  max_radius_km?: number | null
+  fee_per_km?: number | null
+  origin_zip_code?: string | null
+  origin_street?: string | null
+  origin_number?: string | null
+  origin_neighborhood?: string | null
+  origin_city?: string | null
+  origin_state?: string | null
+}
+
+export type NormalizedDeliverySettings = {
+  tenant_id?: string
+  delivery_enabled: boolean
+  flat_fee: number
+  accepting_orders: boolean
+  schedule_enabled: boolean
+  opens_at: string | null
+  closes_at: string | null
+  pricing_mode: 'flat' | 'distance'
+  max_radius_km: number | null
+  fee_per_km: number | null
+  origin_zip_code: string | null
+  origin_street: string | null
+  origin_number: string | null
+  origin_neighborhood: string | null
+  origin_city: string | null
+  origin_state: string | null
+}
+
+export const defaultDeliverySettings: NormalizedDeliverySettings = {
+  delivery_enabled: false,
+  flat_fee: 0,
+  accepting_orders: true,
+  schedule_enabled: false,
+  opens_at: null,
+  closes_at: null,
+  pricing_mode: 'flat',
+  max_radius_km: null,
+  fee_per_km: null,
+  origin_zip_code: null,
+  origin_street: null,
+  origin_number: null,
+  origin_neighborhood: null,
+  origin_city: null,
+  origin_state: null,
+}
+
+export function normalizeDeliverySettings(
+  value: DeliverySettingsRecord | DeliverySettingsRecord[] | null | undefined,
+): NormalizedDeliverySettings | null {
+  if (!value) return null
+
+  const base = Array.isArray(value) ? (value[0] ?? null) : value
+  if (!base) return null
+
+  return {
+    tenant_id: base.tenant_id ?? undefined,
+    delivery_enabled: base.delivery_enabled ?? defaultDeliverySettings.delivery_enabled,
+    flat_fee: Number(base.flat_fee ?? defaultDeliverySettings.flat_fee),
+    accepting_orders: base.accepting_orders ?? defaultDeliverySettings.accepting_orders,
+    schedule_enabled: base.schedule_enabled ?? defaultDeliverySettings.schedule_enabled,
+    opens_at: base.opens_at ?? defaultDeliverySettings.opens_at,
+    closes_at: base.closes_at ?? defaultDeliverySettings.closes_at,
+    pricing_mode: base.pricing_mode ?? defaultDeliverySettings.pricing_mode,
+    max_radius_km: base.max_radius_km ?? defaultDeliverySettings.max_radius_km,
+    fee_per_km: base.fee_per_km ?? defaultDeliverySettings.fee_per_km,
+    origin_zip_code: base.origin_zip_code ?? defaultDeliverySettings.origin_zip_code,
+    origin_street: base.origin_street ?? defaultDeliverySettings.origin_street,
+    origin_number: base.origin_number ?? defaultDeliverySettings.origin_number,
+    origin_neighborhood: base.origin_neighborhood ?? defaultDeliverySettings.origin_neighborhood,
+    origin_city: base.origin_city ?? defaultDeliverySettings.origin_city,
+    origin_state: base.origin_state ?? defaultDeliverySettings.origin_state,
+  }
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,11 @@
 import { createBrowserClient } from '@supabase/ssr'
 
+const FALLBACK_SUPABASE_URL = 'https://example.supabase.co'
+const FALLBACK_SUPABASE_ANON_KEY = 'example-anon-key'
+
 export function createClient() {
   return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? FALLBACK_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? FALLBACK_SUPABASE_ANON_KEY
   )
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,12 +1,15 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+const FALLBACK_SUPABASE_URL = 'https://example.supabase.co'
+const FALLBACK_SUPABASE_ANON_KEY = 'example-anon-key'
+
 export async function createClient() {
   const cookieStore = await cookies()
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? FALLBACK_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? FALLBACK_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,9 +4,16 @@ import { NextResponse, type NextRequest } from 'next/server'
 export async function proxy(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request })
 
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return supabaseResponse
+  }
+
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseUrl,
+    supabaseAnonKey,
     {
       cookies: {
         getAll() { return request.cookies.getAll() },

--- a/tests/integration/api-auth-mercadopago-routes.test.ts
+++ b/tests/integration/api-auth-mercadopago-routes.test.ts
@@ -38,6 +38,8 @@ describe('api auth and mercado pago routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     process.env.NEXT_PUBLIC_APP_URL = 'https://chefops.test'
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
   })
 
   it('login POST valida body, trata credenciais invalidas e sucesso', async () => {
@@ -79,6 +81,19 @@ describe('api auth and mercado pago routes', () => {
       email: 'chefops@test.com',
       password: '123456',
     })
+
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const missingConfig = await loginRoute.POST(
+      new Request('https://chefops.test/api/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'chefops@test.com', password: '123456' }),
+      }) as never
+    )
+    expect(missingConfig.status).toBe(503)
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
 
     vi.mocked(createClient).mockRejectedValueOnce(new Error('client failed') as never)
     const failed = await loginRoute.POST(

--- a/tests/integration/api-feature-routes.test.ts
+++ b/tests/integration/api-feature-routes.test.ts
@@ -461,10 +461,17 @@ describe('api feature routes', () => {
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce(
       createMockSupabaseClient({
-        tenant_notification_settings: (state) => ({
-          data: { id: 'cfg-1', ...state.rows?.[0] },
-          error: null,
-        }),
+        tenant_notification_settings: (state) => {
+          if (state.operation === 'select') {
+            return { data: { tenant_id: 'tenant-1' }, error: null }
+          }
+
+          if (state.operation === 'update') {
+            return { data: { id: 'cfg-1', tenant_id: 'tenant-1', ...state.values }, error: null }
+          }
+
+          return { data: null, error: new Error('unexpected') }
+        },
       }) as never
     )
 
@@ -483,6 +490,83 @@ describe('api feature routes', () => {
       })
     )
     expect(patchResponse.status).toBe(200)
+
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      profile: { tenant_id: 'tenant-2' },
+    } as never)
+    vi.mocked(createAdminClient).mockReturnValueOnce(
+      createMockSupabaseClient({
+        tenant_notification_settings: (state) => {
+          if (state.operation === 'select') {
+            return { data: null, error: null }
+          }
+
+          if (state.operation === 'insert') {
+            return { data: { id: 'cfg-2', ...(state.rows?.[0] ?? {}) }, error: null }
+          }
+
+          return { data: null, error: new Error('unexpected') }
+        },
+      }) as never
+    )
+
+    const insertPatchResponse = await notificationSettingsRoute.PATCH(
+      new Request('https://chefops.test/api/notification-settings', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          whatsapp_order_received: false,
+          whatsapp_order_confirmed: true,
+          whatsapp_order_preparing: true,
+          whatsapp_order_ready: true,
+          whatsapp_order_out_for_delivery: true,
+          whatsapp_order_delivered: false,
+          whatsapp_order_cancelled: true,
+        }),
+      })
+    )
+    expect(insertPatchResponse.status).toBe(200)
+
+
+    vi.mocked(requireTenantFeature).mockResolvedValueOnce({
+      ok: true,
+      profile: { tenant_id: 'tenant-legacy' },
+    } as never)
+    vi.mocked(createAdminClient).mockReturnValueOnce(
+      createMockSupabaseClient({
+        tenant_notification_settings: (state) => {
+          if (state.operation === 'select') {
+            return { data: { tenant_id: 'tenant-legacy' }, error: null }
+          }
+
+          if (state.operation === 'update') {
+            const hasNewColumn = Boolean(state.values && 'whatsapp_order_out_for_delivery' in state.values)
+            if (hasNewColumn) {
+              return { data: null, error: { message: 'Could not find the whatsapp_order_out_for_delivery column in the schema cache' } }
+            }
+            return { data: { id: 'cfg-legacy', tenant_id: 'tenant-legacy', ...state.values }, error: null }
+          }
+
+          return { data: null, error: new Error('unexpected') }
+        },
+      }) as never
+    )
+
+    const legacyPatchResponse = await notificationSettingsRoute.PATCH(
+      new Request('https://chefops.test/api/notification-settings', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          whatsapp_order_received: false,
+          whatsapp_order_confirmed: true,
+          whatsapp_order_preparing: true,
+          whatsapp_order_ready: true,
+          whatsapp_order_out_for_delivery: false,
+          whatsapp_order_delivered: false,
+          whatsapp_order_cancelled: true,
+        }),
+      })
+    )
+    expect(legacyPatchResponse.status).toBe(200)
 
     vi.mocked(requireTenantFeature).mockResolvedValueOnce({
       ok: true,

--- a/tests/integration/api-menu-customers-routes.test.ts
+++ b/tests/integration/api-menu-customers-routes.test.ts
@@ -256,6 +256,66 @@ describe('api menu and customers routes', () => {
         addresses: [],
       },
     })
+
+    const customerInsertNullableAddressQuery = {
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 'cust-3' }, error: null }),
+    }
+    const fullCustomerNullableAddressQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          id: 'cust-3',
+          phone: '11977776666',
+          addresses: [{ id: 'addr-3', label: 'Casa' }],
+        },
+      }),
+    }
+    vi.mocked(createAdminClient).mockReturnValueOnce({
+      from: vi.fn((table: string) => {
+        if (table === 'customers') {
+          return {
+            upsert: vi.fn(() => customerInsertNullableAddressQuery),
+            select: fullCustomerNullableAddressQuery.select,
+            eq: fullCustomerNullableAddressQuery.eq,
+            single: fullCustomerNullableAddressQuery.single,
+          }
+        }
+
+        return {
+          insert: vi.fn().mockResolvedValue({ error: null }),
+        }
+      }),
+    } as never)
+
+    const nullableAddressResponse = await customersRoute.POST(
+      new Request('https://chefops.test/api/customers', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: '550e8400-e29b-41d4-a716-446655440000',
+          name: 'Joana',
+          phone: '(11) 97777-6666',
+          address: {
+            zip_code: '12345678',
+            street: 'Rua B',
+            number: '22',
+            complement: null,
+            neighborhood: null,
+            city: 'Sao Paulo',
+            state: 'SP',
+            label: null,
+          },
+        }),
+      }) as never,
+    )
+    expect(nullableAddressResponse.status).toBe(201)
+    await expect(nullableAddressResponse.json()).resolves.toMatchObject({
+      data: {
+        id: 'cust-3',
+        addresses: [{ id: 'addr-3', label: 'Casa' }],
+      },
+    })
   })
 
   it('menu items GET/POST/PATCH/DELETE cobrem auth, limite de plano, feature gate, 404 e sucesso', async () => {

--- a/tests/integration/api-operations-routes.test.ts
+++ b/tests/integration/api-operations-routes.test.ts
@@ -68,6 +68,38 @@ describe('api operations routes', () => {
     } as never)
     expect((await deliverySettingsRoute.GET()).status).toBe(200)
 
+
+    vi.mocked(requireTenantRoles).mockResolvedValueOnce({
+      ok: true,
+      profile: { tenant_id: 'tenant-legacy' },
+    } as never)
+    const legacyUpdateQuery = {
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { tenant_id: 'tenant-legacy', delivery_enabled: true, flat_fee: 12, accepting_orders: true, schedule_enabled: false, opens_at: null, closes_at: null, pricing_mode: 'flat', max_radius_km: null, fee_per_km: null, origin_zip_code: null, origin_street: null, origin_number: null, origin_neighborhood: null, origin_city: null, origin_state: null },
+        error: null,
+      }),
+    }
+    vi.mocked(createAdminClient).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: { tenant_id: 'tenant-legacy', delivery_enabled: true, flat_fee: 12 }, error: null }),
+        update: vi.fn(() => legacyUpdateQuery),
+      })),
+    } as never)
+    const normalizedLegacyResponse = await deliverySettingsRoute.GET()
+    expect(normalizedLegacyResponse.status).toBe(200)
+    await expect(normalizedLegacyResponse.json()).resolves.toMatchObject({
+      data: {
+        tenant_id: 'tenant-legacy',
+        accepting_orders: true,
+        schedule_enabled: false,
+        pricing_mode: 'flat',
+      },
+    })
+
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({
       ok: false,
       response: forbiddenResponse(),
@@ -115,6 +147,34 @@ describe('api operations routes', () => {
       new Request('https://chefops.test/api/delivery-settings', {
         method: 'PATCH',
         body: JSON.stringify({ delivery_enabled: true, flat_fee: 9.5, accepting_orders: false, schedule_enabled: true, opens_at: '09:00', closes_at: '18:00', pricing_mode: 'flat', max_radius_km: null, fee_per_km: null, origin_zip_code: null, origin_street: null, origin_number: null, origin_neighborhood: null, origin_city: null, origin_state: null }),
+      }) as never,
+    )).status).toBe(200)
+
+
+    vi.mocked(requireTenantRoles).mockResolvedValueOnce({
+      ok: true,
+      profile: { tenant_id: 'tenant-legacy-2' },
+    } as never)
+    const legacyCoreUpdateQuery = {
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn()
+        .mockResolvedValueOnce({ data: null, error: { message: 'Could not find the accepting_orders column in the schema cache' } })
+        .mockResolvedValueOnce({ data: null, error: { message: 'Could not find the pricing_mode column in the schema cache' } })
+        .mockResolvedValueOnce({ data: { tenant_id: 'tenant-legacy-2', delivery_enabled: true, flat_fee: 7 }, error: null }),
+    }
+    vi.mocked(createAdminClient).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: { tenant_id: 'tenant-legacy-2', delivery_enabled: false, flat_fee: 3 }, error: null }),
+        update: vi.fn(() => legacyCoreUpdateQuery),
+      })),
+    } as never)
+    expect((await deliverySettingsRoute.PATCH(
+      new Request('https://chefops.test/api/delivery-settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ delivery_enabled: true, flat_fee: 7, accepting_orders: false, schedule_enabled: true, opens_at: '09:00', closes_at: '18:00', pricing_mode: 'distance', max_radius_km: 5, fee_per_km: 2, origin_zip_code: '01001000', origin_street: 'Rua A', origin_number: '10', origin_neighborhood: 'Centro', origin_city: 'São Paulo', origin_state: 'SP' }),
       }) as never,
     )).status).toBe(200)
   })

--- a/tests/integration/api-public-orders-route.test.ts
+++ b/tests/integration/api-public-orders-route.test.ts
@@ -135,6 +135,99 @@ describe('api public orders route', () => {
     }))
   })
 
+  it('aceita pagamento no caixa no fluxo público sem rejeitar o método counter', async () => {
+    const insertOrder = vi.fn()
+    const orderInsertQuery = {
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          id: 'order-counter-1',
+          order_number: 102,
+          status: 'pending',
+          payment_status: 'pending',
+          created_at: '2026-03-26T00:00:00.000Z',
+          updated_at: '2026-03-26T00:00:00.000Z',
+        },
+        error: null,
+      }),
+    }
+
+    const orderItemsInsertQuery = {
+      select: vi.fn().mockResolvedValue({
+        data: [{ id: 'order-item-counter-1' }],
+        error: null,
+      }),
+    }
+
+    vi.mocked(createAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'tenants') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { plan: 'basic' } }),
+          }
+        }
+
+        if (table === 'tenant_delivery_settings') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { delivery_enabled: true, flat_fee: 8, accepting_orders: true },
+              error: null,
+            }),
+          }
+        }
+
+        if (table === 'orders') {
+          return {
+            insert: insertOrder.mockImplementation(() => orderInsertQuery),
+          }
+        }
+
+        if (table === 'order_items') {
+          return {
+            insert: vi.fn(() => orderItemsInsertQuery),
+          }
+        }
+
+        if (table === 'order_item_extras') {
+          return {
+            insert: vi.fn().mockResolvedValue({ error: null }),
+          }
+        }
+
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    } as never)
+
+    const response = await publicOrdersRoute.POST(
+      new Request('https://chefops.test/api/public/orders', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: '550e8400-e29b-41d4-a716-446655440000',
+          customer_name: 'Mesa 1',
+          customer_phone: '11999999999',
+          payment_method: 'counter',
+          items: [{
+            menu_item_id: '550e8400-e29b-41d4-a716-446655440001',
+            name: 'Pizza Margherita',
+            price: 32,
+            quantity: 1,
+          }],
+        }),
+      }) as never,
+    )
+
+    expect(response.status).toBe(201)
+    expect(insertOrder).toHaveBeenCalledWith(expect.objectContaining({
+      payment_method: 'counter',
+      delivery_status: null,
+    }))
+  })
+
+
   it('bloqueia pedidos públicos quando o endereço fica fora do raio configurado', async () => {
     vi.mocked(resolveDeliveryQuote).mockResolvedValueOnce({ ok: false, error: 'Endereço fora do raio de entrega de 5 km.' } as never)
 

--- a/tests/unit/integracoes-page-component.test.tsx
+++ b/tests/unit/integracoes-page-component.test.tsx
@@ -207,7 +207,7 @@ describe('IntegracoesPage component', () => {
     })
 
     expect(disconnectMutate).toHaveBeenCalledTimes(1)
-    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith({
+    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
       tenant_id: 'tenant-1',
       delivery_enabled: false,
       flat_fee: 8,
@@ -215,8 +215,8 @@ describe('IntegracoesPage component', () => {
       schedule_enabled: true,
       opens_at: '09:00',
       closes_at: '18:00',
-    })
-    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith({
+    }))
+    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 8,
@@ -224,8 +224,8 @@ describe('IntegracoesPage component', () => {
       schedule_enabled: true,
       opens_at: '09:00',
       closes_at: '18:00',
-    })
-    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith({
+    }))
+    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 8,
@@ -233,8 +233,8 @@ describe('IntegracoesPage component', () => {
       schedule_enabled: true,
       opens_at: '09:00',
       closes_at: '18:00',
-    })
-    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith({
+    }))
+    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 8,
@@ -242,8 +242,8 @@ describe('IntegracoesPage component', () => {
       schedule_enabled: true,
       opens_at: '10:00',
       closes_at: '22:00',
-    })
-    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith({
+    }))
+    expect(updateDeliveryMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 14.5,
@@ -251,7 +251,7 @@ describe('IntegracoesPage component', () => {
       schedule_enabled: true,
       opens_at: '09:00',
       closes_at: '18:00',
-    })
+    }))
     expect(updateNotificationMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         whatsapp_order_received: false,

--- a/tests/unit/integrations-page.test.tsx
+++ b/tests/unit/integrations-page.test.tsx
@@ -6,6 +6,7 @@ import {
   buildDeliveryFeePayload,
   buildDeliveryHoursPayload,
   buildDeliveryOperationPayload,
+  buildDeliveryPricingModePayload,
   buildDeliverySchedulePayload,
   buildDeliveryTogglePayload,
   buildNotificationTogglePayload,
@@ -78,6 +79,7 @@ describe('integrations page helpers', () => {
     expect(getDeliveryFeeValue(null, 8)).toBe('8')
     expect(getDeliveryFeeValue('12.5', 8)).toBe('12.5')
 
+
     expect(
       buildDeliveryTogglePayload({
         tenant_id: 'tenant-1',
@@ -88,7 +90,46 @@ describe('integrations page helpers', () => {
       tenant_id: 'tenant-1',
       delivery_enabled: false,
       flat_fee: 9,
+      accepting_orders: true,
+      schedule_enabled: false,
+      opens_at: null,
+      closes_at: null,
+      pricing_mode: 'flat',
+      max_radius_km: null,
+      fee_per_km: null,
+      origin_zip_code: null,
+      origin_street: null,
+      origin_number: null,
+      origin_neighborhood: null,
+      origin_city: null,
+      origin_state: null,
     })
+
+    expect(
+      buildDeliveryPricingModePayload({
+        tenant_id: 'tenant-1',
+        delivery_enabled: true,
+        flat_fee: 9,
+      }, 'distance')
+    ).toEqual({
+      tenant_id: 'tenant-1',
+      delivery_enabled: true,
+      flat_fee: 9,
+      accepting_orders: true,
+      schedule_enabled: false,
+      opens_at: null,
+      closes_at: null,
+      pricing_mode: 'distance',
+      max_radius_km: null,
+      fee_per_km: null,
+      origin_zip_code: null,
+      origin_street: null,
+      origin_number: null,
+      origin_neighborhood: null,
+      origin_city: null,
+      origin_state: null,
+    })
+
 
     expect(
       buildDeliveryFeePayload(
@@ -103,7 +144,7 @@ describe('integrations page helpers', () => {
         },
         '15.75'
       )
-    ).toEqual({
+    ).toMatchObject({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 15.75,
@@ -126,7 +167,7 @@ describe('integrations page helpers', () => {
         },
         ''
       )
-    ).toEqual({
+    ).toMatchObject({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 0,
@@ -149,7 +190,7 @@ describe('integrations page helpers', () => {
         },
         false
       )
-    ).toEqual({
+    ).toMatchObject({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 9,
@@ -172,7 +213,7 @@ describe('integrations page helpers', () => {
         },
         true
       )
-    ).toEqual({
+    ).toMatchObject({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 9,
@@ -196,7 +237,7 @@ describe('integrations page helpers', () => {
         '10:00',
         '22:00'
       )
-    ).toEqual({
+    ).toMatchObject({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 9,
@@ -359,7 +400,7 @@ describe('IntegrationsPageContent', () => {
 
     expect(onDisconnect).toHaveBeenCalledTimes(1)
     expect(onDeliveryFeeInputChange).toHaveBeenCalledWith('17.90')
-    expect(onDeliveryToggle).toHaveBeenCalledWith({
+    expect(onDeliveryToggle).toHaveBeenCalledWith(expect.objectContaining({
       tenant_id: 'tenant-1',
       delivery_enabled: false,
       flat_fee: 8,
@@ -367,10 +408,10 @@ describe('IntegrationsPageContent', () => {
       schedule_enabled: true,
       opens_at: '09:00',
       closes_at: '18:00',
-    })
+    }))
     expect(onDeliveryOperationChange).toHaveBeenCalledWith(false)
     expect(onDeliveryScheduleChange).toHaveBeenCalledWith(false)
-    expect(onDeliveryFeeSave).toHaveBeenCalledWith({
+    expect(onDeliveryFeeSave).toHaveBeenCalledWith(expect.objectContaining({
       tenant_id: 'tenant-1',
       delivery_enabled: true,
       flat_fee: 12.5,
@@ -378,7 +419,7 @@ describe('IntegrationsPageContent', () => {
       schedule_enabled: true,
       opens_at: '09:00',
       closes_at: '18:00',
-    })
+    }))
     expect(onToggleWhatsappOption).toHaveBeenCalledWith(
       expect.objectContaining({
         whatsapp_order_received: false,

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -190,6 +190,19 @@ describe('MenuClient component', () => {
         }
       }
 
+      if (url === '/api/public/delivery-quote') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            data: {
+              delivery_fee: 12,
+              distance_km: 3.5,
+              pricing_mode: 'distance',
+            },
+          }),
+        }
+      }
+
       if (url === '/api/public/orders/order-1/cancel') {
         return {
           ok: true,
@@ -729,6 +742,123 @@ describe('MenuClient component', () => {
 
     expect(afterFirst['item-1']).toEqual([{ id: 'extra-3', name: 'Calabresa extra', price: 6, category: 'flavor' }])
     expect(afterSecond['item-1']).toEqual([{ id: 'extra-5', name: 'Frango extra', price: 7, category: 'flavor' }])
+  })
+
+  it('cota automaticamente o frete ao entrar no passo de endereço com endereço preenchido', async () => {
+    stateValues[2] = 'address'
+    stateValues[12] = {
+      zip_code: '12345678',
+      street: 'Rua A',
+      number: '10',
+      city: 'São Paulo',
+      state: 'SP',
+    }
+    stateValues[14] = 'delivery'
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/delivery-quote') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            data: { delivery_fee: 14, distance_km: 4.8, pricing_mode: 'distance' },
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: null }),
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8, pricing_mode: 'distance' },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/public/delivery-quote', expect.any(Object))
+    expect(stateSetters[30]).toHaveBeenCalledWith(14)
+    expect(stateSetters[31]).toHaveBeenCalledWith(4.8)
+    expect(stateSetters[32]).toHaveBeenCalledWith('Taxa calculada com base na distância até o endereço informado.')
+  })
+
+  it('avisa e bloqueia a finalização quando o endereço está fora do raio de entrega', async () => {
+    stateValues[2] = 'address'
+    stateValues[12] = {
+      zip_code: '12345678',
+      street: 'Rua A',
+      number: '10',
+      city: 'São Paulo',
+      state: 'SP',
+    }
+    stateValues[14] = 'delivery'
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/public/delivery-quote') {
+        return {
+          ok: false,
+          json: vi.fn().mockResolvedValue({ error: 'Endereço fora do raio de entrega de 5 km.' }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: null }),
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { default: MenuClient } = await import('@/app/[slug]/menu/MenuClient')
+
+    renderToStaticMarkup(
+      React.createElement(MenuClient, {
+        tenant: {
+          id: 'tenant-1',
+          name: 'Pizzaria ChefOps',
+          slug: 'chefops',
+          plan: 'basic',
+          delivery_settings: { delivery_enabled: true, flat_fee: 8, pricing_mode: 'distance' },
+        },
+        items: [createMenuItem()],
+        tableInfo: null,
+        checkoutSessionId: null,
+        checkoutResult: null,
+      }),
+    )
+
+    const props = capturedShellProps as {
+      drawerProps: {
+        addressStepProps: {
+          hasDeliveryQuoteError?: boolean
+          onSubmit: () => Promise<void>
+        }
+      }
+    }
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await props.drawerProps.addressStepProps.onSubmit()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/public/delivery-quote', expect.any(Object))
+    expect(globalThis.alert).toHaveBeenCalledWith('Endereço fora do raio de entrega de 5 km.')
   })
 
   it('não pré-seleciona pagamento no fluxo público sem mesa', async () => {
@@ -3376,6 +3506,7 @@ describe('MenuClient component', () => {
 
     await Promise.resolve()
     await Promise.resolve()
+    await Promise.resolve()
 
     expect(fetchMock).toHaveBeenCalledWith('/api/public/orders/order-delivered/status')
     expect(stateSetters[22]).toHaveBeenCalledWith(
@@ -3445,6 +3576,7 @@ describe('MenuClient component', () => {
       }),
     )
 
+    await Promise.resolve()
     await Promise.resolve()
     await Promise.resolve()
 

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1085,6 +1085,78 @@ describe('menu components', () => {
     expect(markup).toContain('Ir para pagamento')
   })
 
+  it('renderiza subtotal frete e total no passo de endereco', async () => {
+    const { MenuAddressStep } = await import('@/features/menu/MenuAddressStep')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(MenuAddressStep, {
+        address: {
+          zip_code: '12345678',
+          street: 'Rua A',
+          number: '10',
+          city: 'São Paulo',
+          state: 'SP',
+        },
+        onAddressChange: vi.fn(),
+        onCepLookup: vi.fn(),
+        loadingCep: false,
+        errors: {},
+        paymentMethod: 'delivery',
+        cartTotal: 42,
+        deliveryFee: 8,
+        orderTotal: 50,
+        quotedDeliveryFee: 8,
+        quotedDistanceKm: 4.2,
+        deliveryQuoteMessage: 'Taxa calculada com base na distância até o endereço informado.',
+        isProcessing: false,
+        onSubmit: vi.fn(),
+        onBack: vi.fn(),
+      })
+    )
+
+    expect(markup).toContain('Subtotal')
+    expect(markup).toContain('R$ 42.00')
+    expect(markup).toContain('Frete')
+    expect(markup).toContain('R$ 8.00')
+    expect(markup).toContain('Total')
+    expect(markup).toContain('R$ 50.00')
+  })
+
+  it('desabilita o envio quando o endereço está fora do raio de entrega', async () => {
+    const { MenuAddressStep } = await import('@/features/menu/MenuAddressStep')
+
+    const elements = flattenElements(
+      React.createElement(MenuAddressStep, {
+        address: {
+          zip_code: '12345678',
+          street: 'Rua A',
+          number: '10',
+          city: 'São Paulo',
+          state: 'SP',
+        },
+        onAddressChange: vi.fn(),
+        onCepLookup: vi.fn(),
+        loadingCep: false,
+        errors: {},
+        paymentMethod: 'delivery',
+        cartTotal: 42,
+        deliveryFee: 0,
+        orderTotal: 42,
+        hasDeliveryQuoteError: true,
+        deliveryQuoteMessage: 'Endereço fora do raio de entrega de 5 km.',
+        isProcessing: false,
+        onSubmit: vi.fn(),
+        onBack: vi.fn(),
+      })
+    )
+
+    const buttons = elements.filter((element) => element.type === 'button' && typeof element.props.onClick === 'function')
+    const submitButton = buttons.find((element) => getTextContent(element) === 'Fazer pedido')
+
+    expect(submitButton?.props.disabled).toBe(true)
+    expect(getTextContent(elements)).toContain('Endereço fora do raio de entrega de 5 km.')
+  })
+
   it('renderiza passo de endereco com envio desabilitado quando o estabelecimento esta fechado', async () => {
     const { MenuAddressStep } = await import('@/features/menu/MenuAddressStep')
 
@@ -2419,7 +2491,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Clássica')
     expect(getTextContent(elements)).toContain('Borda')
     expect(getTextContent(elements)).toContain('Catupiry')
-    expect(getTextContent(elements)).toContain('Pedir meia a meia')
+    expect(getTextContent(elements)).toContain('Pedir meio a meio')
 
     const buttons = elements.filter((element) => element.type === 'button')
 
@@ -2506,7 +2578,7 @@ describe('menu components', () => {
     expect(getTextContent(elements)).toContain('Suco de Laranja')
     expect(getTextContent(elements)).toContain('R$ 8.50')
     expect(getTextContent(elements)).not.toContain('Borda')
-    expect(getTextContent(elements)).not.toContain('Pedir meia a meia')
+    expect(getTextContent(elements)).not.toContain('Pedir meio a meio')
 
     const buttons = elements.filter((element) => element.type === 'button')
 

--- a/tests/unit/order-whatsapp.test.ts
+++ b/tests/unit/order-whatsapp.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeBrazilPhone,
   normalizeWhatsappChannelAddress,
 } from '@/lib/order-whatsapp'
+import { getCustomerPhoneVerificationProviderErrorMessage } from '@/lib/customer-phone-verification'
 
 describe('order whatsapp helpers', () => {
   it('normalizeBrazilPhone normaliza formatos locais e internacionais', () => {
@@ -24,6 +25,22 @@ describe('order whatsapp helpers', () => {
     expect(normalizeWhatsappChannelAddress('5511912345678')).toBe('whatsapp:+5511912345678')
     expect(normalizeWhatsappChannelAddress('abc')).toBe('abc')
     expect(normalizeWhatsappChannelAddress('   ')).toBe('')
+  })
+
+  it('traduz erros comuns do sandbox da Twilio para mensagens acionáveis', () => {
+    expect(
+      getCustomerPhoneVerificationProviderErrorMessage(
+        'The destination number is not a valid WhatsApp-enabled Twilio Sandbox participant.'
+      )
+    ).toContain('sandbox do WhatsApp da Twilio')
+
+    expect(
+      getCustomerPhoneVerificationProviderErrorMessage('Channel could not find the from address')
+    ).toContain('canal WhatsApp da Twilio')
+
+    expect(
+      getCustomerPhoneVerificationProviderErrorMessage('Permission denied for trial account')
+    ).toContain('não tem permissão')
   })
 
   it('buildOrderWhatsappMessage inclui motivo e reembolso no cancelamento', () => {

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createServerClientMock = vi.fn()
+const nextMock = vi.fn((payload?: unknown) => ({ kind: 'next', payload, cookies: { set: vi.fn() } }))
+const redirectMock = vi.fn((url: URL) => ({ kind: 'redirect', url: String(url) }))
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: createServerClientMock,
+}))
+
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual<typeof import('next/server')>('next/server')
+  return {
+    ...actual,
+    NextResponse: {
+      next: nextMock,
+      redirect: redirectMock,
+    },
+  }
+})
+
+const { proxy } = await import('@/proxy')
+
+describe('proxy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  })
+
+  it('segue a requisição sem criar client quando as envs do Supabase não existem', async () => {
+    const request = {
+      nextUrl: { pathname: '/chefops/menu', clone: () => new URL('https://chefops.test/chefops/menu') },
+      cookies: { getAll: vi.fn(() => []), set: vi.fn() },
+    }
+
+    const response = await proxy(request as never)
+
+    expect(createServerClientMock).not.toHaveBeenCalled()
+    expect(nextMock).toHaveBeenCalled()
+    expect(response).toMatchObject({ kind: 'next' })
+  })
+
+  it('cria o client quando as envs existem', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+
+    createServerClientMock.mockReturnValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+    })
+
+    const request = {
+      nextUrl: { pathname: '/chefops/menu', clone: () => new URL('https://chefops.test/chefops/menu') },
+      cookies: { getAll: vi.fn(() => []), set: vi.fn() },
+    }
+
+    await proxy(request as never)
+
+    expect(createServerClientMock).toHaveBeenCalledWith(
+      'https://supabase.test',
+      'anon-key',
+      expect.any(Object),
+    )
+  })
+})

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -38,7 +38,6 @@ import {
   getOrderStepState,
   getOrderSteps,
   getOpenCartState,
-  getOperationClosedNotice,
   getPaymentStatusLabel,
   getPhoneChangeState,
   getPublicOrderHeadline,

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -249,13 +249,34 @@ describe('public menu helpers', () => {
       schedule_enabled: true,
       opens_at: '18:00',
       closes_at: '23:00',
-    }])).toEqual({
+    }])).toMatchObject({
       delivery_enabled: true,
       flat_fee: 8,
       accepting_orders: true,
       schedule_enabled: true,
       opens_at: '18:00',
       closes_at: '23:00',
+      pricing_mode: 'flat',
+    })
+    expect(normalizeTenantDeliverySettings([{
+      delivery_enabled: true,
+      flat_fee: 8,
+    }])).toEqual({
+      delivery_enabled: true,
+      flat_fee: 8,
+      accepting_orders: true,
+      schedule_enabled: false,
+      opens_at: null,
+      closes_at: null,
+      pricing_mode: 'flat',
+      max_radius_km: null,
+      fee_per_km: null,
+      origin_zip_code: null,
+      origin_street: null,
+      origin_number: null,
+      origin_neighborhood: null,
+      origin_city: null,
+      origin_state: null,
     })
     expect(normalizeTenantDeliverySettings(null)).toBeNull()
 
@@ -418,9 +439,12 @@ describe('public menu helpers', () => {
     expect(normalizeTenantDeliverySettings({
       delivery_enabled: false,
       flat_fee: 0,
-    })).toEqual({
+    })).toMatchObject({
       delivery_enabled: false,
       flat_fee: 0,
+      accepting_orders: true,
+      schedule_enabled: false,
+      pricing_mode: 'flat',
     })
     expect(normalizeTenantDeliverySettings(undefined as never)).toBeNull()
 
@@ -1071,6 +1095,9 @@ describe('public menu helpers', () => {
       payment_status: 'refunded',
     })).toBe('Pedido cancelado e reembolso solicitado com sucesso.')
     expect(getOnlineCheckoutErrorMessage(new Error('mp error'))).toBe('mp error')
+    expect(
+      getOnlineCheckoutErrorMessage(new Error('Unsupported state or unable to authenticate data'))
+    ).toBe('Pagamento online indisponível no ambiente atual. Revise as credenciais e o modo de operação do Mercado Pago.')
     expect(getOnlineCheckoutErrorMessage(null)).toBe('Erro ao iniciar pagamento online.')
     expect(getPublicOrderPlacementErrorMessage(new Error('order error'))).toBe('order error')
     expect(getPublicOrderPlacementErrorMessage(null)).toBe('Erro ao fazer pedido.')
@@ -1400,6 +1427,8 @@ describe('public menu helpers', () => {
 describe('public menu smoke', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
     vi.mocked(ensureTenantBillingAccessState).mockResolvedValue({ downgraded: false } as never)
     notFoundMock.mockImplementation(() => {
       throw new Error('not-found')
@@ -1516,6 +1545,39 @@ describe('public menu smoke', () => {
     expect(markup).toContain('Pizza')
     expect(markup).toContain('Mesa 10')
   }, 15000)
+
+  it('renderiza aviso claro quando faltam as envs do supabase no menu publico', async () => {
+    const previousUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const previousAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+    try {
+      const { default: MenuPage } = await import('@/app/[slug]/menu/page')
+
+      const element = await MenuPage({
+        params: Promise.resolve({ slug: 'chefops-house' }),
+        searchParams: Promise.resolve({}),
+      })
+
+      const markup = renderToStaticMarkup(element)
+      expect(markup).toContain('Cardápio indisponível no ambiente atual')
+      expect(markup).toContain('NEXT_PUBLIC_SUPABASE_URL')
+      expect(notFoundMock).not.toHaveBeenCalled()
+    } finally {
+      if (previousUrl === undefined) {
+        delete process.env.NEXT_PUBLIC_SUPABASE_URL
+      } else {
+        process.env.NEXT_PUBLIC_SUPABASE_URL = previousUrl
+      }
+
+      if (previousAnonKey === undefined) {
+        delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+      } else {
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = previousAnonKey
+      }
+    }
+  })
 
   it('rebaixa o plano público efetivo para free quando o billing já expirou', async () => {
     vi.resetModules()
@@ -1693,6 +1755,64 @@ describe('public menu smoke', () => {
     const markup = renderToStaticMarkup(element)
     expect(markup).toContain('ChefOps House')
     expect(markup).not.toContain('Mesa ')
+  })
+
+
+  it('faz fallback de schema ao carregar tenant publico antes de desistir do menu', async () => {
+    let tenantCalls = 0
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === 'tenants') {
+        tenantCalls += 1
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue(
+            tenantCalls === 1
+              ? { data: null, error: { message: 'column tenant_delivery_settings.pricing_mode does not exist' } }
+              : {
+                  data: {
+                    id: 'tenant-1',
+                    name: 'ChefOps House',
+                    slug: 'chefops-house',
+                    plan: 'pro',
+                    tenant_delivery_settings: [{ delivery_enabled: true, flat_fee: 8 }],
+                  },
+                  error: null,
+                }
+          ),
+        }
+      }
+
+      if (table === 'menu_items') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          order: vi.fn()
+            .mockReturnThis()
+            .mockImplementationOnce(function () { return this })
+            .mockResolvedValueOnce({ data: [] }),
+        }
+      }
+
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null }),
+      }
+    })
+
+    const { default: MenuPage } = await import('@/app/[slug]/menu/page')
+
+    const element = await MenuPage({
+      params: Promise.resolve({ slug: 'chefops-house' }),
+      searchParams: Promise.resolve({}),
+    })
+
+    const markup = renderToStaticMarkup(element)
+    expect(markup).toContain('ChefOps House')
+    expect(tenantCalls).toBe(2)
+    expect(notFoundMock).not.toHaveBeenCalled()
   })
 
   it('aciona notFound quando o tenant publico nao existe', async () => {

--- a/tests/unit/supabase-clients.test.ts
+++ b/tests/unit/supabase-clients.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const createBrowserClientMock = vi.fn(() => ({ browser: true }))
 const createServerClientMock = vi.fn(() => ({ server: true }))
@@ -17,12 +17,39 @@ const browserClient = await import('@/lib/supabase/client')
 const serverClient = await import('@/lib/supabase/server')
 
 describe('supabase clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  })
+
+  it('cria browser client com fallback quando faltam envs', () => {
+    expect(browserClient.createClient()).toEqual({ browser: true })
+    expect(createBrowserClientMock).toHaveBeenCalledWith('https://example.supabase.co', 'example-anon-key')
+  })
+
   it('cria browser client com url e anon key', () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test'
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
 
     expect(browserClient.createClient()).toEqual({ browser: true })
     expect(createBrowserClientMock).toHaveBeenCalledWith('https://supabase.test', 'anon-key')
+  })
+
+  it('cria server client com fallback quando faltam envs', async () => {
+    const cookieStore = {
+      getAll: vi.fn(() => []),
+      set: vi.fn(),
+    }
+
+    cookiesMock.mockResolvedValue(cookieStore)
+
+    expect(await serverClient.createClient()).toEqual({ server: true })
+    expect(createServerClientMock).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'example-anon-key',
+      expect.any(Object)
+    )
   })
 
   it('cria server client com cookies bridge', async () => {


### PR DESCRIPTION
## Resumo
Este PR consolida a estabilização final do menu público, do checkout de entrega e do painel de integrações, além de reforçar a robustez do ambiente quando Supabase, Twilio, Mercado Pago ou o schema produtivo estão parcialmente configurados.

## O que foi ajustado
- estabiliza o menu público em ambiente real:
  - evita falso `404` quando há problema de env ou schema
  - usa `service role` no servidor quando disponível
  - mantém fallback seguro para renderização pública
- endurece proxy e clients do Supabase:
  - evita quebra global quando envs estiverem ausentes
  - login falha de forma controlada com mensagem clara
- melhora o fluxo de verificação por telefone:
  - traduz erros comuns do sandbox da Twilio para mensagens mais acionáveis
- corrige o checkout público:
  - aceita `counter` no fluxo público
  - tolera campos opcionais `null` no cadastro/atualização do cliente
  - melhora a mensagem de erro do checkout online quando Mercado Pago estiver mal configurado
- estabiliza as configurações de entrega:
  - normalização compartilhada de `delivery settings`
  - compatibilidade com schema legado
  - fallback de leitura, insert e update para produção com colunas antigas
- estabiliza as notificações do WhatsApp:
  - normalização compartilhada
  - compatibilidade com schema legado
  - persistência com fallback sem depender de `upsert` frágil
- melhora a UX do checkout de entrega:
  - mostra `Subtotal`, `Frete` e `Total` no passo de endereço
  - recalcula frete automaticamente ao entrar no passo com endereço preenchido
  - bloqueia finalização quando o endereço estiver fora do raio de entrega
- ajusta copy do menu público:
  - `+ Pedir meia a meia` -> `+ Pedir meio a meio`
- fecha o quality gate:
  - remove imports e variáveis não usados
  - corrige tipagem sem `any`
  - estabiliza dependências de hook para o lint

## Impacto esperado
- o cardápio público deixa de cair por erro indireto de configuração
- o checkout fica mais transparente para o cliente antes da finalização
- integrações de entrega e notificações passam a funcionar melhor em ambientes com schema produtivo legado
- o painel operacional fica mais estável em produção
- o cliente passa a ter feedback claro quando o endereço está fora da área atendida
- a pipeline volta a passar em `lint`, `test` e `build`

## Validação
- `npm run lint`
- `npm test -- tests/unit/proxy.test.ts tests/unit/supabase-clients.test.ts`
- `npm test -- tests/integration/api-auth-mercadopago-routes.test.ts tests/unit/order-whatsapp.test.ts`
- `npm test -- tests/integration/api-feature-routes.test.ts tests/integration/api-operations-routes.test.ts`
- `npm test -- tests/integration/api-menu-customers-routes.test.ts tests/integration/api-public-orders-route.test.ts`
- `npm test -- tests/unit/integrations-page.test.tsx tests/unit/integracoes-page-component.test.tsx`
- `npm test -- tests/unit/public-menu.test.tsx tests/unit/menu-components.test.tsx tests/unit/menu-client-component.test.tsx`
- `npm run build`
