### PR TITLE
feat: support category-linked extras with automatic menu application

### DIFF
--- a/app/(dashboard)/extras/page.tsx
+++ b/app/(dashboard)/extras/page.tsx
@@ -20,10 +20,16 @@ import {
   type ExtraCategoryFilter,
 } from '@/features/products/extras-page'
 
+type CategoryOption = {
+  id: string
+  name: string
+}
+
 const extraSchema = z.object({
   name: z.string().min(1, 'Nome obrigatório'),
   price: z.coerce.number().min(0),
   category: z.enum(['border', 'flavor', 'other']),
+  category_id: z.string(),
 })
 
 type ExtraForm = z.infer<typeof extraSchema>
@@ -44,6 +50,15 @@ export default function ExtrasPage() {
       const res = await fetch('/api/extras')
       const json = await res.json()
       return json.data as Extra[]
+    },
+  })
+
+  const { data: categories = [] } = useQuery({
+    queryKey: ['categories'],
+    queryFn: async () => {
+      const res = await fetch('/api/categories')
+      const json = await res.json()
+      return (json.data ?? []) as CategoryOption[]
     },
   })
 
@@ -70,19 +85,26 @@ export default function ExtrasPage() {
   }
 
   async function onSubmit(values: ExtraForm) {
+    const payload = {
+      ...values,
+      category_id: values.category === 'border' || values.category_id === 'none'
+        ? null
+        : values.category_id,
+    }
+
     try {
       if (editing) {
         const res = await fetch(`/api/extras/${editing.id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(values),
+          body: JSON.stringify(payload),
         })
         if (!res.ok) throw new Error()
       } else {
         const res = await fetch('/api/extras', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(values),
+          body: JSON.stringify(payload),
         })
         if (!res.ok) throw new Error()
       }
@@ -127,6 +149,7 @@ export default function ExtrasPage() {
       open={open}
       onOpenChange={setOpen}
       editing={editing}
+      categories={categories}
       form={form}
       onSubmit={onSubmit}
     />

--- a/app/[slug]/menu/page.tsx
+++ b/app/[slug]/menu/page.tsx
@@ -3,9 +3,11 @@ import { notFound } from 'next/navigation'
 import MenuClient from './MenuClient'
 import { ensureTenantBillingAccessState } from '@/lib/saas-billing'
 import {
+  applyAutomaticCategoryExtras,
   applyAutomaticBorderExtras,
   normalizePublicMenuItems,
   normalizeTenantDeliverySettings,
+  type MenuExtra,
 } from '@/features/menu/public-menu'
 import { createAdminClient } from '@/lib/supabase/admin'
 
@@ -128,7 +130,7 @@ export default async function MenuPage({
       price, image_url, available, display_order, created_at, updated_at,
       category:categories(id, name),
       extras:menu_item_extras(
-        extra:extras(id, name, price, category)
+        extra:extras(id, name, price, category, category_id)
       )
     `)
     .eq('tenant_id', tenant.id)
@@ -136,17 +138,21 @@ export default async function MenuPage({
     .order('display_order', { ascending: true })
     .order('name', { ascending: true })
 
-  const { data: rawBorderExtras } = await publicSupabase
+  const { data: rawActiveExtras } = await publicSupabase
     .from('extras')
-    .select('id, name, price, category')
+    .select('id, name, price, category, category_id')
     .eq('tenant_id', tenant.id)
     .eq('active', true)
-    .eq('category', 'border')
     .order('name', { ascending: true })
 
-  const items = applyAutomaticBorderExtras(
-    normalizePublicMenuItems((rawItems ?? []) as never),
-    (rawBorderExtras ?? []) as never,
+  const normalizedItems = normalizePublicMenuItems((rawItems ?? []) as never)
+  const activeExtras = (rawActiveExtras ?? []) as MenuExtra[]
+  const items = applyAutomaticCategoryExtras(
+    applyAutomaticBorderExtras(
+      normalizedItems,
+      activeExtras.filter((extra) => extra.category === 'border'),
+    ),
+    activeExtras,
   )
 
   let tableInfo: { id: string; number: string } | null = null

--- a/app/api/extras/[id]/route.ts
+++ b/app/api/extras/[id]/route.ts
@@ -6,6 +6,7 @@ const updateSchema = z.object({
   name: z.string().min(1).optional(),
   price: z.coerce.number().min(0).optional(),
   category: z.enum(['border', 'flavor', 'other']).optional(),
+  category_id: z.string().uuid().nullable().optional(),
   active: z.boolean().optional(),
 })
 

--- a/app/api/extras/route.ts
+++ b/app/api/extras/route.ts
@@ -7,6 +7,7 @@ const extraSchema = z.object({
   name: z.string().min(1, 'Nome obrigatório'),
   price: z.coerce.number().min(0),
   category: z.enum(['border', 'flavor', 'other']),
+  category_id: z.string().uuid().nullable().optional(),
   active: z.boolean().default(true),
 })
 

--- a/features/menu/dashboard-menu-page.ts
+++ b/features/menu/dashboard-menu-page.ts
@@ -188,6 +188,7 @@ export type MenuExtraOption = {
   name: string
   price: number
   category: string
+  category_id?: string | null
 }
 
 const MENU_EXTRA_CATEGORY_ORDER = ['border', 'flavor', 'other'] as const
@@ -205,11 +206,17 @@ export function getSelectableMenuExtras(
   categoryId?: string,
   categories?: MenuCategoryOption[]
 ) {
-  if (!isPizzaCategoryId(categoryId, categories)) {
-    return allExtras
-  }
+  return allExtras.filter((extra) => {
+    if (extra.category_id) {
+      return false
+    }
 
-  return allExtras.filter((extra) => extra.category !== 'border')
+    if (isPizzaCategoryId(categoryId, categories) && extra.category === 'border') {
+      return false
+    }
+
+    return true
+  })
 }
 
 export function getPersistedMenuExtraIds(
@@ -218,17 +225,13 @@ export function getPersistedMenuExtraIds(
   categoryId?: string,
   categories?: MenuCategoryOption[]
 ) {
-  if (!isPizzaCategoryId(categoryId, categories)) {
-    return selectedExtraIds
-  }
-
-  const borderExtraIds = new Set(
+  const nonPersistedExtraIds = new Set(
     allExtras
-      .filter((extra) => extra.category === 'border')
+      .filter((extra) => extra.category_id || (isPizzaCategoryId(categoryId, categories) && extra.category === 'border'))
       .map((extra) => extra.id)
   )
 
-  return selectedExtraIds.filter((extraId) => !borderExtraIds.has(extraId))
+  return selectedExtraIds.filter((extraId) => !nonPersistedExtraIds.has(extraId))
 }
 
 export function groupMenuExtrasByCategory(allExtras: MenuExtraOption[]) {

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -8,6 +8,7 @@ export type MenuExtra = {
   name: string
   price: number
   category: string
+  category_id?: string | null
 }
 
 export type MenuCategory = {
@@ -59,8 +60,8 @@ export type PublicCheckoutStep = 'cart' | 'info' | 'address' | 'done'
 
 type RawExtra = {
   extra:
-    | { id: string; name: string; price: number; category: string }
-    | { id: string; name: string; price: number; category: string }[]
+    | { id: string; name: string; price: number; category: string; category_id?: string | null }
+    | { id: string; name: string; price: number; category: string; category_id?: string | null }[]
     | null
 }
 
@@ -1068,6 +1069,35 @@ export function applyAutomaticBorderExtras(items: PublicMenuItem[], borderExtras
     return {
       ...item,
       extras: [...item.extras, ...automaticBorders],
+    }
+  })
+}
+
+export function applyAutomaticCategoryExtras(items: PublicMenuItem[], extras: MenuExtra[]) {
+  if (extras.length === 0) {
+    return items
+  }
+
+  return items.map((item) => {
+    const existingIds = new Set(
+      item.extras
+        .map((entry) => entry.extra?.id)
+        .filter((extraId): extraId is string => typeof extraId === 'string')
+    )
+
+    const automaticExtras = extras
+      .filter((extra) => extra.category !== 'border')
+      .filter((extra) => extra.category_id && extra.category_id === item.category_id)
+      .filter((extra) => !existingIds.has(extra.id))
+      .map((extra) => ({ extra }))
+
+    if (automaticExtras.length === 0) {
+      return item
+    }
+
+    return {
+      ...item,
+      extras: [...item.extras, ...automaticExtras],
     }
   })
 }

--- a/features/products/ExtrasPageContent.tsx
+++ b/features/products/ExtrasPageContent.tsx
@@ -13,6 +13,12 @@ type ExtraForm = {
   name: string
   price: number
   category: 'border' | 'flavor' | 'other'
+  category_id: string
+}
+
+type CategoryOption = {
+  id: string
+  name: string
 }
 
 const categoryLabels = {
@@ -47,6 +53,7 @@ type Props = {
   open: boolean
   onOpenChange: (open: boolean) => void
   editing: Extra | null
+  categories: CategoryOption[]
   form: UseFormReturn<ExtraForm>
   onSubmit: (values: ExtraForm) => void | Promise<void>
 }
@@ -71,9 +78,12 @@ export function ExtrasPageContent({
   open,
   onOpenChange,
   editing,
+  categories,
   form,
   onSubmit,
 }: Props) {
+  const selectedType = form.watch('category')
+
   return (
     <div>
       <div className="mb-6 flex items-center justify-between">
@@ -131,7 +141,7 @@ export function ExtrasPageContent({
           <table className="w-full text-sm">
             <thead className="border-b border-slate-200 bg-slate-50">
               <tr>
-                {['Adicional', 'Tipo', 'Preço', ''].map((h) => (
+                {['Adicional', 'Tipo', 'Categoria vinculada', 'Preço', ''].map((h) => (
                   <th key={h} className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
                     {h}
                   </th>
@@ -146,6 +156,11 @@ export function ExtrasPageContent({
                     <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${categoryColors[extra.category]}`}>
                       {categoryLabels[extra.category]}
                     </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">
+                    {extra.category === 'border'
+                      ? 'Pizza (automático)'
+                      : categories.find((category) => category.id === extra.category_id)?.name ?? 'Todas as categorias'}
                   </td>
                   <td className="px-4 py-3 text-slate-600">
                     {extra.price > 0 ? `+ R$ ${Number(extra.price).toFixed(2)}` : 'Grátis'}
@@ -210,6 +225,43 @@ export function ExtrasPageContent({
                         <SelectItem value="other">Outro</SelectItem>
                       </SelectContent>
                     </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="category_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Categoria vinculada</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={selectedType === 'border' ? 'none' : field.value}
+                      disabled={selectedType === 'border'}
+                    >
+                      <FormControl>
+                        <SelectTrigger><SelectValue /></SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="none">Todas as categorias</SelectItem>
+                        {categories.map((category) => (
+                          <SelectItem key={category.id} value={category.id}>
+                            {category.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {selectedType === 'border' ? (
+                      <p className="text-xs text-slate-500">
+                        Bordas são aplicadas automaticamente aos itens das categorias de pizza.
+                      </p>
+                    ) : (
+                      <p className="text-xs text-slate-500">
+                        Escolha uma categoria para aplicar este adicional automaticamente ou deixe em todas.
+                      </p>
+                    )}
                     <FormMessage />
                   </FormItem>
                 )}

--- a/features/products/extras-page.ts
+++ b/features/products/extras-page.ts
@@ -6,6 +6,7 @@ export type Extra = {
   name: string
   price: number
   category: ExtraCategory
+  category_id?: string | null
   active: boolean
 }
 
@@ -19,6 +20,7 @@ export type ExtraFormValues = {
   name: string
   price: number
   category: ExtraCategory
+  category_id: string
 }
 
 export function getDefaultExtraFormValues(): ExtraFormValues {
@@ -26,6 +28,7 @@ export function getDefaultExtraFormValues(): ExtraFormValues {
     name: '',
     price: 0,
     category: 'other',
+    category_id: 'none',
   }
 }
 
@@ -38,6 +41,7 @@ export function getExtraFormValues(extra: Extra | null): ExtraFormValues {
     name: extra.name,
     price: extra.price,
     category: extra.category,
+    category_id: extra.category_id ?? 'none',
   }
 }
 

--- a/tests/unit/catalog-edit-page-component.test.tsx
+++ b/tests/unit/catalog-edit-page-component.test.tsx
@@ -45,6 +45,7 @@ vi.mock('react-hook-form', () => ({
     reset: formResetMock,
     setError: formSetErrorMock,
     handleSubmit: vi.fn((callback: (values: unknown) => unknown) => callback),
+    watch: vi.fn(() => 'other'),
     formState: {
       isSubmitting: false,
       errors: {},
@@ -187,6 +188,7 @@ describe('catalog pages edit branches', () => {
         name: 'Borda Cheddar',
         category: 'border',
         price: 12,
+        category_id: null,
       }),
     })
     expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: ['extras'] })
@@ -376,6 +378,7 @@ describe('catalog pages edit branches', () => {
       name: 'Molho especial',
       category: 'other',
       price: 4,
+      category_id: 'none',
     })
 
     await props.onDelete({ id: 'extra-1', name: 'Molho' })
@@ -388,6 +391,7 @@ describe('catalog pages edit branches', () => {
         name: 'Molho especial',
         category: 'other',
         price: 4,
+        category_id: null,
       }),
     })
     expect(fetchMock).toHaveBeenCalledTimes(2)
@@ -443,11 +447,13 @@ describe('catalog pages edit branches', () => {
       name: '',
       category: 'other',
       price: 0,
+      category_id: 'none',
     })
     expect(formResetMock).toHaveBeenCalledWith({
       name: 'Catupiry',
       category: 'border',
       price: 8,
+      category_id: 'none',
     })
     expect(stateSetters[1]).toHaveBeenCalledWith(null)
     expect(stateSetters[0]).toHaveBeenCalledWith(true)
@@ -487,6 +493,7 @@ describe('catalog pages edit branches', () => {
       name: 'Molho verde',
       category: 'other',
       price: 5,
+      category_id: 'none',
     })
 
     expect(fetchMock).toHaveBeenCalledWith('/api/extras/extra-20', {
@@ -496,6 +503,7 @@ describe('catalog pages edit branches', () => {
         name: 'Molho verde',
         category: 'other',
         price: 5,
+        category_id: null,
       }),
     })
     expect(formSetErrorMock).toHaveBeenCalledWith('root', {

--- a/tests/unit/catalog-page-content.test.tsx
+++ b/tests/unit/catalog-page-content.test.tsx
@@ -139,9 +139,11 @@ describe('catalog page contents', () => {
         editing: null,
         form: {
           control: {},
+          watch: () => 'other',
           handleSubmit: () => vi.fn(),
           formState: { isSubmitting: false, errors: {} },
         },
+        categories: [{ id: 'cat-1', name: 'Pizzas' }],
         onSubmit: vi.fn(),
       }
 
@@ -350,32 +352,34 @@ describe('catalog page contents', () => {
     const onOpenChange = vi.fn()
 
     const props = {
-        planUsageText: ' (1/20)',
-        extrasLimitReached: false,
-        extrasLimit: 20,
-        openCreate,
-        nameFilter: '',
-        onNameFilterChange,
-        categoryFilter: 'all',
-        onCategoryFilterChange,
-        isLoading: false,
-        filteredExtras: [{ id: 'extra-1', name: 'Borda', category: 'border', price: 10 }],
-        paginatedExtras: [{ id: 'extra-1', name: 'Borda', category: 'border', price: 10 }],
-        openEdit,
-        onDelete,
-        page: 1,
-        totalPages: 1,
-        onPageChange,
-        open: true,
-        onOpenChange,
-        editing: null,
-        form: {
-          control: {},
-          handleSubmit: () => vi.fn(),
-          formState: { isSubmitting: false, errors: {} },
-        },
-        onSubmit: vi.fn(),
-      }
+      planUsageText: ' (1/20)',
+      extrasLimitReached: false,
+      extrasLimit: 20,
+      openCreate,
+      nameFilter: '',
+      onNameFilterChange,
+      categoryFilter: 'all',
+      onCategoryFilterChange,
+      isLoading: false,
+      filteredExtras: [{ id: 'extra-1', name: 'Borda', category: 'border', price: 10, category_id: null }],
+      paginatedExtras: [{ id: 'extra-1', name: 'Borda', category: 'border', price: 10, category_id: null }],
+      openEdit,
+      onDelete,
+      page: 1,
+      totalPages: 1,
+      onPageChange,
+      open: true,
+      onOpenChange,
+      editing: null,
+      categories: [{ id: 'cat-1', name: 'Pizzas' }],
+      form: {
+        control: {},
+        handleSubmit: () => vi.fn(),
+        formState: { isSubmitting: false, errors: {} },
+        watch: () => 'border',
+      },
+      onSubmit: vi.fn(),
+    }
 
     const markup = renderToStaticMarkup(React.createElement(ExtrasPageContent, props))
 
@@ -431,9 +435,11 @@ describe('catalog page contents', () => {
       form: {
         control: {},
         handleSubmit: (callback: (values: unknown) => void) => () =>
-          callback({ name: 'Cheddar', category: 'flavor', price: 5 }),
+          callback({ name: 'Cheddar', category: 'flavor', price: 5, category_id: 'cat-1' }),
+        watch: () => 'border',
         formState: { isSubmitting: true, errors: { root: { message: 'Erro ao salvar adicional.' } } },
       },
+      categories: [{ id: 'cat-1', name: 'Pizzas' }],
       onSubmit,
     })
 
@@ -470,9 +476,11 @@ describe('catalog page contents', () => {
       form: {
         control: {},
         handleSubmit: (callback: (values: unknown) => void) => () =>
-          callback({ name: 'Cheddar', category: 'flavor', price: 5 }),
+          callback({ name: 'Cheddar', category: 'flavor', price: 5, category_id: 'cat-1' }),
+        watch: () => 'other',
         formState: { isSubmitting: false, errors: {} },
       },
+      categories: [{ id: 'cat-1', name: 'Pizzas' }],
       onSubmit,
     })
 
@@ -493,7 +501,7 @@ describe('catalog page contents', () => {
     expect(openCreate).toHaveBeenCalledTimes(1)
     expect(openEdit).toHaveBeenCalledWith({ id: 'extra-1', name: 'Molho', category: 'other', price: 0 })
     expect(onDelete).toHaveBeenCalledWith({ id: 'extra-1', name: 'Molho', category: 'other', price: 0 })
-    expect(onSubmit).toHaveBeenCalledWith({ name: 'Cheddar', category: 'flavor', price: 5 })
+    expect(onSubmit).toHaveBeenCalledWith({ name: 'Cheddar', category: 'flavor', price: 5, category_id: 'cat-1' })
   })
 
   it('cobre loading e render de adicional de sabor', async () => {
@@ -522,9 +530,11 @@ describe('catalog page contents', () => {
         editing: null,
         form: {
           control: {},
+          watch: () => 'other',
           handleSubmit: () => vi.fn(),
           formState: { isSubmitting: false, errors: {} },
         },
+        categories: [],
         onSubmit: vi.fn(),
       }),
     )
@@ -552,9 +562,11 @@ describe('catalog page contents', () => {
         editing: null,
         form: {
           control: {},
+          watch: () => 'flavor',
           handleSubmit: () => vi.fn(),
           formState: { isSubmitting: false, errors: {} },
         },
+        categories: [{ id: 'cat-2', name: 'Lanches' }],
         onSubmit: vi.fn(),
       }),
     )

--- a/tests/unit/catalog-pages-component.test.tsx
+++ b/tests/unit/catalog-pages-component.test.tsx
@@ -97,6 +97,7 @@ describe('catalog and users page components', () => {
       reset: vi.fn(),
       setError: vi.fn(),
       handleSubmit: vi.fn((callback: (values: unknown) => unknown) => callback),
+      watch: vi.fn(() => 'other'),
       formState: {
         isSubmitting: false,
         errors: {},
@@ -429,10 +430,12 @@ describe('catalog and users page components', () => {
   })
 
   it('executa a queryFn real da página de extras', async () => {
-    let capturedQueryFn: (() => Promise<unknown>) | null = null
+    let extrasQueryFn: (() => Promise<unknown>) | null = null
 
-    useQueryMock.mockImplementation((options: { queryFn: () => Promise<unknown> }) => {
-      capturedQueryFn = options.queryFn
+    useQueryMock.mockImplementation((options: { queryKey: string[]; queryFn: () => Promise<unknown> }) => {
+      if (options.queryKey[0] === 'extras') {
+        extrasQueryFn = options.queryFn
+      }
       return {
         data: [],
         isLoading: false,
@@ -458,8 +461,8 @@ describe('catalog and users page components', () => {
 
     renderToStaticMarkup(React.createElement(ExtrasPage))
 
-    expect(capturedQueryFn).toBeTypeOf('function')
-    await expect(capturedQueryFn?.()).resolves.toEqual([
+    expect(extrasQueryFn).toBeTypeOf('function')
+    await expect(extrasQueryFn?.()).resolves.toEqual([
       {
         id: 'extra-1',
         name: 'Borda',

--- a/tests/unit/dashboard-menu-page.test.ts
+++ b/tests/unit/dashboard-menu-page.test.ts
@@ -319,7 +319,7 @@ describe('dashboard menu page helpers', () => {
     expect(getSelectableMenuExtras(
       [
         { id: 'extra-1', name: 'Catupiry', price: 4, category: 'border' },
-        { id: 'extra-2', name: 'Cheddar', price: 3, category: 'border' },
+        { id: 'extra-2', name: 'Cheddar', price: 3, category: 'border', category_id: 'cat-1' },
         { id: 'extra-3', name: 'Molho da casa', price: 2, category: 'other' },
       ],
       'cat-1',
@@ -332,6 +332,7 @@ describe('dashboard menu page helpers', () => {
       ['extra-1', 'extra-3'],
       [
         { id: 'extra-1', name: 'Catupiry', price: 4, category: 'border' },
+        { id: 'extra-2', name: 'Cheddar', price: 3, category: 'border', category_id: 'cat-1' },
         { id: 'extra-3', name: 'Molho da casa', price: 2, category: 'other' },
       ],
       'cat-1',

--- a/tests/unit/extras-page.test.ts
+++ b/tests/unit/extras-page.test.ts
@@ -40,6 +40,7 @@ describe('extras page helpers', () => {
       name: '',
       price: 0,
       category: 'other',
+      category_id: 'none',
     })
 
     expect(getExtraFormValues(null)).toEqual(getDefaultExtraFormValues())
@@ -47,6 +48,7 @@ describe('extras page helpers', () => {
       name: 'Borda de catupiry',
       price: 8,
       category: 'border',
+      category_id: 'none',
     })
   })
 


### PR DESCRIPTION
## Resumo

Este PR melhora o cadastro de adicionais para permitir vínculo automático por categoria do cardápio.

## Problema

Hoje apenas adicionais do tipo `Borda` têm aplicação automática, entrando nos itens de pizza sem necessidade de vínculo manual.

Já os adicionais do tipo `Extras` precisavam ser vinculados item por item, o que não atende bem cenários em que o adicional faz sentido para uma categoria inteira, como por exemplo:

- `Vinagrete` para `Refeições`
- `Farofa` para `Prato do dia`
- `Molho especial` para uma categoria específica

## O que mudou

- o modal de cadastro/edição de adicional ganhou um novo campo `Categoria vinculada`
- esse campo permite escolher uma categoria específica do cardápio
- o vínculo é persistido em `extras.category_id`
- adicionais com `category_id` passam a ser aplicados automaticamente aos itens daquela categoria no cardápio público
- adicionais automáticos por categoria deixam de depender de vínculo manual em `menu_item_extras`
- no admin, esses adicionais automáticos deixam de aparecer como opção de seleção manual item a item

## Regras finais

### Borda
- continua com comportamento automático para categorias de pizza
- não depende de categoria manual no formulário
- o campo `Categoria vinculada` fica desabilitado nesse caso

### Extras e Outro
- podem ser deixados sem categoria específica
- podem ser vinculados a uma categoria do cardápio
- quando há categoria vinculada, entram automaticamente nos itens dessa categoria

## Persistência

Foi adicionada a coluna:

- `extras.category_id`

Script incluído em:

- `docs/sql/add-extras-category-id.sql`

## Impacto

- reduz trabalho operacional no cadastro de adicionais
- evita vínculo manual repetitivo em vários itens do cardápio
- mantém a lógica especial de borda para pizza
- permite modelar adicionais que fazem sentido por categoria, e não por item isolado

## Cobertura e estabilidade

- testes unitários atualizados para extras, catálogo e regras do cardápio
- suíte completa validada
- build validado

## Validação

- `npm test`
- `npm run build`
