### PR TITLE
fix: improve public order creation and allow removing cart add-ons

### DIFF
--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -46,6 +46,7 @@ import {
   type PublicMenuItem as MenuItem,
   type PublicOrderStatus,
   removeCartItem,
+  removeCartItemExtra,
   resolvePublicCheckoutUrl,
   serializeStoredActiveOrder,
   getAddressFlowTarget,
@@ -213,6 +214,10 @@ export default function MenuClient({
 
   function removeFromCart(index: number) {
     setCart((prev) => removeCartItem(prev, index))
+  }
+
+  function removeExtraFromCart(index: number, extraIndex: number) {
+    setCart((prev) => removeCartItemExtra(prev, index, extraIndex))
   }
 
   function clearCart() {
@@ -874,6 +879,7 @@ export default function MenuClient({
           onIncrement: incrementCart,
           onDecrement: decrementCart,
           onRemove: removeFromCart,
+          onRemoveExtra: removeExtraFromCart,
           onContinue: () => {
             if (operationClosedNotice) {
               toast.error(operationClosedNotice)

--- a/app/api/public/orders/route.ts
+++ b/app/api/public/orders/route.ts
@@ -229,6 +229,9 @@ export async function POST(request: NextRequest) {
       .single()
 
     if (orderError) throw orderError
+    if (!order?.id) {
+      throw new Error('Não foi possível criar o pedido.')
+    }
 
     const orderItems = items.map((item) => ({
       order_id: order.id,
@@ -245,6 +248,9 @@ export async function POST(request: NextRequest) {
       .select()
 
     if (itemsError) throw itemsError
+    if (!insertedItems || insertedItems.length !== items.length) {
+      throw new Error('Não foi possível salvar os itens do pedido.')
+    }
 
     const extras = insertedItems.flatMap((insertedItem, idx) =>
       (items[idx].extras ?? []).map((extra) => ({
@@ -266,7 +272,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('[public-orders:post]', error)
     return NextResponse.json(
-      { error: 'Erro ao criar pedido.' },
+      { error: error instanceof Error ? error.message : 'Erro ao criar pedido.' },
       { status: 500 }
     )
   }

--- a/features/menu/MenuCartStep.tsx
+++ b/features/menu/MenuCartStep.tsx
@@ -11,6 +11,7 @@ export function MenuCartStep({
   onIncrement,
   onDecrement,
   onRemove,
+  onRemoveExtra,
   onContinue,
   onClear,
   disabled = false,
@@ -22,6 +23,7 @@ export function MenuCartStep({
   onIncrement: (index: number) => void
   onDecrement: (index: number) => void
   onRemove: (index: number) => void
+  onRemoveExtra: (itemIndex: number, extraIndex: number) => void
   onContinue: () => void
   onClear: () => void
   disabled?: boolean
@@ -57,10 +59,22 @@ export function MenuCartStep({
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-slate-800">{item.name}</p>
-              {item.extras?.map((extra) => (
-                <p key={extra.name} className="text-xs text-slate-400">
-                  + {extra.name} R$ {extra.price.toFixed(2)}
-                </p>
+              {item.extras?.map((extra, extraIdx) => (
+                <div
+                  key={`${extra.id ?? extra.name}-${extraIdx}`}
+                  className="flex items-center justify-between gap-2 text-xs text-slate-400"
+                >
+                  <p>
+                    + {extra.name} R$ {extra.price.toFixed(2)}
+                  </p>
+                  <button
+                    onClick={() => onRemoveExtra(idx, extraIdx)}
+                    className="text-slate-300 hover:text-red-500 transition-colors"
+                    aria-label={`Remover adicional ${extra.name}`}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
               ))}
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -125,7 +125,7 @@ export function createCartItem(
     quantity: 1,
     extras: [selectedBorder, ...selectedExtras]
       .filter(Boolean)
-      .map((extra) => ({ name: extra!.name, price: extra!.price })),
+      .map((extra) => ({ id: extra!.id, name: extra!.name, price: extra!.price })),
     half_flavor: halfFlavor ? { menu_item_id: halfFlavor.id, name: halfFlavor.name } : undefined,
   } satisfies CartItem
 }
@@ -147,6 +147,17 @@ export function decrementCartItem(cart: CartItem[], index: number) {
 
 export function removeCartItem(cart: CartItem[], index: number) {
   return cart.filter((_, idx) => idx !== index)
+}
+
+export function removeCartItemExtra(cart: CartItem[], itemIndex: number, extraIndex: number) {
+  return cart.map((item, idx) => {
+    if (idx !== itemIndex) return item
+
+    return {
+      ...item,
+      extras: (item.extras ?? []).filter((_, idx) => idx !== extraIndex),
+    }
+  })
 }
 
 export function getCheckoutNoticeFromResult(checkoutResult: string | null) {

--- a/features/orders/types.ts
+++ b/features/orders/types.ts
@@ -43,7 +43,7 @@ export type CartItem = {
   price: number
   quantity: number
   notes?: string
-  extras?: { name: string; price: number }[]
+  extras?: { id?: string; name: string; price: number }[]
   half_flavor?: {
     menu_item_id: string
     name: string

--- a/lib/delivery-pricing.ts
+++ b/lib/delivery-pricing.ts
@@ -91,26 +91,30 @@ export async function geocodeAddress(
   address: DeliveryPricingAddress,
   fetchImpl: typeof fetch = fetch,
 ): Promise<Coordinates | null> {
-  const query = buildAddressQuery(address)
-  const response = await fetchImpl(`https://nominatim.openstreetmap.org/search?${query.toString()}`, {
-    headers: {
-      'Accept-Language': 'pt-BR',
-      'User-Agent': 'ChefOps Delivery Quote/1.0',
-    },
-    cache: 'no-store',
-  })
+  try {
+    const query = buildAddressQuery(address)
+    const response = await fetchImpl(`https://nominatim.openstreetmap.org/search?${query.toString()}`, {
+      headers: {
+        'Accept-Language': 'pt-BR',
+        'User-Agent': 'ChefOps Delivery Quote/1.0',
+      },
+      cache: 'no-store',
+    })
 
-  if (!response.ok) return null
+    if (!response.ok) return null
 
-  const data = (await response.json()) as Array<{ lat?: string; lon?: string }>
-  const first = data[0]
-  if (!first?.lat || !first?.lon) return null
+    const data = (await response.json()) as Array<{ lat?: string; lon?: string }>
+    const first = data[0]
+    if (!first?.lat || !first?.lon) return null
 
-  const lat = Number(first.lat)
-  const lon = Number(first.lon)
-  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null
+    const lat = Number(first.lat)
+    const lon = Number(first.lon)
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null
 
-  return { lat, lon }
+    return { lat, lon }
+  } catch {
+    return null
+  }
 }
 
 export async function resolveDeliveryQuote(

--- a/tests/unit/menu-client-component.test.tsx
+++ b/tests/unit/menu-client-component.test.tsx
@@ -499,15 +499,17 @@ describe('MenuClient component', () => {
       drawerProps: {
         cartStepProps: {
           onRemove: (index: number) => void
+          onRemoveExtra: (index: number, extraIndex: number) => void
           onClear: () => void
         }
       }
     }
 
     props.drawerProps.cartStepProps.onRemove(0)
+    props.drawerProps.cartStepProps.onRemoveExtra(0, 0)
     props.drawerProps.cartStepProps.onClear()
 
-    expect(stateSetters[0]).toHaveBeenCalledTimes(2)
+    expect(stateSetters[0]).toHaveBeenCalledTimes(3)
     expect(toastErrorMock).not.toHaveBeenCalledWith('O estabelecimento está fechado para novos pedidos no momento.')
   })
 
@@ -699,11 +701,11 @@ describe('MenuClient component', () => {
 
     expect(stateSetters[0]).toHaveBeenCalledWith(expect.any(Function))
     const addUpdater = stateSetters[0].mock.calls.at(-1)?.[0] as (prev: unknown[]) => unknown[]
-    const nextCart = addUpdater([]) as Array<{ extras?: Array<{ name: string; price: number }> }>
+    const nextCart = addUpdater([]) as Array<{ extras?: Array<{ id?: string; name: string; price: number }> }>
 
     expect(nextCart[0]?.extras).toEqual([
-      { name: 'Cheddar', price: 4 },
-      { name: 'Calabresa extra', price: 6 },
+      { id: 'extra-2', name: 'Cheddar', price: 4 },
+      { id: 'extra-3', name: 'Calabresa extra', price: 6 },
     ])
     expect(stateSetters[29]).toHaveBeenCalledWith(expect.any(Function))
   })

--- a/tests/unit/menu-components.test.tsx
+++ b/tests/unit/menu-components.test.tsx
@@ -416,6 +416,7 @@ describe('menu components', () => {
         onIncrement: vi.fn(),
         onDecrement: vi.fn(),
         onRemove: vi.fn(),
+        onRemoveExtra: vi.fn(),
         onContinue: vi.fn(),
         onClear: vi.fn(),
       })
@@ -448,6 +449,7 @@ describe('menu components', () => {
         onIncrement: vi.fn(),
         onDecrement: vi.fn(),
         onRemove: vi.fn(),
+        onRemoveExtra: vi.fn(),
         onContinue: vi.fn(),
         onClear: vi.fn(),
       })
@@ -478,6 +480,7 @@ describe('menu components', () => {
         onIncrement: vi.fn(),
         onDecrement: vi.fn(),
         onRemove: vi.fn(),
+        onRemoveExtra: vi.fn(),
         onContinue: vi.fn(),
         onClear: vi.fn(),
       })
@@ -492,6 +495,7 @@ describe('menu components', () => {
     const onIncrement = vi.fn()
     const onDecrement = vi.fn()
     const onRemove = vi.fn()
+    const onRemoveExtra = vi.fn()
     const onContinue = vi.fn()
     const onClear = vi.fn()
 
@@ -503,7 +507,7 @@ describe('menu components', () => {
             name: 'Pizza Pepperoni',
             price: 35,
             quantity: 1,
-            extras: [],
+            extras: [{ id: 'extra-1', name: 'Cheddar', price: 4 }],
           },
         ],
         cartTotal: 35,
@@ -512,6 +516,7 @@ describe('menu components', () => {
         onIncrement,
         onDecrement,
         onRemove,
+        onRemoveExtra,
         onContinue,
         onClear,
       })
@@ -521,7 +526,7 @@ describe('menu components', () => {
       (element) => element.type === 'button' && typeof element.props.onClick === 'function'
     )
 
-    expect(actionButtons).toHaveLength(5)
+    expect(actionButtons).toHaveLength(6)
     expect(getTextContent(elements)).not.toContain('Taxa de entrega')
 
     actionButtons[0].props.onClick()
@@ -529,12 +534,14 @@ describe('menu components', () => {
     actionButtons[2].props.onClick()
     actionButtons[3].props.onClick()
     actionButtons[4].props.onClick()
+    actionButtons[5].props.onClick()
 
     expect(onDecrement).toHaveBeenCalledWith(0)
     expect(onIncrement).toHaveBeenCalledWith(0)
-    expect(onRemove).toHaveBeenCalledWith(0)
+    expect(onRemoveExtra).toHaveBeenCalledWith(0, 0)
     expect(onContinue).toHaveBeenCalledOnce()
     expect(onClear).toHaveBeenCalledOnce()
+    expect(onRemove).toHaveBeenCalledWith(0)
   })
 
   it('renderiza dialogo de abertura de comanda e aciona cancelamento', async () => {

--- a/tests/unit/public-menu.test.tsx
+++ b/tests/unit/public-menu.test.tsx
@@ -70,6 +70,7 @@ import {
   normalizeTenantDeliverySettings,
   paymentOptionsByContext,
   removeCartItem,
+  removeCartItemExtra,
   resolvePublicCheckoutUrl,
   serializeStoredActiveOrder,
   shouldRequirePhoneVerification,
@@ -569,9 +570,9 @@ describe('public menu helpers', () => {
       price: 32,
       quantity: 1,
       extras: [
-        { name: 'Catupiry', price: 5 },
-        { name: 'Cheddar', price: 4 },
-        { name: 'Calabresa extra', price: 6 },
+        { id: 'border-1', name: 'Catupiry', price: 5 },
+        { id: 'extra-2', name: 'Cheddar', price: 4 },
+        { id: 'extra-3', name: 'Calabresa extra', price: 6 },
       ],
       half_flavor: { menu_item_id: 'item-2', name: 'Calabresa' },
     })
@@ -588,6 +589,14 @@ describe('public menu helpers', () => {
     ])
     expect(decrementCartItem([cartItem], 0)).toEqual([])
     expect(removeCartItem([cartItem, { ...cartItem, menu_item_id: 'item-3' }], 0)).toHaveLength(1)
+    expect(removeCartItemExtra([cartItem], 0, 1)).toMatchObject([
+      {
+        extras: [
+          { name: 'Catupiry', price: 5 },
+          { name: 'Calabresa extra', price: 6 },
+        ],
+      },
+    ])
 
     expect(serializeStoredActiveOrder('order-1', 42)).toBe('{"id":"order-1","order_number":42}')
     expect(parseStoredActiveOrder('{"id":"order-1","order_number":42}')).toEqual({


### PR DESCRIPTION
## Resumo

Este PR melhora o fluxo de pedidos no cardápio público em dois pontos importantes:

- permite remover adicionais individualmente no carrinho
- reduz falhas genéricas durante a criação do pedido

## O que mudou

### 1. Remoção individual de adicionais
Antes, quando um cliente adicionava extras a um item, a única forma de remover esses adicionais era excluir o item inteiro do carrinho.

Agora o carrinho permite:

- remover um adicional específico de um item
- manter o item principal no carrinho
- recalcular o total normalmente após a remoção

### 2. Criação de pedido mais resiliente
O fluxo público de criação de pedido foi reforçado para evitar cair em erro genérico em cenários de falha intermediária.

Ajustes aplicados:

- os adicionais do carrinho agora carregam identificador interno para suportar remoção granular
- a geocodificação usada no cálculo de entrega passou a falhar de forma segura
- a rota pública de pedidos valida melhor o retorno da criação do pedido e dos itens
- quando ocorre erro interno na criação, a API passa a devolver a mensagem real do problema sempre que possível, em vez de responder apenas com `Erro ao criar pedido.`

## Impacto

- melhora a experiência do cliente ao editar o carrinho
- reduz fricção no checkout
- facilita diagnóstico quando houver falha real no backend
- mantém o Quality Gate estável com testes atualizados

## Cobertura e estabilidade

- testes unitários atualizados para o novo comportamento do carrinho
- helpers do menu público atualizados para o formato novo dos adicionais
- suíte completa validada sem regressões

## Validação

- `npm test`
- `npm run build`
