### PR TITLE
fix: retry plan subscriptions without payer email on mercado pago mismatch

### DIFF
--- a/lib/mercadopago.ts
+++ b/lib/mercadopago.ts
@@ -14,6 +14,13 @@ export class MercadoPagoApiError extends Error {
   }
 }
 
+function isMercadoPagoPayerCollectorMismatchError(error: unknown) {
+  return (
+    error instanceof MercadoPagoApiError &&
+    error.message.includes('Both payer and collector must be real or test users')
+  )
+}
+
 function getRequiredEnv(name: string) {
   const value = process.env[name]
 
@@ -176,24 +183,35 @@ export async function createSaasSubscriptionLink(params: {
   const accessToken = params.accessToken ?? getMercadoPagoAccessToken()
   const includePayerEmail = !!params.payerEmail && !isMercadoPagoTestAccessToken(accessToken)
 
-  return mercadoPagoRequest<SubscriptionPreapproval>('/preapproval', {
-    method: 'POST',
-    idempotencyKey: crypto.randomUUID(),
-    accessToken,
-    body: JSON.stringify({
-      reason: params.reason,
-      ...(includePayerEmail ? { payer_email: params.payerEmail } : {}),
-      external_reference: params.externalReference,
-      auto_recurring: {
-        frequency: 1,
-        frequency_type: 'months',
-        transaction_amount: params.amount,
-        currency_id: 'BRL',
-      },
-      back_url: params.backUrl,
-      status: 'pending',
-    }),
-  })
+  const requestSubscription = (shouldIncludePayerEmail: boolean) =>
+    mercadoPagoRequest<SubscriptionPreapproval>('/preapproval', {
+      method: 'POST',
+      idempotencyKey: crypto.randomUUID(),
+      accessToken,
+      body: JSON.stringify({
+        reason: params.reason,
+        ...(shouldIncludePayerEmail ? { payer_email: params.payerEmail } : {}),
+        external_reference: params.externalReference,
+        auto_recurring: {
+          frequency: 1,
+          frequency_type: 'months',
+          transaction_amount: params.amount,
+          currency_id: 'BRL',
+        },
+        back_url: params.backUrl,
+        status: 'pending',
+      }),
+    })
+
+  try {
+    return await requestSubscription(includePayerEmail)
+  } catch (error) {
+    if (includePayerEmail && isMercadoPagoPayerCollectorMismatchError(error)) {
+      return requestSubscription(false)
+    }
+
+    throw error
+  }
 }
 
 export async function getPreapprovalById(preapprovalId: string, accessToken?: string) {

--- a/tests/unit/mercadopago.test.ts
+++ b/tests/unit/mercadopago.test.ts
@@ -273,6 +273,39 @@ describe('mercadopago helpers', () => {
     expect(JSON.parse(String(request?.body))).not.toHaveProperty('payer_email')
   })
 
+  it('refaz a assinatura SaaS sem payer_email quando o Mercado Pago detecta mismatch de ambiente', async () => {
+    process.env.MERCADO_PAGO_ACCESS_TOKEN = 'APP_USR-123'
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ message: 'Both payer and collector must be real or test users' }),
+          { status: 400 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'pre-fallback', status: 'pending' }), { status: 200 })
+      )
+
+    await expect(
+      createSaasSubscriptionLink({
+        reason: 'ChefOps Premium',
+        payerEmail: 'owner@test.com',
+        externalReference: 'saas:tenant:1:plan:pro',
+        amount: 189,
+        backUrl: 'https://chefops.test/planos',
+      })
+    ).resolves.toMatchObject({ id: 'pre-fallback', status: 'pending' })
+
+    const firstRequest = fetchMock.mock.calls[0]?.[1]
+    const secondRequest = fetchMock.mock.calls[1]?.[1]
+
+    expect(JSON.parse(String(firstRequest?.body))).toMatchObject({
+      payer_email: 'owner@test.com',
+    })
+    expect(JSON.parse(String(secondRequest?.body))).not.toHaveProperty('payer_email')
+  })
+
   it('verifyMercadoPagoWebhookSignature valida manifesto assinado', () => {
     process.env.MERCADO_PAGO_WEBHOOK_SECRET = 'webhook-secret'
 


### PR DESCRIPTION
## Resumo

Este PR corrige a falha na criação de assinatura de planos pagos quando o Mercado Pago acusa incompatibilidade entre pagador e coletor.

## Problema

Em produção, ao tentar iniciar uma assinatura, o usuário podia receber o alerta:

- `A assinatura não pôde ser iniciada porque o ambiente do Mercado Pago está misturando usuários de teste e produção...`

Mesmo com credenciais corretas, a criação do `preapproval` podia falhar quando o `payer_email` enviado entrava em conflito com a validação de ambiente feita pelo Mercado Pago.

## Correção aplicada

- o helper de assinatura SaaS agora tenta criar o `preapproval` com `payer_email`
- se o Mercado Pago responder o erro:
  - `Both payer and collector must be real or test users`
- o fluxo refaz automaticamente a requisição sem `payer_email`
- se a segunda tentativa funcionar, a assinatura segue normalmente sem expor erro ao usuário
- outros erros continuam sendo propagados normalmente

## Impacto

- reduz falhas ao iniciar assinatura de planos pagos
- evita alerta indevido para usuários em produção
- mantém compatibilidade com o fluxo atual de checkout do Mercado Pago
- melhora a resiliência da integração sem alterar o contrato da rota

## Cobertura e estabilidade

- teste unitário adicionado para validar o retry automático sem `payer_email`
- suíte completa validada com sucesso
- build validado com sucesso

## Validação

- `npm test`
- `npm run build`
