### PR TITLE
fix: simplify public delivery fee UX and enforce base fee minimum

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -98,6 +98,18 @@ type Customer = {
   addresses?: CustomerAddress[]
 }
 
+function hasCompleteDeliveryAddress(address: Partial<CustomerAddress>) {
+  const cleanZipCode = String(address.zip_code ?? '').replace(/\D/g, '')
+
+  return Boolean(
+    cleanZipCode.length === 8 &&
+      address.street &&
+      address.number &&
+      address.city &&
+      address.state,
+  )
+}
+
 export default function MenuClient({
   tenant,
   items,
@@ -347,7 +359,7 @@ export default function MenuClient({
   }
 
   const resolveDeliveryQuote = useCallback(async (nextAddress: Partial<CustomerAddress>) => {
-    if (!nextAddress.zip_code || !nextAddress.street || !nextAddress.number || !nextAddress.city || !nextAddress.state) {
+    if (!hasCompleteDeliveryAddress(nextAddress)) {
       setQuotedDeliveryFee(null)
       setQuotedDistanceKm(null)
       setDeliveryQuoteMessage(null)
@@ -367,7 +379,7 @@ export default function MenuClient({
       const flatFee = Number(tenant.delivery_settings.flat_fee ?? 0)
       setQuotedDeliveryFee(flatFee)
       setQuotedDistanceKm(null)
-      setDeliveryQuoteMessage('Taxa fixa de entrega aplicada para este pedido.')
+      setDeliveryQuoteMessage(null)
       lastDeliveryQuoteAlertRef.current = null
       return { deliveryFee: flatFee, distanceKm: null }
     }
@@ -388,11 +400,7 @@ export default function MenuClient({
 
     setQuotedDeliveryFee(json.data.delivery_fee)
     setQuotedDistanceKm(json.data.distance_km ?? null)
-    setDeliveryQuoteMessage(
-      json.data.pricing_mode === 'distance'
-        ? 'Taxa calculada com base na distância até o endereço informado.'
-        : 'Taxa fixa de entrega aplicada para este pedido.',
-    )
+    setDeliveryQuoteMessage(null)
     lastDeliveryQuoteAlertRef.current = null
 
     return {
@@ -435,7 +443,7 @@ export default function MenuClient({
 
     if (!shouldQuoteDelivery || operationClosedNotice) return
 
-    if (!address.zip_code || !address.street || !address.number || !address.city || !address.state) {
+    if (!hasCompleteDeliveryAddress(address)) {
       setQuotedDeliveryFee(null)
       setQuotedDistanceKm(null)
       setDeliveryQuoteMessage(null)

--- a/features/menu/MenuAddressStep.tsx
+++ b/features/menu/MenuAddressStep.tsx
@@ -135,7 +135,7 @@ export function MenuAddressStep({
             <span>R$ {cartTotal.toFixed(2)}</span>
           </div>
           <div className="flex items-center justify-between text-sm text-slate-600">
-            <span>Frete</span>
+            <span>Taxa entrega</span>
             <span>{quotedDeliveryFee !== null ? `R$ ${deliveryFee.toFixed(2)}` : 'A calcular'}</span>
           </div>
           <div className="flex items-center justify-between text-sm font-semibold text-slate-900 pt-2 border-t border-slate-200">
@@ -147,12 +147,6 @@ export function MenuAddressStep({
           <p className={hasDeliveryQuoteError ? 'text-xs text-red-600' : 'text-xs text-slate-600'}>
             {deliveryQuoteMessage}
           </p>
-        )}
-        {quotedDistanceKm !== null && !disabled && (
-          <p className="text-xs text-slate-500">Distância estimada: {quotedDistanceKm.toFixed(1)} km</p>
-        )}
-        {quotedDeliveryFee !== null && !disabled && (
-          <p className="text-xs text-slate-500">Taxa calculada: R$ {quotedDeliveryFee.toFixed(2)}</p>
         )}
         {disabled && (
           <p className="text-xs text-amber-700">Estabelecimento fechado para novos pedidos</p>

--- a/lib/delivery-pricing.ts
+++ b/lib/delivery-pricing.ts
@@ -59,7 +59,8 @@ export function isDistancePricingEnabled(settings: DeliveryPricingSettings) {
 export function calculateDistanceDeliveryFee(distanceKm: number, settings: DeliveryPricingSettings) {
   const baseFee = Number(settings.flat_fee ?? 0)
   const feePerKm = Number(settings.fee_per_km ?? 0)
-  return roundCurrency(baseFee + distanceKm * feePerKm)
+  const calculatedFee = distanceKm * feePerKm
+  return roundCurrency(Math.max(baseFee, calculatedFee))
 }
 
 export function hasValidDistancePricingConfiguration(settings: DeliveryPricingSettings) {
@@ -155,7 +156,7 @@ export async function resolveDeliveryQuote(
   const maxRadiusKm = Number(settings.max_radius_km ?? 0)
 
   if (distanceKm > maxRadiusKm) {
-    return { ok: false, error: `Endereço fora do raio de entrega de ${maxRadiusKm} km.` }
+    return { ok: false, error: 'Desculpe, nosso estabelecimento não atende a sua região.' }
   }
 
   return {

--- a/tests/unit/delivery-pricing.test.ts
+++ b/tests/unit/delivery-pricing.test.ts
@@ -21,7 +21,17 @@ describe('delivery pricing helpers', () => {
         flat_fee: 5,
         fee_per_km: 2,
       }),
-    ).toBe(14)
+    ).toBe(9)
+  })
+
+  it('cobra no mínimo a taxa base quando o cálculo por distância fica abaixo dela', () => {
+    expect(
+      calculateDistanceDeliveryFee(0.1, {
+        delivery_enabled: true,
+        flat_fee: 5,
+        fee_per_km: 1,
+      }),
+    ).toBe(5)
   })
 
   it('resolve cotação fixa e por distância', async () => {
@@ -115,6 +125,9 @@ describe('delivery pricing helpers', () => {
       fetchMock as unknown as typeof fetch,
     )
 
-    expect(quoted).toEqual({ ok: false, error: 'Endereço fora do raio de entrega de 5 km.' })
+    expect(quoted).toEqual({
+      ok: false,
+      error: 'Desculpe, nosso estabelecimento não atende a sua região.',
+    })
   })
 })

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -799,7 +799,7 @@ describe('MenuClient component', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/public/delivery-quote', expect.any(Object))
     expect(stateSetters[30]).toHaveBeenCalledWith(14)
     expect(stateSetters[31]).toHaveBeenCalledWith(4.8)
-    expect(stateSetters[32]).toHaveBeenCalledWith('Taxa calculada com base na distância até o endereço informado.')
+    expect(stateSetters[32]).toHaveBeenCalledWith(null)
   })
 
   it('avisa e bloqueia a finalização quando o endereço está fora do raio de entrega', async () => {
@@ -817,7 +817,9 @@ describe('MenuClient component', () => {
       if (url === '/api/public/delivery-quote') {
         return {
           ok: false,
-          json: vi.fn().mockResolvedValue({ error: 'Endereço fora do raio de entrega de 5 km.' }),
+          json: vi
+            .fn()
+            .mockResolvedValue({ error: 'Desculpe, nosso estabelecimento não atende a sua região.' }),
         }
       }
 
@@ -861,7 +863,9 @@ describe('MenuClient component', () => {
     await props.drawerProps.addressStepProps.onSubmit()
 
     expect(fetchMock).toHaveBeenCalledWith('/api/public/delivery-quote', expect.any(Object))
-    expect(globalThis.alert).toHaveBeenCalledWith('Endereço fora do raio de entrega de 5 km.')
+    expect(globalThis.alert).toHaveBeenCalledWith(
+      'Desculpe, nosso estabelecimento não atende a sua região.',
+    )
   })
 
   it('não pré-seleciona pagamento no fluxo público sem mesa', async () => {

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -1106,8 +1106,6 @@ describe('menu components', () => {
         deliveryFee: 8,
         orderTotal: 50,
         quotedDeliveryFee: 8,
-        quotedDistanceKm: 4.2,
-        deliveryQuoteMessage: 'Taxa calculada com base na distância até o endereço informado.',
         isProcessing: false,
         onSubmit: vi.fn(),
         onBack: vi.fn(),
@@ -1116,10 +1114,12 @@ describe('menu components', () => {
 
     expect(markup).toContain('Subtotal')
     expect(markup).toContain('R$ 42.00')
-    expect(markup).toContain('Frete')
+    expect(markup).toContain('Taxa entrega')
     expect(markup).toContain('R$ 8.00')
     expect(markup).toContain('Total')
     expect(markup).toContain('R$ 50.00')
+    expect(markup).not.toContain('Distância estimada')
+    expect(markup).not.toContain('Taxa calculada')
   })
 
   it('desabilita o envio quando o endereço está fora do raio de entrega', async () => {


### PR DESCRIPTION
## Resumo

Este PR melhora o comportamento e a experiência da taxa de entrega no cardápio público.

## O que mudou

- o cálculo por distância agora respeita a taxa base mínima
- quando o valor calculado ficar abaixo da taxa base, o sistema cobra apenas a taxa base
- quando o endereço estiver fora da área atendida, a mensagem exibida ao cliente passa a ser mais amigável
- o checkout deixa de exibir mensagens técnicas e detalhes internos sobre o cálculo da entrega
- o rótulo `Frete` foi alterado para `Taxa entrega`
- o fluxo deixa de disparar erros enquanto o cliente ainda está digitando um CEP incompleto

## Ajustes aplicados

### 1. Piso mínimo da taxa de entrega
Na modalidade por distância, a taxa final agora é o maior valor entre:

- a taxa base configurada pelo estabelecimento
- o valor calculado pela distância

Isso evita cobrar menos do que o mínimo operacional definido pelo restaurante.

### 2. Mensagem mais amigável fora da área atendida
Quando o endereço do cliente estiver fora do raio permitido, a interface passa a mostrar:

- `Desculpe, nosso estabelecimento não atende a sua região.`

### 3. Sem erros durante CEP incompleto
O cálculo da entrega agora só acontece quando o endereço possui dados suficientes, incluindo CEP completo com 8 dígitos.

Com isso, o cliente não recebe toasts e alertas indevidos enquanto ainda está preenchendo o endereço.

### 4. Interface mais limpa para o consumidor
Foram removidas do passo de endereço mensagens como:

- explicação de que a taxa foi calculada por distância
- distância estimada
- valor calculado isoladamente

O consumidor vê apenas o resumo final com:

- `Subtotal`
- `Taxa entrega`
- `Total`

## Impacto

- melhora a clareza e a confiança no checkout
- evita ruído visual e mensagens técnicas para o cliente final
- reduz fricção durante o preenchimento do endereço
- mantém a cobrança alinhada com a operação real do estabelecimento

## Cobertura e estabilidade

- testes unitários atualizados para refletir:
  - o piso mínimo da taxa base
  - a nova mensagem de fora da área
  - a remoção das mensagens de cálculo
  - o novo rótulo `Taxa entrega`
- suíte completa validada sem regressões

## Validação

- `npm test`
- `npm run build`
