### PR TITLE
fix: hide pending subscriptions from plans summary and cancel banner

### DIFF
--- a/features/plans/components/PlanosPageContent.tsx
+++ b/features/plans/components/PlanosPageContent.tsx
@@ -4,7 +4,7 @@ import { PlanCard } from '@/features/plans/components/PlanCard'
 import { PlanSubscriptionSummary } from '@/features/plans/components/PlanSubscriptionSummary'
 import type { Plan } from '@/features/plans/types'
 
-import { dashboardPlans } from '@/features/plans/plans-page'
+import { dashboardPlans, isPaidSubscriptionConfirmed } from '@/features/plans/plans-page'
 
 type CurrentSubscription = {
   status: string
@@ -29,6 +29,8 @@ export function PlanosPageContent({
   onSelectPlan,
   onCancelSubscription,
 }: Props) {
+  const hasConfirmedPaidSubscription = isPaidSubscriptionConfirmed(currentSubscription)
+
   return (
     <div>
       <PlanSubscriptionSummary currentPlan={currentPlan} currentSubscription={currentSubscription} />
@@ -46,8 +48,8 @@ export function PlanosPageContent({
         ))}
       </div>
 
-      {currentSubscription &&
-        ['authorized', 'pending'].includes(currentSubscription.status) &&
+      {hasConfirmedPaidSubscription &&
+        currentSubscription &&
         !currentSubscription.cancel_at_period_end && (
           <div className="mt-6 rounded-xl border border-amber-200 bg-amber-50 p-6">
             <h3 className="font-medium text-amber-900">Cancelar renovação</h3>

--- a/features/plans/plans-page.ts
+++ b/features/plans/plans-page.ts
@@ -14,30 +14,39 @@ export function isPaidSubscriptionActive(subscription: BillingSubscription) {
   return !!subscription && ['authorized', 'pending'].includes(subscription.status)
 }
 
+export function isPaidSubscriptionConfirmed(subscription: BillingSubscription) {
+  return !!subscription && subscription.status === 'authorized'
+}
+
 export function formatPlanDate(date: string | null) {
   if (!date) return null
   return new Date(date).toLocaleDateString('pt-BR')
 }
 
 export function getSubscriptionSummary(subscription: BillingSubscription) {
-  if (!subscription) return null
+  if (!isPaidSubscriptionConfirmed(subscription)) return null
+  const activeSubscription = subscription as NonNullable<BillingSubscription>
 
-  const base = `Assinatura atual: ${PLAN_LABELS[subscription.plan]} · status ${subscription.status}`
-  const nextPayment = formatPlanDate(subscription.next_payment_date)
+  const base = `Assinatura atual: ${PLAN_LABELS[activeSubscription.plan]} · status ${activeSubscription.status}`
+  const nextPayment = formatPlanDate(activeSubscription.next_payment_date)
 
   return nextPayment ? `${base} · próxima cobrança em ${nextPayment}` : base
 }
 
 export function getCancellationSummary(subscription: BillingSubscription) {
-  if (!subscription?.cancel_at_period_end || !subscription.next_payment_date) return null
+  if (!isPaidSubscriptionConfirmed(subscription)) return null
+  const activeSubscription = subscription as NonNullable<BillingSubscription>
+  if (!activeSubscription.cancel_at_period_end || !activeSubscription.next_payment_date) return null
 
-  return `Renovação cancelada. O acesso continua até ${formatPlanDate(subscription.next_payment_date)}.`
+  return `Renovação cancelada. O acesso continua até ${formatPlanDate(activeSubscription.next_payment_date)}.`
 }
 
 export function getScheduledPlanSummary(subscription: BillingSubscription) {
-  if (!subscription?.scheduled_plan || !subscription.next_payment_date) return null
+  if (!isPaidSubscriptionConfirmed(subscription)) return null
+  const activeSubscription = subscription as NonNullable<BillingSubscription>
+  if (!activeSubscription.scheduled_plan || !activeSubscription.next_payment_date) return null
 
-  return `Mudança programada para ${PLAN_LABELS[subscription.scheduled_plan]} em ${formatPlanDate(subscription.next_payment_date)}.`
+  return `Mudança programada para ${PLAN_LABELS[activeSubscription.scheduled_plan]} em ${formatPlanDate(activeSubscription.next_payment_date)}.`
 }
 
 export function getPlanCardState({

--- a/tests/unit/plans-page.test.tsx
+++ b/tests/unit/plans-page.test.tsx
@@ -128,6 +128,7 @@ describe('plans page helpers and components', () => {
     expect(plansPage.getPlanPriceLabel('free')).toBe('Grátis')
     expect(plansPage.getPlanPriceLabel('basic')).toBe('R$ 89/mês')
     expect(plansPage.isPaidSubscriptionActive(subscription)).toBe(true)
+    expect(plansPage.isPaidSubscriptionConfirmed(subscription)).toBe(true)
     expect(plansPage.formatPlanDate(null)).toBeNull()
     expect(
       plansPage.getSubscriptionSummary({
@@ -135,7 +136,20 @@ describe('plans page helpers and components', () => {
         plan: 'basic',
         next_payment_date: null,
       })
-    ).toBe('Assinatura atual: Standard · status pending')
+    ).toBeNull()
+    expect(
+      plansPage.getCancellationSummary({
+        status: 'pending',
+        plan: 'basic',
+        next_payment_date: '2026-04-21T00:00:00.000Z',
+        cancel_at_period_end: true,
+      })
+    ).toBeNull()
+    expect(plansPage.isPaidSubscriptionConfirmed({
+      status: 'pending',
+      plan: 'basic',
+      next_payment_date: null,
+    })).toBe(false)
   })
 
   it('renderiza resumo, card e painel de ajuda', async () => {
@@ -231,8 +245,8 @@ describe('plans page helpers and components', () => {
     )
 
     expect(summaryMarkup).toContain('Seu plano atual:')
-    expect(summaryMarkup).toContain('Assinatura atual:')
-    expect(summaryMarkup).toContain('Mudança programada para Premium')
+    expect(summaryMarkup).not.toContain('Assinatura atual:')
+    expect(summaryMarkup).not.toContain('Mudança programada para Premium')
     expect(cardMarkup).toContain('Premium')
     expect(cardMarkup).toContain('Assinar agora')
     expect(cardMarkup).toContain('White-label')
@@ -243,7 +257,7 @@ describe('plans page helpers and components', () => {
     expect(summaryWithoutSubscriptionMarkup).toContain('Seu plano atual:')
     expect(summaryWithoutSubscriptionMarkup).not.toContain('Assinatura atual:')
     expect(summaryWithoutCurrentPlanMarkup).toContain('Basic')
-    expect(summaryWithoutNextPaymentMarkup).toContain('Assinatura atual:')
+    expect(summaryWithoutNextPaymentMarkup).not.toContain('Assinatura atual:')
     expect(summaryWithoutNextPaymentMarkup).not.toContain('próxima cobrança em')
     expect(summaryWithCancellationOnlyMarkup).toContain('Renovação cancelada')
     expect(summaryWithCancellationOnlyMarkup).not.toContain('Mudança programada para')


### PR DESCRIPTION
## Resumo

Este PR corrige a exibição incorreta de assinatura na página de planos quando o usuário inicia o checkout no Mercado Pago, mas ainda não conclui a assinatura.

## Problema

Ao clicar em assinar um plano pago, o sistema redirecionava corretamente para o Mercado Pago.

Porém, se o usuário voltasse para a página anterior antes da confirmação da assinatura, a tela de planos já mostrava:

- `Assinatura atual: ...`
- `status Pending`
- `próxima cobrança em ...`
- banner de `Cancelar renovação`

Isso gerava uma falsa percepção de que a assinatura já estava ativa, quando na prática ela ainda não havia sido confirmada.

## Correção aplicada

- a página de planos agora diferencia:
  - assinatura paga iniciada
  - assinatura paga efetivamente confirmada
- o resumo de assinatura passa a ser exibido apenas quando o status é `authorized`
- o banner de cancelamento de renovação também passa a aparecer apenas quando a assinatura está realmente confirmada
- assinaturas em `pending` não são mais tratadas como assinatura ativa para exibição visual do resumo

## Impacto

- evita confusão para o usuário ao voltar do checkout
- impede que a interface mostre cobrança futura antes da confirmação real
- remove o banner de cancelamento em estados ainda não confirmados
- mantém a lógica de upgrade e troca de plano consistente com o status real da assinatura

## Cobertura e estabilidade

- testes unitários da página de planos atualizados
- suíte completa validada com sucesso
- build validado com sucesso

## Validação

- `npm test`
- `npm run build`
