### PR TITLE
feat: implement zip code address lookup and tenant-based shipping calculation

### DIFF
--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -31,6 +31,7 @@ type RegisterForm = z.infer<typeof registerSchema>
 export default function RegisterPage() {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
+  const [loadingZipCode, setLoadingZipCode] = useState(false)
 
   const form = useForm<RegisterForm>({
     resolver: zodResolver(registerSchema),
@@ -52,6 +53,27 @@ export default function RegisterPage() {
 
   function handleTenantNameChange(value: string) {
     form.setValue('tenant_slug', buildTenantSlug(value), { shouldValidate: true })
+  }
+
+  async function handleZipCodeChange(value: string) {
+    const clean = normalizeDigits(value)
+    if (clean.length !== 8) return
+
+    setLoadingZipCode(true)
+
+    try {
+      const res = await fetch(`/api/cep/${clean}`)
+      const json = await res.json()
+
+      if (!res.ok || !json.data) return
+
+      form.setValue('street', json.data.street ?? '', { shouldValidate: true })
+      form.setValue('neighborhood', json.data.neighborhood ?? '', { shouldValidate: true })
+      form.setValue('city', json.data.city ?? '', { shouldValidate: true })
+      form.setValue('state', json.data.state ?? '', { shouldValidate: true })
+    } finally {
+      setLoadingZipCode(false)
+    }
   }
 
   async function onSubmit(values: RegisterForm) {
@@ -76,8 +98,10 @@ export default function RegisterPage() {
     <RegisterPageContent
       form={form}
       error={error}
+      loadingZipCode={loadingZipCode}
       onSubmit={onSubmit}
       onTenantNameChange={handleTenantNameChange}
+      onZipCodeChange={handleZipCodeChange}
     />
   )
 }

--- a/app/(dashboard)/integracoes/page.tsx
+++ b/app/(dashboard)/integracoes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { toast } from 'sonner'
 import {
   useDisconnectMercadoPagoAccount,
   useMercadoPagoAccount,
@@ -48,6 +49,7 @@ export default function IntegracoesPage() {
   const [deliveryOriginNeighborhoodInput, setDeliveryOriginNeighborhoodInput] = useState<string | null>(null)
   const [deliveryOriginCityInput, setDeliveryOriginCityInput] = useState<string | null>(null)
   const [deliveryOriginStateInput, setDeliveryOriginStateInput] = useState<string | null>(null)
+  const [deliveryOriginLookupPending, setDeliveryOriginLookupPending] = useState(false)
   const [openingHourInput, setOpeningHourInput] = useState<string | null>(null)
   const [closingHourInput, setClosingHourInput] = useState<string | null>(null)
 
@@ -73,6 +75,34 @@ export default function IntegracoesPage() {
   const closingHourValue = getDeliveryHourValue(closingHourInput, deliverySettings.data?.closes_at)
   const whatsappOptions = hasWhatsappNotifications && notificationSettings.data ? whatsappOptionDefinitions : []
 
+  async function handleDeliveryOriginCepLookup(cep: string) {
+    const clean = cep.replace(/\D/g, '')
+    if (clean.length !== 8) return
+
+    setDeliveryOriginLookupPending(true)
+
+    try {
+      const res = await fetch(`/api/cep/${clean}`)
+      const json = await res.json()
+
+      if (!res.ok) {
+        throw new Error(json.error || 'Não foi possível buscar o CEP informado.')
+      }
+
+      if (!json.data) return
+
+      setDeliveryOriginZipInput(clean)
+      setDeliveryOriginStreetInput(json.data.street ?? '')
+      setDeliveryOriginNeighborhoodInput(json.data.neighborhood ?? '')
+      setDeliveryOriginCityInput(json.data.city ?? '')
+      setDeliveryOriginStateInput((json.data.state ?? '').toUpperCase())
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Não foi possível buscar o CEP informado.')
+    } finally {
+      setDeliveryOriginLookupPending(false)
+    }
+  }
+
   return (
     <FeatureGate feature="payments">
       <IntegrationsPageContent
@@ -93,6 +123,7 @@ export default function IntegracoesPage() {
         deliveryOriginNeighborhoodValue={deliveryOriginNeighborhoodValue}
         deliveryOriginCityValue={deliveryOriginCityValue}
         deliveryOriginStateValue={deliveryOriginStateValue}
+        deliveryOriginLookupPending={deliveryOriginLookupPending}
         openingHourValue={openingHourValue}
         closingHourValue={closingHourValue}
         onDeliveryToggle={async (payload) => {
@@ -132,6 +163,7 @@ export default function IntegracoesPage() {
           if (field === 'origin_city') setDeliveryOriginCityInput(value)
           if (field === 'origin_state') setDeliveryOriginStateInput(value.toUpperCase())
         }}
+        onDeliveryOriginCepLookup={handleDeliveryOriginCepLookup}
         onDeliveryDistanceSave={async (payload) => {
           await updateDeliverySettings.mutateAsync(payload)
           setDeliveryRadiusInput(null)

--- a/app/(dashboard)/produtos/page.tsx
+++ b/app/(dashboard)/produtos/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useProducts, useCategories, useCreateProduct, useUpdateProduct } from '@/features/products/hooks/useProducts'
+import { useProducts, useCategories, useCreateProduct, useUpdateProduct, useDeleteProduct } from '@/features/products/hooks/useProducts'
 import { Resolver, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -55,6 +55,7 @@ export default function ProdutosPage() {
   const { data: categories } = useCategories()
   const createProduct = useCreateProduct()
   const updateProduct = useUpdateProduct()
+  const deleteProduct = useDeleteProduct()
   const { data: plan } = usePlan()
   const canAddMoreProducts = useCanAddMore('products', data?.count ?? 0)
   const productLimitReached = isProductLimitReached(plan, canAddMoreProducts)
@@ -77,16 +78,36 @@ export default function ProdutosPage() {
   }
 
   async function onSubmit(values: ProductForm) {
+    const payload = {
+      ...values,
+      sku: values.sku?.trim() || undefined,
+      category_id: values.category_id?.trim() || undefined,
+    }
+
     try {
       if (editing) {
-        await updateProduct.mutateAsync({ id: editing.id, ...values })
+        await updateProduct.mutateAsync({ id: editing.id, ...payload })
       } else {
-        await createProduct.mutateAsync(values)
+        await createProduct.mutateAsync(payload)
       }
       setOpen(false)
     } catch (e: unknown) {
       form.setError('root', {
         message: e instanceof Error ? e.message : 'Erro ao salvar produto.',
+      })
+    }
+  }
+
+  async function handleDelete(product: Product) {
+    if (!window.confirm(`Excluir o produto "${product.name}"? Ele será desativado e poderá ser reativado depois.`)) {
+      return
+    }
+
+    try {
+      await deleteProduct.mutateAsync(product.id)
+    } catch (e: unknown) {
+      form.setError('root', {
+        message: e instanceof Error ? e.message : 'Erro ao excluir produto.',
       })
     }
   }
@@ -193,9 +214,19 @@ export default function ProdutosPage() {
                     </Badge>
                   </td>
                   <td className="px-4 py-3">
-                    <Button variant="ghost" size="sm" onClick={() => openEdit(product)}>
-                      Editar
-                    </Button>
+                    <div className="flex items-center justify-end gap-2">
+                      <Button variant="ghost" size="sm" onClick={() => openEdit(product)}>
+                        Editar
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(product)}
+                        disabled={deleteProduct.isPending}
+                      >
+                        Excluir
+                      </Button>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -59,7 +59,17 @@ export async function POST(request: NextRequest) {
 
     const { data: tenant, error: tenantError } = await admin
       .from('tenants')
-      .insert({ name: tenant_name, slug: tenant_slug })
+      .insert({
+        name: tenant_name,
+        slug: tenant_slug,
+        cnpj,
+        zip_code,
+        street,
+        number,
+        neighborhood,
+        city,
+        state,
+      })
       .select()
       .single()
 

--- a/app/api/delivery-settings/route.ts
+++ b/app/api/delivery-settings/route.ts
@@ -97,9 +97,10 @@ async function createDeliverySettings(admin: ReturnType<typeof createAdminClient
   throw lastError ?? new Error('Não foi possível criar a configuração de entrega.')
 }
 
-async function ensureDeliverySettings(tenantId: string) {
-  const admin = createAdminClient()
-
+async function ensureDeliverySettings(
+  tenantId: string,
+  admin: ReturnType<typeof createAdminClient> = createAdminClient(),
+) {
   const { data: existing, error } = await admin
     .from('tenant_delivery_settings')
     .select('*')
@@ -111,6 +112,56 @@ async function ensureDeliverySettings(tenantId: string) {
   if (existing) return normalizeDeliverySettings(existing)
 
   return createDeliverySettings(admin, tenantId)
+}
+
+async function getTenantAddressFallback(
+  admin: ReturnType<typeof createAdminClient>,
+  tenantId: string,
+) {
+  try {
+    const { data, error } = await admin
+      .from('tenants')
+      .select('zip_code, street, number, neighborhood, city, state')
+      .eq('id', tenantId)
+      .maybeSingle()
+
+    if (error) {
+      if (isMissingColumnError(error)) return null
+      throw error
+    }
+
+    if (!data) return null
+
+    return {
+      origin_zip_code: data.zip_code ?? null,
+      origin_street: data.street ?? null,
+      origin_number: data.number ?? null,
+      origin_neighborhood: data.neighborhood ?? null,
+      origin_city: data.city ?? null,
+      origin_state: data.state ?? null,
+    }
+  } catch (error) {
+    if (isMissingColumnError(error)) return null
+    throw error
+  }
+}
+
+async function getDeliverySettingsWithTenantFallback(tenantId: string) {
+  const admin = createAdminClient()
+  const settings = await ensureDeliverySettings(tenantId, admin)
+  const tenantAddress = await getTenantAddressFallback(admin, tenantId)
+
+  if (!tenantAddress) return settings
+
+  return normalizeDeliverySettings({
+    ...settings,
+    origin_zip_code: settings.origin_zip_code ?? tenantAddress.origin_zip_code,
+    origin_street: settings.origin_street ?? tenantAddress.origin_street,
+    origin_number: settings.origin_number ?? tenantAddress.origin_number,
+    origin_neighborhood: settings.origin_neighborhood ?? tenantAddress.origin_neighborhood,
+    origin_city: settings.origin_city ?? tenantAddress.origin_city,
+    origin_state: settings.origin_state ?? tenantAddress.origin_state,
+  })
 }
 
 async function updateDeliverySettings(
@@ -147,7 +198,7 @@ export async function GET() {
     const auth = await requireTenantRoles(['owner'])
     if (!auth.ok) return auth.response
 
-    const settings = await ensureDeliverySettings(auth.profile.tenant_id)
+    const settings = await getDeliverySettingsWithTenantFallback(auth.profile.tenant_id)
     return NextResponse.json({ data: settings })
   } catch (error) {
     console.error('[delivery-settings:get]', error)

--- a/app/api/delivery-settings/route.ts
+++ b/app/api/delivery-settings/route.ts
@@ -148,7 +148,10 @@ async function getTenantAddressFallback(
 
 async function getDeliverySettingsWithTenantFallback(tenantId: string) {
   const admin = createAdminClient()
-  const settings = await ensureDeliverySettings(tenantId, admin)
+  const settings = (await ensureDeliverySettings(tenantId, admin)) ?? {
+    ...defaultDeliverySettings,
+    tenant_id: tenantId,
+  }
   const tenantAddress = await getTenantAddressFallback(admin, tenantId)
 
   if (!tenantAddress) return settings

--- a/features/auth/components/RegisterPageContent.tsx
+++ b/features/auth/components/RegisterPageContent.tsx
@@ -32,11 +32,20 @@ type RegisterFormValues = {
 type Props = {
   form: UseFormReturn<RegisterFormValues>
   error: string | null
+  loadingZipCode: boolean
   onSubmit: SubmitHandler<RegisterFormValues>
   onTenantNameChange: (value: string) => void
+  onZipCodeChange: (value: string) => void
 }
 
-export function RegisterPageContent({ form, error, onSubmit, onTenantNameChange }: Props) {
+export function RegisterPageContent({
+  form,
+  error,
+  loadingZipCode,
+  onSubmit,
+  onTenantNameChange,
+  onZipCodeChange,
+}: Props) {
   return (
     <Card>
       <CardHeader>
@@ -107,7 +116,17 @@ export function RegisterPageContent({ form, error, onSubmit, onTenantNameChange 
                     <FormItem>
                       <FormLabel>CEP</FormLabel>
                       <FormControl>
-                        <Input placeholder="00000-000" {...field} />
+                        <div className="space-y-1">
+                          <Input
+                            placeholder="00000-000"
+                            {...field}
+                            onChange={(event) => {
+                              field.onChange(event)
+                              onZipCodeChange(event.target.value)
+                            }}
+                          />
+                          {loadingZipCode && <p className="text-xs text-slate-400">Buscando CEP...</p>}
+                        </div>
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/features/payments/IntegrationsPageContent.tsx
+++ b/features/payments/IntegrationsPageContent.tsx
@@ -40,6 +40,7 @@ type Props = {
   deliveryOriginNeighborhoodValue?: string
   deliveryOriginCityValue?: string
   deliveryOriginStateValue?: string
+  deliveryOriginLookupPending?: boolean
   openingHourValue: string
   closingHourValue: string
   onDeliveryToggle: (payload: DeliverySettingsShape) => void | Promise<void>
@@ -61,6 +62,7 @@ type Props = {
       | 'origin_state',
     value: string,
   ) => void
+  onDeliveryOriginCepLookup?: (cep: string) => void | Promise<void>
   onDeliveryDistanceSave?: (payload: DeliverySettingsShape) => void | Promise<void>
   onDeliveryHoursSave: (payload: DeliverySettingsShape) => void | Promise<void>
   hasWhatsappNotifications: boolean
@@ -89,6 +91,7 @@ export function IntegrationsPageContent({
   deliveryOriginNeighborhoodValue = '',
   deliveryOriginCityValue = '',
   deliveryOriginStateValue = '',
+  deliveryOriginLookupPending = false,
   openingHourValue,
   closingHourValue,
   onDeliveryToggle,
@@ -99,6 +102,7 @@ export function IntegrationsPageContent({
   onDeliveryFeeSave,
   onDeliveryPricingModeChange,
   onDeliveryDistanceInputChange,
+  onDeliveryOriginCepLookup,
   onDeliveryDistanceSave,
   onDeliveryHoursSave,
   hasWhatsappNotifications,
@@ -385,11 +389,20 @@ export function IntegrationsPageContent({
                   <div className="grid gap-4 md:grid-cols-2">
                     <label className="text-sm text-slate-600">
                       <span className="mb-1 block">CEP de origem</span>
-                      <input
-                        value={deliveryOriginZipValue}
-                        onChange={(event) => onDeliveryDistanceInputChange?.('origin_zip_code', event.target.value)}
-                        className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
-                      />
+                      <div className="space-y-1">
+                        <input
+                          value={deliveryOriginZipValue}
+                          onChange={(event) => {
+                            const value = event.target.value.replace(/\D/g, '')
+                            onDeliveryDistanceInputChange?.('origin_zip_code', value)
+                            if (value.length === 8) onDeliveryOriginCepLookup?.(value)
+                          }}
+                          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+                        />
+                        {deliveryOriginLookupPending && (
+                          <span className="text-xs text-slate-400">Buscando CEP...</span>
+                        )}
+                      </div>
                     </label>
                     <label className="text-sm text-slate-600">
                       <span className="mb-1 block">Cidade de origem</span>

--- a/features/products/hooks/useProducts.ts
+++ b/features/products/hooks/useProducts.ts
@@ -60,6 +60,21 @@ export function useUpdateProduct() {
   })
 }
 
+export function useDeleteProduct() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetch(`/api/products/${id}`, {
+        method: 'DELETE',
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error)
+      return json.data
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['products'] }),
+  })
+}
+
 export function useCategories() {
   return useQuery({
     queryKey: ['categories'],

--- a/tests/integration/api-auth-mercadopago-routes.test.ts
+++ b/tests/integration/api-auth-mercadopago-routes.test.ts
@@ -127,15 +127,17 @@ describe('api auth and mercado pago routes', () => {
     )
     expect(invalid.status).toBe(400)
 
+    const duplicateInsertMock = vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: null,
+        error: { code: '23505' },
+      }),
+    }))
+
     vi.mocked(createAdminClient).mockReturnValueOnce({
       from: vi.fn(() => ({
-        insert: vi.fn(() => ({
-          select: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({
-            data: null,
-            error: { code: '23505' },
-          }),
-        })),
+        insert: duplicateInsertMock,
       })),
     } as never)
 
@@ -159,6 +161,17 @@ describe('api auth and mercado pago routes', () => {
       }) as never
     )
     expect(conflict.status).toBe(409)
+    expect(duplicateInsertMock).toHaveBeenCalledWith({
+      name: 'Casa',
+      slug: 'casa',
+      cnpj: '12345678000190',
+      zip_code: '01001000',
+      street: 'Rua A',
+      number: '123',
+      neighborhood: 'Centro',
+      city: 'São Paulo',
+      state: 'SP',
+    })
 
     vi.mocked(createAdminClient).mockReturnValueOnce({
       from: vi.fn(() => ({
@@ -200,17 +213,19 @@ describe('api auth and mercado pago routes', () => {
 
     const cleanupEq = vi.fn()
     const deleteMock = vi.fn(() => ({ eq: cleanupEq }))
+    const rollbackInsertMock = vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 'tenant-1' },
+        error: null,
+      }),
+    }))
+
     vi.mocked(createAdminClient).mockReturnValueOnce({
       from: vi.fn((table: string) => {
         if (table === 'tenants') {
           return {
-            insert: vi.fn(() => ({
-              select: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({
-                data: { id: 'tenant-1' },
-                error: null,
-              }),
-            })),
+            insert: rollbackInsertMock,
             delete: deleteMock,
           }
         }
@@ -245,17 +260,30 @@ describe('api auth and mercado pago routes', () => {
     )
     expect(rollback.status).toBe(500)
     expect(cleanupEq).toHaveBeenCalledWith('id', 'tenant-1')
+    expect(rollbackInsertMock).toHaveBeenCalledWith({
+      name: 'Casa',
+      slug: 'casa',
+      cnpj: '12345678000190',
+      zip_code: '01001000',
+      street: 'Rua A',
+      number: '123',
+      neighborhood: 'Centro',
+      city: 'São Paulo',
+      state: 'SP',
+    })
 
     const createUserSuccessMock = vi.fn().mockResolvedValue({ error: null })
+    const successInsertMock = vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 'tenant-2' },
+        error: null,
+      }),
+    }))
+
     vi.mocked(createAdminClient).mockReturnValueOnce({
       from: vi.fn(() => ({
-        insert: vi.fn(() => ({
-          select: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({
-            data: { id: 'tenant-2' },
-            error: null,
-          }),
-        })),
+        insert: successInsertMock,
       })),
       auth: {
         admin: {
@@ -285,6 +313,17 @@ describe('api auth and mercado pago routes', () => {
     )
     expect(success.status).toBe(201)
     expect((await success.json()).data.tenant_slug).toBe('casa')
+    expect(successInsertMock).toHaveBeenCalledWith({
+      name: 'Casa',
+      slug: 'casa',
+      cnpj: '12345678000190',
+      zip_code: '01001000',
+      street: 'Rua A',
+      number: '123',
+      neighborhood: 'Centro',
+      city: 'São Paulo',
+      state: 'SP',
+    })
     expect(createUserSuccessMock).toHaveBeenCalledWith({
       email: 'maria@test.com',
       password: '123456',

--- a/tests/integration/api-operations-routes.test.ts
+++ b/tests/integration/api-operations-routes.test.ts
@@ -53,20 +53,52 @@ describe('api operations routes', () => {
       profile: { tenant_id: 'tenant-1' },
     } as never)
     vi.mocked(createAdminClient).mockReturnValueOnce({
-      from: vi.fn(() => ({
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-        insert: vi.fn(() => ({
+      from: vi.fn((table: string) => {
+        if (table === 'tenant_delivery_settings') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            insert: vi.fn(() => ({
+              select: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({
+                data: { tenant_id: 'tenant-1', delivery_enabled: false, flat_fee: 0, accepting_orders: true, schedule_enabled: false, opens_at: null, closes_at: null, pricing_mode: 'flat', max_radius_km: null, fee_per_km: null, origin_zip_code: null, origin_street: null, origin_number: null, origin_neighborhood: null, origin_city: null, origin_state: null },
+                error: null,
+              }),
+            })),
+          }
+        }
+
+        return {
           select: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({
-            data: { tenant_id: 'tenant-1', delivery_enabled: false, flat_fee: 0, accepting_orders: true, schedule_enabled: false, opens_at: null, closes_at: null, pricing_mode: 'flat', max_radius_km: null, fee_per_km: null, origin_zip_code: null, origin_street: null, origin_number: null, origin_neighborhood: null, origin_city: null, origin_state: null },
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: {
+              zip_code: '01001000',
+              street: 'Praça da Sé',
+              number: '100',
+              neighborhood: 'Sé',
+              city: 'São Paulo',
+              state: 'SP',
+            },
             error: null,
           }),
-        })),
-      })),
+        }
+      }),
     } as never)
-    expect((await deliverySettingsRoute.GET()).status).toBe(200)
+    const hydratedSettingsResponse = await deliverySettingsRoute.GET()
+    expect(hydratedSettingsResponse.status).toBe(200)
+    await expect(hydratedSettingsResponse.json()).resolves.toMatchObject({
+      data: {
+        tenant_id: 'tenant-1',
+        origin_zip_code: '01001000',
+        origin_street: 'Praça da Sé',
+        origin_number: '100',
+        origin_neighborhood: 'Sé',
+        origin_city: 'São Paulo',
+        origin_state: 'SP',
+      },
+    })
 
 
     vi.mocked(requireTenantRoles).mockResolvedValueOnce({

--- a/tests/unit/auth-pages-component.test.tsx
+++ b/tests/unit/auth-pages-component.test.tsx
@@ -162,14 +162,51 @@ describe('auth pages components', () => {
 
     const props = capturedRegisterContentProps as {
       error: string | null
+      loadingZipCode: boolean
       onSubmit: (values: Record<string, unknown>) => Promise<void>
       onTenantNameChange: (value: string) => void
+      onZipCodeChange: (value: string) => Promise<void>
     }
 
     expect(props.error).toBeNull()
+    expect(props.loadingZipCode).toBe(false)
     props.onTenantNameChange('Pizzaria do João')
 
     expect(setValueMock).toHaveBeenCalledWith('tenant_slug', 'pizzaria-do-joao', {
+      shouldValidate: true,
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: {
+            zip_code: '01001000',
+            street: 'Praça da Sé',
+            neighborhood: 'Sé',
+            city: 'São Paulo',
+            state: 'SP',
+          },
+        }),
+      }).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ data: { tenant_slug: 'pizzaria-do-joao' } }),
+      })
+    )
+
+    await props.onZipCodeChange('01001-000')
+
+    expect(setValueMock).toHaveBeenCalledWith('street', 'Praça da Sé', {
+      shouldValidate: true,
+    })
+    expect(setValueMock).toHaveBeenCalledWith('neighborhood', 'Sé', {
+      shouldValidate: true,
+    })
+    expect(setValueMock).toHaveBeenCalledWith('city', 'São Paulo', {
+      shouldValidate: true,
+    })
+    expect(setValueMock).toHaveBeenCalledWith('state', 'SP', {
       shouldValidate: true,
     })
 

--- a/tests/unit/integracoes-page-component.test.tsx
+++ b/tests/unit/integracoes-page-component.test.tsx
@@ -13,6 +13,7 @@ const searchParamsGetMock = vi.fn()
 let shouldRunEffects = false
 
 let capturedContentProps: Record<string, unknown> | null = null
+const toastErrorMock = vi.fn()
 
 vi.mock('react', async () => {
   const actualReact = await vi.importActual<typeof import('react')>('react')
@@ -62,6 +63,12 @@ vi.mock('@/features/payments/IntegrationsPageContent', () => ({
   IntegrationsPageContent: (props: Record<string, unknown>) => {
     capturedContentProps = props
     return React.createElement('div', null, 'Integrations Page Content Mock')
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
   },
 }))
 
@@ -146,6 +153,8 @@ describe('IntegracoesPage component', () => {
       onDeliveryHoursSave: (payload: Record<string, unknown>) => Promise<void>
       onDeliveryFeeInputChange: (value: string) => void
       onDeliveryFeeSave: (payload: Record<string, unknown>) => Promise<void>
+      onDeliveryDistanceInputChange: (field: string, value: string) => void
+      onDeliveryOriginCepLookup: (cep: string) => Promise<void>
       onToggleWhatsappOption: (payload: Record<string, unknown>) => Promise<void>
     }
 
@@ -162,9 +171,26 @@ describe('IntegracoesPage component', () => {
       .mutateAsync as ReturnType<typeof vi.fn>
     const updateNotificationMutateAsync = useUpdateNotificationSettingsMock.mock.results[0]?.value
       .mutateAsync as ReturnType<typeof vi.fn>
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: {
+            zip_code: '01001000',
+            street: 'Praça da Sé',
+            neighborhood: 'Sé',
+            city: 'São Paulo',
+            state: 'SP',
+          },
+        }),
+      }),
+    )
 
     props.onDisconnect()
     props.onDeliveryFeeInputChange('14.50')
+    props.onDeliveryDistanceInputChange('origin_number', '100')
+    await props.onDeliveryOriginCepLookup('01001-000')
     await props.onDeliveryToggle({
       tenant_id: 'tenant-1',
       delivery_enabled: false,
@@ -257,6 +283,7 @@ describe('IntegracoesPage component', () => {
         whatsapp_order_received: false,
       })
     )
+    expect(fetch).toHaveBeenCalledWith('/api/cep/01001000')
   })
 
   it('cobre fallback sem conta conectada e alerta de erro OAuth', async () => {

--- a/tests/unit/integrations-page.test.tsx
+++ b/tests/unit/integrations-page.test.tsx
@@ -441,6 +441,7 @@ describe('IntegrationsPageContent', () => {
         deliverySettingsData: null,
         deliverySettingsPending: false,
         deliveryFeeValue: '0',
+        deliveryOriginLookupPending: true,
         openingHourValue: '',
         closingHourValue: '',
         onDeliveryToggle: vi.fn(),
@@ -462,6 +463,75 @@ describe('IntegrationsPageContent', () => {
     expect(markup).toContain('Carregando integração...')
     expect(markup).toContain('Não foi possível carregar as configurações de entrega.')
     expect(markup).toContain('Recurso disponível apenas nos planos Standard e Premium.')
+  })
+
+  it('renderiza indicador de busca de CEP no cálculo por distância', async () => {
+    const { IntegrationsPageContent } = await import('@/features/payments/IntegrationsPageContent')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(IntegrationsPageContent, {
+        connected: true,
+        accountLoading: false,
+        accountData: {
+          mercado_pago_user_id: 'seller-1',
+          live_mode: true,
+          token_expires_at: '2026-01-01T00:00:00.000Z',
+        },
+        disconnectPending: false,
+        onDisconnect: vi.fn(),
+        deliverySettingsLoading: false,
+        deliverySettingsData: {
+          tenant_id: 'tenant-1',
+          delivery_enabled: true,
+          flat_fee: 8,
+          accepting_orders: true,
+          schedule_enabled: false,
+          opens_at: null,
+          closes_at: null,
+          pricing_mode: 'distance',
+          max_radius_km: 5,
+          fee_per_km: 2,
+          origin_zip_code: '01001000',
+          origin_street: 'Praça da Sé',
+          origin_number: '100',
+          origin_neighborhood: 'Sé',
+          origin_city: 'São Paulo',
+          origin_state: 'SP',
+        },
+        deliverySettingsPending: false,
+        deliveryFeeValue: '8',
+        deliveryRadiusValue: '5',
+        deliveryFeePerKmValue: '2',
+        deliveryOriginZipValue: '01001000',
+        deliveryOriginStreetValue: 'Praça da Sé',
+        deliveryOriginNumberValue: '100',
+        deliveryOriginNeighborhoodValue: 'Sé',
+        deliveryOriginCityValue: 'São Paulo',
+        deliveryOriginStateValue: 'SP',
+        deliveryOriginLookupPending: true,
+        openingHourValue: '',
+        closingHourValue: '',
+        onDeliveryToggle: vi.fn(),
+        onDeliveryOperationChange: vi.fn(),
+        onDeliveryScheduleChange: vi.fn(),
+        onDeliveryHoursChange: vi.fn(),
+        onDeliveryFeeInputChange: vi.fn(),
+        onDeliveryFeeSave: vi.fn(),
+        onDeliveryPricingModeChange: vi.fn(),
+        onDeliveryDistanceInputChange: vi.fn(),
+        onDeliveryOriginCepLookup: vi.fn(),
+        onDeliveryDistanceSave: vi.fn(),
+        onDeliveryHoursSave: vi.fn(),
+        hasWhatsappNotifications: false,
+        notificationSettingsLoading: false,
+        notificationSettingsData: null,
+        notificationSettingsPending: false,
+        whatsappOptions: whatsappOptionDefinitions,
+        onToggleWhatsappOption: vi.fn(),
+      })
+    )
+
+    expect(markup).toContain('Buscando CEP...')
   })
 
   it('renderiza fallback de conta desconectada e estados de loading pendente', async () => {

--- a/tests/unit/page-smoke.test.tsx
+++ b/tests/unit/page-smoke.test.tsx
@@ -17,6 +17,7 @@ const useCategoriesMock = vi.fn()
 const useProductsMock = vi.fn()
 const useCreateProductMock = vi.fn()
 const useUpdateProductMock = vi.fn()
+const useDeleteProductMock = vi.fn()
 const useStockBalanceMock = vi.fn()
 const useStockMovementsMock = vi.fn()
 const useCreateMovementMock = vi.fn()
@@ -179,6 +180,7 @@ vi.mock('@/features/products/hooks/useProducts', () => ({
   useProducts: () => useProductsMock(),
   useCreateProduct: () => useCreateProductMock(),
   useUpdateProduct: () => useUpdateProductMock(),
+  useDeleteProduct: () => useDeleteProductMock(),
 }))
 
 vi.mock('@/features/notifications/hooks/useNotificationSettings', () => ({
@@ -358,6 +360,7 @@ describe('page smoke', () => {
     })
     useCreateProductMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
     useUpdateProductMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
+    useDeleteProductMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() })
     useStockBalanceMock.mockReturnValue({
       data: [
         {

--- a/tests/unit/produtos-page-component.test.tsx
+++ b/tests/unit/produtos-page-component.test.tsx
@@ -7,6 +7,7 @@ const useProductsMock = vi.fn()
 const useCategoriesMock = vi.fn()
 const useCreateProductMock = vi.fn()
 const useUpdateProductMock = vi.fn()
+const useDeleteProductMock = vi.fn()
 const usePlanMock = vi.fn()
 const useCanAddMoreMock = vi.fn()
 const formResetMock = vi.fn()
@@ -130,6 +131,7 @@ vi.mock('@/features/products/hooks/useProducts', () => ({
   useCategories: () => useCategoriesMock(),
   useCreateProduct: () => useCreateProductMock(),
   useUpdateProduct: () => useUpdateProductMock(),
+  useDeleteProduct: () => useDeleteProductMock(),
 }))
 
 vi.mock('@/features/plans/hooks/usePlan', () => ({
@@ -212,6 +214,10 @@ describe('ProdutosPage component', () => {
     useUpdateProductMock.mockReturnValue({
       mutateAsync: vi.fn().mockResolvedValue(undefined),
     })
+    useDeleteProductMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue(undefined),
+    })
     usePlanMock.mockReturnValue({
       data: { max_products: 10 },
     })
@@ -251,10 +257,16 @@ describe('ProdutosPage component', () => {
 
     const novoProdutoButton = getButtonByText('Novo produto')
     const editarButton = getButtonByText('Editar')
+    const excluirButton = getButtonByText('Excluir')
     const paginationProps = capturedPaginationProps as { onPageChange: (page: number) => void }
+
+    vi.stubGlobal('window', {
+      confirm: vi.fn(() => true),
+    })
 
     ;(novoProdutoButton?.onClick as (() => void) | undefined)?.()
     ;(editarButton?.onClick as (() => void) | undefined)?.()
+    await (excluirButton?.onClick as (() => Promise<void>) | undefined)?.()
     paginationProps.onPageChange(3)
 
     expect(formResetMock).toHaveBeenCalledWith({
@@ -279,9 +291,11 @@ describe('ProdutosPage component', () => {
 
     const createProductMutateAsync = useCreateProductMock.mock.results[0]?.value.mutateAsync as ReturnType<typeof vi.fn>
     const updateProductMutateAsync = useUpdateProductMock.mock.results[0]?.value.mutateAsync as ReturnType<typeof vi.fn>
+    const deleteProductMutateAsync = useDeleteProductMock.mock.results[0]?.value.mutateAsync as ReturnType<typeof vi.fn>
 
     expect(createProductMutateAsync).not.toHaveBeenCalled()
     expect(updateProductMutateAsync).not.toHaveBeenCalled()
+    expect(deleteProductMutateAsync).toHaveBeenCalledWith('prod-1')
   })
 
   it('renderiza estados alternativos de loading, vazio e limite de plano', async () => {
@@ -403,6 +417,39 @@ describe('ProdutosPage component', () => {
       min_stock: 2,
     })
     expect(setOpenEditMock).toHaveBeenCalledWith(false)
+
+    useStateMock
+      .mockImplementationOnce((initial: unknown) => [initial, vi.fn()])
+      .mockImplementationOnce((initial: unknown) => [initial, vi.fn()])
+      .mockImplementationOnce((initial: unknown) => [initial, vi.fn()])
+      .mockImplementationOnce(() => [true, vi.fn()])
+      .mockImplementationOnce(() => [{
+        id: 'prod-2',
+        tenant_id: 'tenant-1',
+        category_id: null,
+        name: 'Molho',
+        sku: '',
+        unit: 'ml',
+        cost_price: 4,
+        min_stock: 0,
+        active: true,
+        category: null,
+      }, vi.fn()])
+
+    const { default: ProdutosPageEditWithoutCategory } = await import('@/app/(dashboard)/produtos/page')
+    renderToStaticMarkup(React.createElement(ProdutosPageEditWithoutCategory))
+    await getDialogFormSubmitHandler()?.()
+
+    const updateWithoutCategoryMutateAsync = useUpdateProductMock.mock.results[2]?.value.mutateAsync as ReturnType<typeof vi.fn>
+    expect(updateWithoutCategoryMutateAsync).toHaveBeenCalledWith({
+      id: 'prod-2',
+      name: 'Farinha',
+      sku: 'FR-1',
+      category_id: 'cat-1',
+      unit: 'kg',
+      cost_price: 12,
+      min_stock: 2,
+    })
 
     useCreateProductMock.mockReturnValueOnce({
       mutateAsync: vi.fn().mockRejectedValue(new Error('Falha ao salvar produto')),


### PR DESCRIPTION
## Resumo

Este PR corrige o erro de Quality Gate no pipeline de CI/CD causado por uma checagem de tipos no build do Next.js.

## Problema

O build falhava em `app/api/delivery-settings/route.ts` porque o TypeScript identificava que `settings` poderia ser `null` no fluxo de fallback do endereço do estabelecimento.

## Correção aplicada

- adicionado fallback explícito com `defaultDeliverySettings` no retorno de `ensureDeliverySettings`
- garantido que o objeto usado para hidratar os campos `origin_*` nunca seja nulo
- preservado o comportamento existente da API de `delivery-settings`

## Impacto

- elimina a falha de type check no `npm run build`
- mantém o preenchimento automático do endereço de origem do frete
- estabiliza o pipeline de CI/CD

## Validação

- `npm run build`
