### PR TITLE
refactor(menu): remove manual link of additional items on the menu and test correction

### DIFF
--- a/.agents/rules/master-rules.md
+++ b/.agents/rules/master-rules.md
@@ -1,0 +1,7 @@
+---
+trigger: always_on
+---
+
+Nunca em hipótese alguma, altere o layout dessa aplicação sem uma solicitação explicita para isso.
+
+Todo o desenvolvimento aqui, deve ser feito seguindo a metodologia XP e deve ser feito fortemente o TDD.

--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -44,6 +44,7 @@ import {
   buildPublicOrderPayload,
   parseStoredActiveOrder,
   type MenuExtra,
+  type PublicCheckoutStep,
   type PublicMenuItem as MenuItem,
   type PublicOrderStatus,
   removeCartItem,
@@ -125,7 +126,7 @@ export default function MenuClient({
 
   const [cart, setCart] = useState<CartItem[]>([])
   const [cartOpen, setCartOpen] = useState(false)
-  const [checkoutStep, setCheckoutStep] = useState<'cart' | 'info' | 'address' | 'done'>('cart')
+  const [checkoutStep, setCheckoutStep] = useState<PublicCheckoutStep>('cart')
   const [halfFlavorModal, setHalfFlavorModal] = useState<{ item: MenuItem } | null>(null)
   const [selectedBorders, setSelectedBorders] = useState<Record<string, MenuExtra | null>>({})
   const [phone, setPhone] = useState('')

--- a/app/[slug]/menu/MenuClient.tsx
+++ b/app/[slug]/menu/MenuClient.tsx
@@ -34,6 +34,7 @@ import {
   getSuccessfulPublicOrderState,
   groupMenuItems,
   incrementCartItem,
+  isSameCartItem,
   getLookupCustomerFoundState,
   getLookupCustomerMissingState,
   getOnlineCheckoutErrorMessage,
@@ -158,6 +159,10 @@ export default function MenuClient({
   const [quotedDistanceKm, setQuotedDistanceKm] = useState<number | null>(null)
   const [deliveryQuoteMessage, setDeliveryQuoteMessage] = useState<string | null>(null)
   const [editingAddressId, setEditingAddressId] = useState<string | null>(null)
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const [previousOrders, setPreviousOrders] = useState<PublicOrderStatus[]>([])
+  const [loadingHistory, setLoadingHistory] = useState(false)
+  const [pendingHistoryOpen, setPendingHistoryOpen] = useState(false)
   const lastDeliveryQuoteAlertRef = useRef<string | null>(null)
   const activeOrderStorageKey = getActiveOrderStorageKey(tenant.slug, tableInfo?.id)
 
@@ -173,6 +178,8 @@ export default function MenuClient({
     quotedDeliveryFee,
   )
 
+  const activeOrdersCount = previousOrders.filter(o => !['delivered', 'cancelled'].includes(o.status)).length
+
   function addToCart(item: MenuItem, halfFlavor?: MenuItem) {
     if (operationClosedNotice) {
       toast.error(operationClosedNotice)
@@ -183,7 +190,14 @@ export default function MenuClient({
     const selectedExtras = selectedExtraOptions[item.id] ?? []
     const cartItem = createCartItem(item, border, selectedExtras, halfFlavor)
 
-    setCart((prev) => [...prev, cartItem])
+    const existingIndex = cart.findIndex((i) => isSameCartItem(i, cartItem))
+
+    if (existingIndex !== -1) {
+      incrementCart(existingIndex)
+    } else {
+      setCart((prev) => [...prev, cartItem])
+    }
+
     setSelectedBorders((prev) => ({ ...prev, [item.id]: null }))
     setSelectedExtraOptions((prev) => ({ ...prev, [item.id]: [] }))
     setHalfFlavorModal(null)
@@ -240,12 +254,37 @@ export default function MenuClient({
       if (def) setAddress(def)
       return
     }
-
     const nextState = getLookupCustomerMissingState()
     setExistingCustomer(nextState.existingCustomer)
     setIsNewCustomer(nextState.isNewCustomer)
     setCustomerName(nextState.customerName)
     setPhoneVerified(nextState.phoneVerified)
+  }
+
+  async function handleOpenHistory() {
+    if (!phoneVerified) {
+      setPendingHistoryOpen(true)
+      const nextState = getOpenCartState()
+      setCartOpen(nextState.cartOpen)
+      setCheckoutStep('info')
+      return
+    }
+
+    setCartOpen(true)
+    setCheckoutStep('history')
+    setLoadingHistory(true)
+    try {
+      const cleanPhone = phone.replace(/\D/g, '')
+      const res = await fetch(`/api/public/orders?phone=${cleanPhone}&tenant_id=${tenant.id}`)
+      const json = await res.json()
+      if (json.data) {
+        setPreviousOrders(json.data)
+      }
+    } catch (error) {
+      toast.error('Não foi possível carregar seu histórico de pedidos.')
+    } finally {
+      setLoadingHistory(false)
+    }
   }
 
   async function handlePhoneLookup() {
@@ -328,6 +367,22 @@ export default function MenuClient({
       if (true) {
         setLookingUpPhone(true)
         await lookupCustomer(cleanPhone)
+      }
+
+      if (pendingHistoryOpen) {
+        setPendingHistoryOpen(false)
+        setCartOpen(true)
+        setCheckoutStep('history')
+        setLoadingHistory(true)
+        try {
+          const res = await fetch(`/api/public/orders?phone=${cleanPhone}&tenant_id=${tenant.id}`)
+          const json = await res.json()
+          if (json.data) {
+            setPreviousOrders(json.data)
+          }
+        } finally {
+          setLoadingHistory(false)
+        }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Não foi possível validar o código.'
@@ -896,6 +951,7 @@ export default function MenuClient({
         setCartOpen(nextState.cartOpen)
         setCheckoutStep(nextState.checkoutStep)
       }}
+      activeOrdersCount={activeOrdersCount}
       groups={groupedValues}
       activeCategory={activeCategory}
       onCategoryChange={setActiveCategory}
@@ -935,15 +991,18 @@ export default function MenuClient({
       halfFlavorModal={halfFlavorModal}
       halfFlavorOptions={halfFlavorModal ? getHalfFlavorOptions(items, halfFlavorModal.item) : []}
       onCloseHalfFlavor={() => setHalfFlavorModal(null)}
-      onSelectHalfFlavor={(flavor) => {
-        if (!halfFlavorModal) return
-        addToCart(halfFlavorModal.item, flavor)
-      }}
+      onSelectHalfFlavor={(halfFlavor) =>
+        halfFlavorModal && addToCart(halfFlavorModal.item, halfFlavor)
+      }
+      onOrdersHistoryOpen={handleOpenHistory}
       drawerProps={{
         open: cartOpen,
         title: getCheckoutStepTitle(checkoutStep),
         checkoutStep,
-        onClose: () => setCartOpen(false),
+        onClose: () => {
+          setCartOpen(false)
+          setPendingHistoryOpen(false)
+        },
         onStepChange: (step) => {
           if (operationClosedNotice) {
             toast.error(operationClosedNotice)
@@ -962,15 +1021,15 @@ export default function MenuClient({
           onDecrement: decrementCart,
           onRemove: removeFromCart,
           onRemoveExtra: removeExtraFromCart,
+          onClear: clearCart,
           onContinue: () => {
             if (operationClosedNotice) {
               toast.error(operationClosedNotice)
               return
             }
 
-            setCheckoutStep(getCartDrawerState('info').checkoutStep)
+            setCheckoutStep('info')
           },
-          onClear: clearCart,
         },
         infoStepProps: {
           tableInfo,
@@ -1050,7 +1109,7 @@ export default function MenuClient({
           cartTotal,
           deliveryFee,
           orderTotal,
-          isProcessing: isCheckoutProcessing,
+          isProcessing: onlineCheckoutLoading || createOrder.isPending,
           onContinue: handleContinueToAddress,
           onBack: () => {
             if (operationClosedNotice) {
@@ -1092,7 +1151,7 @@ export default function MenuClient({
           quotedDeliveryFee,
           quotedDistanceKm,
           deliveryQuoteMessage,
-          isProcessing: isCheckoutProcessing,
+          isProcessing: onlineCheckoutLoading || createOrder.isPending,
           onSubmit: handleAddressSubmit,
           onSaveAddress: handleSaveAddress,
           onDeleteAddress: handleDeleteAddress,
@@ -1111,14 +1170,32 @@ export default function MenuClient({
           orderNumber,
           tableInfo,
           publicOrderStatus,
-          orderSteps,
-          getStepState,
+          orderSteps: getOrderSteps(tableInfo, publicOrderStatus?.payment_method),
+          getStepState: (key) => getOrderStepState(
+            publicOrderStatus?.status ?? null,
+            getOrderSteps(tableInfo, publicOrderStatus?.payment_method).map(s => s.key),
+            key
+          ),
           cancelOrderLoading,
           confirmDeliveryLoading,
           onCancelOrder: handleCancelOrder,
           onConfirmDelivery: handleConfirmDelivery,
           onClose: () => setCartOpen(false),
         },
+        historyStepProps: {
+          orders: previousOrders,
+          loading: loadingHistory,
+          onSelectOrder: (id) => {
+            setOrderId(id)
+            const order = previousOrders.find(o => o.id === id)
+            if (order) {
+              setOrderNumber(order.order_number)
+              setPublicOrderStatus(order)
+              setCheckoutStep('done')
+              setCartOpen(true)
+            }
+          }
+        }
       }}
     />
   )

--- a/app/api/public/orders/route.ts
+++ b/app/api/public/orders/route.ts
@@ -277,3 +277,50 @@ export async function POST(request: NextRequest) {
     )
   }
 }
+
+export async function GET(request: NextRequest) {
+  try {
+    const admin = createAdminClient()
+    const { searchParams } = new URL(request.url)
+    const phone = searchParams.get('phone')
+    const tenant_id = searchParams.get('tenant_id')
+
+    if (!phone || !tenant_id) {
+      return NextResponse.json(
+        { error: 'Parâmetros phone e tenant_id são obrigatórios.' },
+        { status: 400 }
+      )
+    }
+
+    const cleanPhone = phone.replace(/\D/g, '')
+
+    const { data: orders, error } = await admin
+      .from('orders')
+      .select(`
+        id,
+        order_number,
+        status,
+        payment_status,
+        payment_method,
+        delivery_status,
+        cancelled_reason,
+        total,
+        created_at,
+        updated_at
+      `)
+      .eq('tenant_id', tenant_id)
+      .eq('customer_phone', cleanPhone)
+      .order('created_at', { ascending: false })
+      .limit(10)
+
+    if (error) throw error
+
+    return NextResponse.json({ data: orders })
+  } catch (error) {
+    console.error('[public-orders:get]', error)
+    return NextResponse.json(
+      { error: 'Erro ao buscar pedidos.' },
+      { status: 500 }
+    )
+  }
+}

--- a/docs/sql/add-delivery-distance-km.sql
+++ b/docs/sql/add-delivery-distance-km.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+ADD COLUMN IF NOT EXISTS delivery_distance_km numeric;

--- a/docs/sql/add-extras-category-id.sql
+++ b/docs/sql/add-extras-category-id.sql
@@ -1,0 +1,5 @@
+alter table public.extras
+add column if not exists category_id uuid references public.categories(id) on delete set null;
+
+create index if not exists extras_category_id_idx
+on public.extras(category_id);

--- a/docs/sql/add-extras-target-categories.sql
+++ b/docs/sql/add-extras-target-categories.sql
@@ -1,0 +1,12 @@
+-- 1. Cria o novo array para categorias alvo
+alter table public.extras
+add column if not exists target_categories uuid[] default '{}'::uuid[];
+
+-- 2. Migra os dados do category_id existente para o novo array (onde não for nulo)
+update public.extras
+set target_categories = array[category_id]
+where category_id is not null;
+
+-- 3. Remove a coluna e a fk antiga
+alter table public.extras
+drop column if exists category_id;

--- a/features/menu/MenuCheckoutDrawer.tsx
+++ b/features/menu/MenuCheckoutDrawer.tsx
@@ -4,11 +4,13 @@ import { MenuAddressStep } from '@/features/menu/MenuAddressStep'
 import { MenuCartStep } from '@/features/menu/MenuCartStep'
 import { MenuDoneStep } from '@/features/menu/MenuDoneStep'
 import { MenuInfoStep } from '@/features/menu/MenuInfoStep'
+import { MenuHistoryStep } from '@/features/menu/MenuHistoryStep'
 
 type MenuCartStepProps = ComponentProps<typeof MenuCartStep>
 type MenuInfoStepProps = ComponentProps<typeof MenuInfoStep>
 type MenuAddressStepProps = ComponentProps<typeof MenuAddressStep>
 type MenuDoneStepProps = ComponentProps<typeof MenuDoneStep>
+type MenuHistoryStepProps = ComponentProps<typeof MenuHistoryStep>
 
 export function MenuCheckoutDrawer({
   open,
@@ -20,16 +22,18 @@ export function MenuCheckoutDrawer({
   infoStepProps,
   addressStepProps,
   doneStepProps,
+  historyStepProps,
 }: {
   open: boolean
   title: string
-  checkoutStep: 'cart' | 'info' | 'address' | 'done'
+  checkoutStep: 'cart' | 'info' | 'address' | 'done' | 'history'
   onClose: () => void
-  onStepChange: (step: 'cart' | 'info' | 'address' | 'done') => void
+  onStepChange: (step: 'cart' | 'info' | 'address' | 'done' | 'history') => void
   cartStepProps: MenuCartStepProps
   infoStepProps: MenuInfoStepProps
   addressStepProps: MenuAddressStepProps
   doneStepProps: MenuDoneStepProps
+  historyStepProps: MenuHistoryStepProps
 }) {
   if (!open) return null
 
@@ -66,6 +70,8 @@ export function MenuCheckoutDrawer({
         )}
 
         {checkoutStep === 'done' && <MenuDoneStep {...doneStepProps} onClose={onClose} />}
+
+        {checkoutStep === 'history' && <MenuHistoryStep {...historyStepProps} />}
       </div>
     </div>
   )

--- a/features/menu/MenuHistoryStep.tsx
+++ b/features/menu/MenuHistoryStep.tsx
@@ -65,7 +65,7 @@ export function MenuHistoryStep({ orders, loading, onSelectOrder }: Props) {
                       {new Date(order.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
                     </p>
                     <p className="text-sm font-bold text-slate-800">
-                      Total: R$ {Number(order.total).toFixed(2)}
+                      Total: R$ {Number(order.total ?? 0).toFixed(2)}
                     </p>
                   </div>
                 </div>

--- a/features/menu/MenuHistoryStep.tsx
+++ b/features/menu/MenuHistoryStep.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { Clock, Package, ChevronRight } from 'lucide-react'
+import type { PublicOrderStatus } from '@/features/menu/public-menu'
+import { getOrderSteps, getPublicOrderStatusCardTone } from '@/features/menu/public-menu'
+
+type Props = {
+  orders: PublicOrderStatus[]
+  loading: boolean
+  onSelectOrder: (orderId: string) => void
+}
+
+const statusTones = {
+  warning: 'bg-orange-100 text-orange-700',
+  progress: 'bg-blue-100 text-blue-700',
+  delivery: 'bg-purple-100 text-purple-700',
+  default: 'bg-slate-100 text-slate-700',
+}
+
+export function MenuHistoryStep({ orders, loading, onSelectOrder }: Props) {
+  return (
+    <div className="flex-1 overflow-y-auto p-4 bg-slate-50/50">
+      {loading ? (
+        <div className="h-full flex flex-col items-center justify-center gap-3 py-12">
+          <div className="w-8 h-8 border-4 border-slate-200 border-t-slate-900 rounded-full animate-spin" />
+          <p className="text-sm text-slate-500 font-medium">Buscando seu histórico...</p>
+        </div>
+      ) : orders.length === 0 ? (
+        <div className="h-full flex flex-col items-center justify-center text-center px-8 py-12">
+          <div className="w-20 h-20 bg-white rounded-3xl shadow-sm flex items-center justify-center mb-6">
+            <Package className="w-10 h-10 text-slate-300" />
+          </div>
+          <h3 className="text-xl font-bold text-slate-900 mb-2">Nenhum pedido ainda</h3>
+          <p className="text-sm text-slate-500 leading-relaxed">
+            Você ainda não realizou pedidos com este número de telefone. Que tal começar agora?
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1 mb-2">
+            Últimos 10 pedidos
+          </p>
+          {orders.map((order) => {
+            const tone = getPublicOrderStatusCardTone(order) as keyof typeof statusTones
+            const steps = getOrderSteps(null, order.payment_method)
+            const step = steps.find(s => s.key === order.status)
+
+            return (
+              <button
+                key={order.id}
+                onClick={() => onSelectOrder(order.id)}
+                className="w-full text-left p-4 rounded-2xl border border-white bg-white shadow-sm hover:shadow-md hover:border-slate-200 transition-all flex items-center justify-between group active:scale-[0.98]"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <span className="font-extrabold text-slate-900 tracking-tight">#{order.order_number}</span>
+                    <span className={`px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wider ${statusTones[tone] || statusTones.default}`}>
+                      {step?.label ?? (order.status === 'cancelled' ? 'Cancelado' : order.status)}
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <p className="text-xs text-slate-400 flex items-center gap-1">
+                      <Clock className="w-3 h-3" />
+                      {new Date(order.created_at).toLocaleDateString('pt-BR')} às{' '}
+                      {new Date(order.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
+                    </p>
+                    <p className="text-sm font-bold text-slate-800">
+                      Total: R$ {Number(order.total).toFixed(2)}
+                    </p>
+                  </div>
+                </div>
+                <div className="w-8 h-8 rounded-full bg-slate-50 flex items-center justify-center group-hover:bg-slate-900 group-hover:text-white transition-colors">
+                  <ChevronRight className="w-4 h-4" />
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/features/menu/MenuStatusPanel.tsx
+++ b/features/menu/MenuStatusPanel.tsx
@@ -11,12 +11,14 @@ export function MenuStatusPanel({
   cartOpen,
   onTrackOrder,
   tableInfo,
+  activeOrdersCount = 0,
 }: {
   checkoutNotice: string | null
   publicOrderStatus: PublicOrderStatus | null
   cartOpen: boolean
   onTrackOrder: () => void
   tableInfo: { id: string; number: string } | null
+  activeOrdersCount?: number
 }) {
   const checkoutNoticeTone = getCheckoutNoticeTone(publicOrderStatus)
   const shouldShowNotice = shouldShowCheckoutNoticeBanner({
@@ -24,6 +26,8 @@ export function MenuStatusPanel({
     publicOrderStatus,
     cartOpen,
   })
+
+  const othersCount = activeOrdersCount - (publicOrderStatus && !['delivered', 'cancelled'].includes(publicOrderStatus.status) ? 1 : 0)
 
   return (
     <>
@@ -45,6 +49,7 @@ export function MenuStatusPanel({
         <PublicOrderStatusCard
           publicOrderStatus={publicOrderStatus}
           onTrack={onTrackOrder}
+          othersCount={Math.max(0, othersCount)}
         />
       )}
 

--- a/features/menu/MenuTopBar.tsx
+++ b/features/menu/MenuTopBar.tsx
@@ -1,15 +1,17 @@
-import { ChefHat, ShoppingCart } from 'lucide-react'
+import { ChefHat, ShoppingCart, Clock } from 'lucide-react'
 
 export function MenuTopBar({
   tenantName,
   tableInfo,
   cartCount,
   onCartOpen,
+  onOrdersHistoryOpen,
 }: {
   tenantName: string
   tableInfo: { id: string; number: string } | null
   cartCount: number
   onCartOpen: () => void
+  onOrdersHistoryOpen: () => void
 }) {
   return (
     <header className="bg-white border-b border-slate-200 sticky top-0 z-10">
@@ -23,18 +25,33 @@ export function MenuTopBar({
             {tableInfo && <p className="text-xs text-slate-400">Mesa {tableInfo.number}</p>}
           </div>
         </div>
-        <button
-          onClick={onCartOpen}
-          className="relative flex items-center gap-2 bg-slate-900 text-white px-4 py-2 rounded-lg text-sm font-medium"
-        >
-          <ShoppingCart className="w-4 h-4" />
-          Carrinho
-          {cartCount > 0 && (
-            <span className="absolute -top-2 -right-2 w-5 h-5 bg-orange-500 text-white text-xs rounded-full flex items-center justify-center font-bold">
-              {cartCount}
-            </span>
-          )}
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onOrdersHistoryOpen}
+            className="hidden sm:flex items-center gap-2 text-slate-500 hover:text-slate-900 px-3 py-2 rounded-lg text-sm font-medium transition-colors"
+          >
+            <Clock className="w-4 h-4" />
+            Meus Pedidos
+          </button>
+          <button
+            onClick={onOrdersHistoryOpen}
+            className="sm:hidden flex items-center justify-center w-10 h-10 text-slate-500 hover:text-slate-900 rounded-lg transition-colors"
+          >
+            <Clock className="w-5 h-5" />
+          </button>
+          <button
+            onClick={onCartOpen}
+            className="relative flex items-center gap-2 bg-slate-900 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-slate-800 transition-colors"
+          >
+            <ShoppingCart className="w-4 h-4" />
+            <span className="hidden sm:inline">Carrinho</span>
+            {cartCount > 0 && (
+              <span className="absolute -top-2 -right-2 w-5 h-5 bg-orange-500 text-white text-[10px] rounded-full flex items-center justify-center font-bold border-2 border-white shadow-sm">
+                {cartCount}
+              </span>
+            )}
+          </button>
+        </div>
       </div>
     </header>
   )

--- a/features/menu/PublicMenuPageShell.tsx
+++ b/features/menu/PublicMenuPageShell.tsx
@@ -36,6 +36,8 @@ type Props = {
   halfFlavorOptions: PublicMenuItem[]
   onCloseHalfFlavor: () => void
   onSelectHalfFlavor: (item: PublicMenuItem) => void
+  onOrdersHistoryOpen: () => void
+  activeOrdersCount: number
   drawerProps: React.ComponentProps<typeof MenuCheckoutDrawer>
 }
 
@@ -64,6 +66,8 @@ export function PublicMenuPageShell({
   halfFlavorOptions,
   onCloseHalfFlavor,
   onSelectHalfFlavor,
+  onOrdersHistoryOpen,
+  activeOrdersCount,
   drawerProps,
 }: Props) {
   return (
@@ -73,6 +77,7 @@ export function PublicMenuPageShell({
         tableInfo={tableInfo}
         cartCount={cartCount}
         onCartOpen={onCartOpen}
+        onOrdersHistoryOpen={onOrdersHistoryOpen}
       />
 
       <main className="max-w-2xl mx-auto px-4 py-6">
@@ -82,6 +87,7 @@ export function PublicMenuPageShell({
           cartOpen={cartOpen}
           onTrackOrder={onTrackOrder}
           tableInfo={tableInfo}
+          activeOrdersCount={activeOrdersCount}
         />
 
         <MenuCategoryFilter

--- a/features/menu/PublicOrderStatusCard.tsx
+++ b/features/menu/PublicOrderStatusCard.tsx
@@ -10,9 +10,11 @@ import {
 export function PublicOrderStatusCard({
   publicOrderStatus,
   onTrack,
+  othersCount = 0,
 }: {
   publicOrderStatus: PublicOrderStatus
   onTrack: () => void
+  othersCount?: number
 }) {
   const tone = getPublicOrderStatusCardTone(publicOrderStatus)
   const toneClasses = {
@@ -52,6 +54,11 @@ export function PublicOrderStatusCard({
           <p className={`mt-1 text-sm ${toneClasses.message}`}>
             {getPublicOrderStatusCardMessage(publicOrderStatus)}
           </p>
+          {othersCount > 0 && (
+            <p className={`mt-2 text-xs font-bold uppercase tracking-wider ${toneClasses.title} bg-white/40 inline-block px-2 py-0.5 rounded-full`}>
+              + {othersCount} {othersCount === 1 ? 'pedido ativo' : 'pedidos ativos'}
+            </p>
+          )}
         </div>
         <Button
           size="sm"

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -38,6 +38,7 @@ export type PublicOrderStatus = {
   delivery_driver?: { name: string } | null
   cancelled_reason?: string | null
   refunded_at?: string | null
+  total?: number
   created_at: string
   updated_at: string
 }

--- a/features/menu/public-menu.ts
+++ b/features/menu/public-menu.ts
@@ -55,7 +55,7 @@ export type PublicCustomerLookupState = {
   customerName: string
 }
 
-export type PublicCheckoutStep = 'cart' | 'info' | 'address' | 'done'
+export type PublicCheckoutStep = 'cart' | 'info' | 'address' | 'done' | 'history'
 
 type RawExtra = {
   extra:
@@ -128,6 +128,24 @@ export function createCartItem(
       .map((extra) => ({ id: extra!.id, name: extra!.name, price: extra!.price })),
     half_flavor: halfFlavor ? { menu_item_id: halfFlavor.id, name: halfFlavor.name } : undefined,
   } satisfies CartItem
+}
+
+export function isSameCartItem(a: CartItem, b: CartItem) {
+  if (a.menu_item_id !== b.menu_item_id) return false
+  if (a.notes !== b.notes) return false
+  if (a.half_flavor?.menu_item_id !== b.half_flavor?.menu_item_id) return false
+
+  const aExtras = [...(a.extras ?? [])].sort((x, y) => (x.id ?? x.name).localeCompare(y.id ?? y.name))
+  const bExtras = [...(b.extras ?? [])].sort((x, y) => (x.id ?? x.name).localeCompare(y.id ?? y.name))
+
+  if (aExtras.length !== bExtras.length) return false
+
+  for (let i = 0; i < aExtras.length; i++) {
+    if (aExtras[i].id !== bExtras[i].id) return false
+    if (aExtras[i].name !== bExtras[i].name) return false
+  }
+
+  return true
 }
 
 export function incrementCartItem(cart: CartItem[], index: number) {
@@ -391,10 +409,11 @@ export function getOrderSteps(
   }>
 }
 
-export function getCheckoutStepTitle(step: 'cart' | 'info' | 'address' | 'done') {
+export function getCheckoutStepTitle(step: PublicCheckoutStep) {
   if (step === 'cart') return 'Seu pedido'
   if (step === 'info') return 'Seus dados'
   if (step === 'address') return 'Endereço de entrega'
+  if (step === 'history') return 'Meus últimos pedidos'
   return 'Pedido realizado!'
 }
 

--- a/features/orders/OrderCard.tsx
+++ b/features/orders/OrderCard.tsx
@@ -140,6 +140,13 @@ export function OrderCard({
             <p className="mt-2 rounded bg-slate-50 px-2 py-1 text-xs text-slate-400">Obs: {order.notes}</p>
           )}
 
+          {order.status === 'cancelled' && order.cancelled_reason && (
+            <div className="mt-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-800">
+              <p className="font-medium">Motivo do cancelamento:</p>
+              <p>{order.cancelled_reason}</p>
+            </div>
+          )}
+
           {shouldShowWhatsappCard(order, hasWhatsappNotifications) && latestWhatsapp && (
             <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
               <div className="flex flex-wrap items-center gap-2">
@@ -200,6 +207,7 @@ export function OrderCard({
             <p className="font-semibold text-slate-900">R$ {Number(order.total).toFixed(2)}</p>
           </div>
           <p className="mt-0.5 text-xs text-slate-400">
+            {new Date(order.created_at).toLocaleDateString('pt-BR')} às{' '}
             {new Date(order.created_at).toLocaleTimeString('pt-BR', {
               hour: '2-digit',
               minute: '2-digit',

--- a/lib/order-whatsapp.ts
+++ b/lib/order-whatsapp.ts
@@ -117,7 +117,9 @@ export function buildOrderWhatsappMessage(params: {
       const reasonNote = params.order.cancelled_reason
         ? ` Motivo: ${params.order.cancelled_reason}.`
         : ''
-      return `${greeting} Seu pedido ${orderRef} foi cancelado pela ${params.tenantName}.${reasonNote}${refundNote}`
+      const isByCustomer = params.order.cancelled_reason?.toLowerCase().includes('cliente')
+      const cancellationSource = isByCustomer ? '' : ` pela ${params.tenantName}`
+      return `${greeting} Seu pedido ${orderRef} foi cancelado${cancellationSource}.${reasonNote}${refundNote}`
     }
   }
 }

--- a/tests/unit/cardapio-page-component.test.tsx
+++ b/tests/unit/cardapio-page-component.test.tsx
@@ -86,9 +86,6 @@ describe('CardapioPage component', () => {
     useCreateMenuItemMock.mockReturnValue({
       mutateAsync: vi.fn().mockResolvedValue({ id: 'item-created' }),
     })
-    useQueryMock.mockReturnValue({
-      data: [{ id: 'extra-1', name: 'Borda recheada', price: 5, category: 'Bordas' }],
-    })
     useHasFeatureMock.mockReturnValue(true)
     usePlanMock.mockReturnValue({
       data: {
@@ -102,14 +99,6 @@ describe('CardapioPage component', () => {
     invalidateQueriesMock.mockResolvedValue(undefined)
 
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url === '/api/menu-items/item-1/extras') {
-        return {
-          ok: true,
-          json: vi.fn().mockResolvedValue({
-            data: [{ id: 'extra-1' }],
-          }),
-        }
-      }
 
       if (url === '/api/menu-items/item-1/ingredients') {
         return {
@@ -208,7 +197,6 @@ describe('CardapioPage component', () => {
     const createMenuItemMutateAsync = useCreateMenuItemMock.mock.results[0]?.value.mutateAsync as ReturnType<typeof vi.fn>
 
     expect(formResetMock).toHaveBeenCalled()
-    expect(fetch).toHaveBeenCalledWith('/api/menu-items/item-1/extras')
     expect(fetch).toHaveBeenCalledWith('/api/menu-items/item-1/ingredients')
     expect(confirm).toHaveBeenCalledWith('Deseja desativar "Pizza Margherita"?')
     expect(fetch).toHaveBeenCalledWith('/api/menu-items/item-1', {
@@ -224,11 +212,6 @@ describe('CardapioPage component', () => {
       category_id: 'cat-1',
       display_order: 2,
       product_id: undefined,
-    })
-    expect(fetch).toHaveBeenCalledWith('/api/menu-items/item-created/extras', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ extra_ids: [] }),
     })
     expect(fetch).toHaveBeenCalledWith('/api/menu-items/item-created/ingredients', {
       method: 'PUT',
@@ -247,12 +230,6 @@ describe('CardapioPage component', () => {
     })
 
     const fetchMock = vi.fn(async (url: string) => {
-      if (url === '/api/menu-items/item-1/extras') {
-        return {
-          ok: true,
-          json: vi.fn().mockResolvedValue({ data: [] }),
-        }
-      }
 
       if (url === '/api/menu-items/item-1') {
         return {
@@ -368,7 +345,6 @@ describe('CardapioPage component', () => {
       totalPages: number
       dialogProps: {
         products?: Array<{ id: string; name: string }>
-        allExtras?: Array<{ id: string; name: string }>
         onSubmit: (values: {
           name: string
           description?: string
@@ -390,7 +366,6 @@ describe('CardapioPage component', () => {
     expect(props.menuItemLimit).toBeUndefined()
     expect(props.totalPages).toBe(1)
     expect(props.dialogProps.products).toBeUndefined()
-    expect(props.dialogProps.allExtras).toBeUndefined()
 
     await props.dialogProps.onSubmit({
       name: 'Pizza sem id',
@@ -409,7 +384,6 @@ describe('CardapioPage component', () => {
       display_order: 1,
       product_id: undefined,
     })
-    expect(fetchMock).not.toHaveBeenCalledWith('/api/menu-items/undefined/extras', expect.anything())
     expect(formResetMock).toHaveBeenCalled()
   })
 })

--- a/tests/unit/cardapio-stateful-page-component.test.tsx
+++ b/tests/unit/cardapio-stateful-page-component.test.tsx
@@ -108,9 +108,6 @@ describe('CardapioPage stateful branches', () => {
     useCreateMenuItemMock.mockReturnValue({
       mutateAsync: vi.fn().mockResolvedValue({ id: 'item-created' }),
     })
-    useQueryMock.mockReturnValue({
-      data: [{ id: 'extra-1', name: 'Borda recheada', price: 5, category: 'Bordas' }],
-    })
     useHasFeatureMock.mockReturnValue(false)
     usePlanMock.mockReturnValue({
       data: {
@@ -134,18 +131,9 @@ describe('CardapioPage stateful branches', () => {
       display_order: 1,
       product_id: 'prod-1',
     }
-    stateValues[6] = ['extra-1']
+    stateValues[6] = 'prod-1'
 
     const fetchMock = vi.fn(async (url: string) => {
-      if (url === '/api/menu-items/item-1/extras') {
-        return {
-          ok: true,
-          json: vi.fn().mockResolvedValue({
-            data: [{ id: 'extra-1' }],
-          }),
-        }
-      }
-
       if (url === '/api/menu-items/item-1') {
         return {
           ok: true,
@@ -197,9 +185,8 @@ describe('CardapioPage stateful branches', () => {
       display_order: 3,
     })
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-1/extras')
     expect(fetchMock).not.toHaveBeenCalledWith('/api/menu-items/item-1/ingredients')
-    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/menu-items/item-1', {
+    expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -211,12 +198,6 @@ describe('CardapioPage stateful branches', () => {
         product_id: null,
       }),
     })
-    expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-1/extras', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ extra_ids: ['extra-1'] }),
-    })
-    expect(fetchMock).not.toHaveBeenCalledWith('/api/menu-items/item-1/ingredients', expect.anything())
     expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: ['menu-items'] })
   })
 
@@ -224,7 +205,7 @@ describe('CardapioPage stateful branches', () => {
     stateValues[0] = true
     stateValues[1] = null
     stateValues[2] = 'item-1'
-    stateValues[6] = ['extra-1']
+    stateValues[6] = 'none'
 
     const createMenuItemMutateAsync = vi.fn().mockResolvedValue({ id: 'item-created' })
     useCreateMenuItemMock.mockReturnValue({
@@ -232,13 +213,6 @@ describe('CardapioPage stateful branches', () => {
     })
 
     const fetchMock = vi.fn(async (url: string) => {
-      if (url === '/api/menu-items/item-created/extras') {
-        return {
-          ok: true,
-          json: vi.fn().mockResolvedValue({ data: null }),
-        }
-      }
-
       if (url === '/api/menu-items/item-1') {
         return {
           ok: false,
@@ -294,15 +268,9 @@ describe('CardapioPage stateful branches', () => {
       category_id: 'cat-1',
       display_order: 2,
     })
-    expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-created/extras', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ extra_ids: ['extra-1'] }),
-    })
     expect(stateSetters[0]).toHaveBeenCalledWith(false)
-    expect(stateSetters[6]).toHaveBeenCalledWith([])
-    expect(stateSetters[7]).toHaveBeenCalledWith('none')
-    expect(stateSetters[8]).toHaveBeenCalledWith([])
+    expect(stateSetters[6]).toHaveBeenCalledWith('none')
+    expect(stateSetters[7]).toHaveBeenCalledWith([])
     expect(alert).toHaveBeenCalledWith('Erro ao desativar item.')
     expect(stateSetters[2]).toHaveBeenCalledWith('item-1')
     expect(stateSetters[2]).toHaveBeenCalledWith(null)
@@ -312,15 +280,6 @@ describe('CardapioPage stateful branches', () => {
     useHasFeatureMock.mockReturnValue(true)
 
     const fetchMock = vi.fn(async (url: string) => {
-      if (url === '/api/menu-items/item-1/extras') {
-        return {
-          ok: true,
-          json: vi.fn().mockResolvedValue({
-            data: [{ id: 'extra-1' }],
-          }),
-        }
-      }
-
       if (url === '/api/menu-items/item-1/ingredients') {
         return {
           ok: true,
@@ -356,7 +315,6 @@ describe('CardapioPage stateful branches', () => {
       product_id: 'prod-1',
     })
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-1/extras')
     expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-1/ingredients')
     expect(stateSetters[1]).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -364,9 +322,8 @@ describe('CardapioPage stateful branches', () => {
         product_id: 'prod-1',
       }),
     )
-    expect(stateSetters[6]).toHaveBeenCalledWith(['extra-1'])
-    expect(stateSetters[8]).toHaveBeenCalledWith([{ product_id: 'prod-1', quantity: 2 }])
-    expect(stateSetters[7]).toHaveBeenCalledWith('prod-1')
+    expect(stateSetters[7]).toHaveBeenCalledWith([{ product_id: 'prod-1', quantity: 2 }])
+    expect(stateSetters[6]).toHaveBeenCalledWith('prod-1')
     expect(stateSetters[0]).toHaveBeenCalledWith(true)
   })
 
@@ -383,15 +340,6 @@ describe('CardapioPage stateful branches', () => {
     }
 
     const fetchMock = vi.fn(async (url: string) => {
-      if (url === '/api/menu-items/item-1/extras') {
-        return {
-          ok: true,
-          json: vi.fn().mockResolvedValue({
-            data: [{ id: 'extra-1' }],
-          }),
-        }
-      }
-
       if (url === '/api/menu-items/item-1/ingredients') {
         return {
           ok: true,
@@ -453,10 +401,9 @@ describe('CardapioPage stateful branches', () => {
       display_order: 1,
     })
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-1/extras')
     expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-1/ingredients')
-    expect(stateSetters[8]).toHaveBeenCalledWith([])
-    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/menu-items/item-1', {
+    expect(stateSetters[7]).toHaveBeenCalledWith([])
+    expect(fetchMock).toHaveBeenCalledWith('/api/menu-items/item-1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -502,49 +449,23 @@ describe('CardapioPage stateful branches', () => {
 
     expect(formResetMock).toHaveBeenCalled()
     expect(stateSetters[1]).toHaveBeenCalledWith(null)
-    expect(stateSetters[7]).toHaveBeenCalledWith('none')
-    expect(stateSetters[8]).toHaveBeenCalledWith([])
-    expect(stateSetters[6]).toHaveBeenCalledWith([])
+    expect(stateSetters[6]).toHaveBeenCalledWith('none')
+    expect(stateSetters[7]).toHaveBeenCalledWith([])
     expect(stateSetters[0]).toHaveBeenCalledWith(true)
     expect(stateSetters[0]).toHaveBeenCalledWith(false)
     expect(stateSetters[5]).toHaveBeenCalledWith('cat-1')
     expect(stateSetters[4]).toHaveBeenCalledWith('inactive')
     expect(stateSetters[3]).toHaveBeenCalledWith(1)
-    expect(stateSetters[7]).toHaveBeenCalledWith('prod-1')
+    expect(stateSetters[6]).toHaveBeenCalledWith('prod-1')
 
-    const addIngredientUpdater = stateSetters[8].mock.calls[1]?.[0] as (value: Array<{ product_id: string; quantity: number }>) => Array<{ product_id: string; quantity: number }>
-    const updateIngredientUpdater = stateSetters[8].mock.calls[2]?.[0] as (value: Array<{ product_id: string; quantity: number }>) => Array<{ product_id: string; quantity: number }>
-    const removeIngredientUpdater = stateSetters[8].mock.calls[3]?.[0] as (value: Array<{ product_id: string; quantity: number }>) => Array<{ product_id: string; quantity: number }>
+    const addIngredientUpdater = stateSetters[7].mock.calls[1]?.[0] as (value: Array<{ product_id: string; quantity: number }>) => Array<{ product_id: string; quantity: number }>
+    const updateIngredientUpdater = stateSetters[7].mock.calls[2]?.[0] as (value: Array<{ product_id: string; quantity: number }>) => Array<{ product_id: string; quantity: number }>
+    const removeIngredientUpdater = stateSetters[7].mock.calls[3]?.[0] as (value: Array<{ product_id: string; quantity: number }>) => Array<{ product_id: string; quantity: number }>
 
     expect(addIngredientUpdater([])).toEqual([{ product_id: 'none', quantity: 1 }])
     expect(updateIngredientUpdater([{ product_id: 'none', quantity: 1 }])).toEqual([
       { product_id: 'prod-1', quantity: 2 },
     ])
     expect(removeIngredientUpdater([{ product_id: 'prod-1', quantity: 2 }])).toEqual([])
-  })
-
-  it('executa a queryFn real dos extras do cardápio', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        data: [{ id: 'extra-1', name: 'Borda recheada', price: 5, category: 'Bordas' }],
-      }),
-    })
-
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { default: CardapioPage } = await import('@/app/(dashboard)/cardapio/page')
-
-    renderToStaticMarkup(React.createElement(CardapioPage))
-
-    const queryOptions = useQueryMock.mock.calls[0]?.[0] as
-      | { queryKey: string[]; queryFn: () => Promise<unknown> }
-      | undefined
-
-    expect(queryOptions?.queryKey).toEqual(['extras'])
-    await expect(queryOptions?.queryFn()).resolves.toEqual([
-      { id: 'extra-1', name: 'Borda recheada', price: 5, category: 'Bordas' },
-    ])
-    expect(fetchMock).toHaveBeenCalledWith('/api/extras')
   })
 })

--- a/tests/unit/dashboard-menu-page.test.ts
+++ b/tests/unit/dashboard-menu-page.test.ts
@@ -8,22 +8,17 @@ import {
   buildMenuPageSummary,
   buildUpdateMenuItemPayload,
   filterMenuItems,
-  getPersistedMenuExtraIds,
   getCreateMenuEditorState,
   getMenuDialogTitle,
   getMenuEditState,
   getMenuFilterChangeState,
-  getMenuExtraCategoryLabel,
   getMenuSubmitErrorMessage,
   getInitialMenuItemFormValues,
-  getSelectableMenuExtras,
-  groupMenuExtrasByCategory,
   getMenuSubmitSuccessState,
   getMenuTotalPages,
   getNormalizedIngredients,
   paginateMenuItems,
   removeMenuIngredient,
-  toggleMenuExtraSelection,
   updateMenuIngredient,
 } from '@/features/menu/dashboard-menu-page'
 
@@ -138,7 +133,6 @@ describe('dashboard menu page helpers', () => {
       },
       linkedProductId: 'none',
       ingredients: [],
-      selectedExtras: [],
     })
 
     expect(getMenuEditState({
@@ -151,7 +145,6 @@ describe('dashboard menu page helpers', () => {
         display_order: 3,
         product_id: 'prod-1',
       } as never,
-      selectedExtras: [{ id: 'extra-1' }, { id: 'extra-2' }],
       ingredients: [{ product_id: 'prod-2', quantity: '1.5' as never }],
       hasStockAutomation: true,
     })).toEqual({
@@ -171,7 +164,6 @@ describe('dashboard menu page helpers', () => {
         category_id: 'cat-1',
         display_order: 3,
       },
-      selectedExtras: ['extra-1', 'extra-2'],
       ingredients: [{ product_id: 'prod-2', quantity: 1.5 }],
       linkedProductId: 'prod-1',
     })
@@ -186,7 +178,6 @@ describe('dashboard menu page helpers', () => {
         display_order: 1,
         product_id: 'prod-3',
       } as never,
-      selectedExtras: null,
       ingredients: [{ product_id: 'prod-4', quantity: 2 }],
       hasStockAutomation: false,
     })).toEqual({
@@ -206,7 +197,6 @@ describe('dashboard menu page helpers', () => {
         category_id: 'none',
         display_order: 1,
       },
-      selectedExtras: [],
       ingredients: [],
       linkedProductId: 'none',
     })
@@ -221,7 +211,6 @@ describe('dashboard menu page helpers', () => {
         display_order: 4,
         product_id: null,
       } as never,
-      selectedExtras: undefined,
       ingredients: null,
       hasStockAutomation: true,
     })).toEqual({
@@ -241,7 +230,6 @@ describe('dashboard menu page helpers', () => {
         category_id: 'none',
         display_order: 4,
       },
-      selectedExtras: [],
       ingredients: [],
       linkedProductId: 'none',
     })
@@ -255,7 +243,6 @@ describe('dashboard menu page helpers', () => {
         price: 0,
         display_order: 0,
       },
-      selectedExtras: [],
       ingredients: [],
       linkedProductId: 'none',
     })
@@ -267,7 +254,7 @@ describe('dashboard menu page helpers', () => {
     expect(getMenuSubmitErrorMessage(null)).toBe('Erro ao salvar item.')
   })
 
-  it('manipula ingredientes, extras e toggle de disponibilidade', () => {
+  it('manipula ingredientes e toggle de disponibilidade', () => {
     expect(addMenuIngredient([])).toEqual([{ product_id: 'none', quantity: 1 }])
     expect(updateMenuIngredient(
       [{ product_id: 'prod-1', quantity: 1 }, { product_id: 'prod-2', quantity: 2 }],
@@ -281,63 +268,6 @@ describe('dashboard menu page helpers', () => {
       [{ product_id: 'prod-1', quantity: 1 }, { product_id: 'prod-2', quantity: 2 }],
       0
     )).toEqual([{ product_id: 'prod-2', quantity: 2 }])
-
-    expect(toggleMenuExtraSelection(['extra-1'], 'extra-2', true)).toEqual(['extra-1', 'extra-2'])
-    expect(toggleMenuExtraSelection(['extra-1', 'extra-2'], 'extra-1', false)).toEqual(['extra-2'])
-    expect(getMenuExtraCategoryLabel('border')).toBe('Borda')
-    expect(getMenuExtraCategoryLabel('flavor')).toBe('Extras')
-    expect(getMenuExtraCategoryLabel('other')).toBe('Outros')
-    expect(getMenuExtraCategoryLabel('massas')).toBe('massas')
-    expect(
-      groupMenuExtrasByCategory([
-        { id: 'extra-1', name: 'Catupiry', price: 4, category: 'border' },
-        { id: 'extra-2', name: 'Cheddar', price: 3, category: 'border' },
-        { id: 'extra-3', name: 'Calabresa', price: 6, category: 'flavor' },
-        { id: 'extra-4', name: 'Molho da casa', price: 2, category: 'other' },
-      ])
-    ).toEqual([
-      {
-        category: 'border',
-        label: 'Borda',
-        extras: [
-          { id: 'extra-1', name: 'Catupiry', price: 4, category: 'border' },
-          { id: 'extra-2', name: 'Cheddar', price: 3, category: 'border' },
-        ],
-      },
-      {
-        category: 'flavor',
-        label: 'Extras',
-        extras: [{ id: 'extra-3', name: 'Calabresa', price: 6, category: 'flavor' }],
-      },
-      {
-        category: 'other',
-        label: 'Outros',
-        extras: [{ id: 'extra-4', name: 'Molho da casa', price: 2, category: 'other' }],
-      },
-    ])
-
-    expect(getSelectableMenuExtras(
-      [
-        { id: 'extra-1', name: 'Catupiry', price: 4, category: 'border' },
-        { id: 'extra-2', name: 'Cheddar', price: 3, category: 'border', category_id: 'cat-1' },
-        { id: 'extra-3', name: 'Molho da casa', price: 2, category: 'other' },
-      ],
-      'cat-1',
-      [{ id: 'cat-1', name: 'Pizzas' }],
-    )).toEqual([
-      { id: 'extra-3', name: 'Molho da casa', price: 2, category: 'other' },
-    ])
-
-    expect(getPersistedMenuExtraIds(
-      ['extra-1', 'extra-3'],
-      [
-        { id: 'extra-1', name: 'Catupiry', price: 4, category: 'border' },
-        { id: 'extra-2', name: 'Cheddar', price: 3, category: 'border', category_id: 'cat-1' },
-        { id: 'extra-3', name: 'Molho da casa', price: 2, category: 'other' },
-      ],
-      'cat-1',
-      [{ id: 'cat-1', name: 'Pizzas' }],
-    )).toEqual(['extra-3'])
 
     expect(buildMenuAvailabilityState({ name: 'Pizza', available: true } as never)).toEqual({
       action: 'desativar',

--- a/tsc_output.txt
+++ b/tsc_output.txt
@@ -1,0 +1,603 @@
+tests/integration/api-auth-mercadopago-routes.test.ts(472,54): error TS2345: Argument of type '"state-123"' is not assignable to parameter of type '`${string}-${string}-${string}-${string}-${string}`'.
+tests/integration/api-core-routes.test.ts(481,7): error TS2345: Argument of type 'Request' is not assignable to parameter of type 'NextRequest'.
+  Type 'Request' is missing the following properties from type 'NextRequest': cookies, nextUrl, page, ua
+tests/integration/api-menu-customers-routes.test.ts(346,58): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/integration/api-menu-customers-routes.test.ts(362,58): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/integration/api-operations-routes.test.ts(36,56): error TS2345: Argument of type '(...args: unknown[]) => Promise<unknown>' is not assignable to parameter of type '(feature: PlanFeature, allowedRoles?: EstablishmentRole[] | undefined) => Promise<{ ok: false; response: NextResponse<{ error: string; }>; } | { ...; }>'.
+  Type 'Promise<unknown>' is not assignable to type 'Promise<{ ok: false; response: NextResponse<{ error: string; }>; } | { supabase: SupabaseClient<any, "public", "public", any, any>; user: User; profile: { ...; }; ok: true; response?: undefined; }>'.
+    Type 'unknown' is not assignable to type '{ ok: false; response: NextResponse<{ error: string; }>; } | { supabase: SupabaseClient<any, "public", "public", any, any>; user: User; profile: { ...; }; ok: true; response?: undefined; }'.
+tests/integration/checkout-session.test.ts(279,9): error TS2739: Type '{ zip_code: string; street: string; number: string; neighborhood: string; city: string; state: string; }' is missing the following properties from type 'CustomerAddress': label, is_default
+tests/integration/public-cancel-route.test.ts(45,52): error TS2322: Type 'Promise<{ sent: false; reason: "noop"; }>' is not assignable to type 'Promise<{ sent: boolean; reason: "already-sent"; } | { sent: boolean; reason: "missing-phone"; } | { sent: boolean; reason: "missing-config"; } | { sent: boolean; reason: "feature-not-available"; } | { ...; } | { ...; }>'.
+  Type '{ sent: false; reason: "noop"; }' is not assignable to type '{ sent: boolean; reason: "already-sent"; } | { sent: boolean; reason: "missing-phone"; } | { sent: boolean; reason: "missing-config"; } | { sent: boolean; reason: "feature-not-available"; } | { ...; } | { ...; }'.
+    Type '{ sent: false; reason: "noop"; }' is not assignable to type '{ sent: boolean; reason?: undefined; }'.
+      Types of property 'reason' are incompatible.
+        Type '"noop"' is not assignable to type 'undefined'.
+tests/regression/mercado-pago-webhook.test.ts(48,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(71,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(101,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(129,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(153,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(179,7): error TS2345: Argument of type '{ json: () => Promise<never>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(206,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(252,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(295,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(317,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(370,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(417,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(480,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(548,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/regression/mercado-pago-webhook.test.ts(607,7): error TS2345: Argument of type '{ json: () => Promise<any>; headers: Headers; nextUrl: URL; }' is not assignable to parameter of type 'Pick<NextRequest, "nextUrl" | "json" | "headers">'.
+  Types of property 'nextUrl' are incompatible.
+    Type 'URL' is missing the following properties from type 'NextURL': analyze, formatPathname, formatSearch, buildId, and 6 more.
+tests/unit/admin-helpers.test.ts(196,31): error TS2345: Argument of type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: null; total_users: number; total_orders: number; total_revenue: null; last_order_at: null; }' is not assignable to parameter of type 'AdminTenant'.
+  Types of property 'plan' are incompatible.
+    Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-helpers.test.ts(197,42): error TS2345: Argument of type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: null; total_users: number; total_orders: number; total_revenue: null; last_order_at: null; }' is not assignable to parameter of type 'AdminTenant'.
+  Types of property 'plan' are incompatible.
+    Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-helpers.test.ts(240,40): error TS2345: Argument of type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; }' is not assignable to parameter of type 'AdminTenant'.
+  Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; }' is not assignable to type 'AdminTenant'.
+    Types of property 'plan' are incompatible.
+      Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-helpers.test.ts(245,40): error TS2345: Argument of type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; }' is not assignable to parameter of type 'AdminTenant'.
+  Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; }' is not assignable to type 'AdminTenant'.
+    Types of property 'plan' are incompatible.
+      Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-helpers.test.ts(250,36): error TS2345: Argument of type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; }' is not assignable to parameter of type 'AdminTenant'.
+  Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; }' is not assignable to type 'AdminTenant'.
+    Types of property 'plan' are incompatible.
+      Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-helpers.test.ts(264,42): error TS2345: Argument of type '({ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; })[]' is not assignable to parameter of type 'AdminTenant[]'.
+  Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; }' is not assignable to type 'AdminTenant'.
+    Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; }' is not assignable to type 'AdminTenant'.
+      Types of property 'plan' are incompatible.
+        Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-helpers.test.ts(289,42): error TS2345: Argument of type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; }' is not assignable to parameter of type 'AdminTenant'.
+  Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; }' is not assignable to type 'AdminTenant'.
+    Types of property 'plan' are incompatible.
+      Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-helpers.test.ts(296,33): error TS2345: Argument of type '({ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; })[]' is not assignable to parameter of type 'AdminTenant[]'.
+  Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; }' is not assignable to type 'AdminTenant'.
+    Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; }' is not assignable to type 'AdminTenant'.
+      Types of property 'plan' are incompatible.
+        Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-helpers.test.ts(301,33): error TS2345: Argument of type '({ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; })[]' is not assignable to parameter of type 'AdminTenant[]'.
+  Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; } | { ...; }' is not assignable to type 'AdminTenant'.
+    Type '{ id: string; name: string; slug: string; plan: string; status: string; created_at: string; suspended_at: null; suspension_reason: null; next_billing_at: string; total_users: number; total_orders: number; total_revenue: number; last_order_at: string; }' is not assignable to type 'AdminTenant'.
+      Types of property 'plan' are incompatible.
+        Type 'string' is not assignable to type '"free" | "basic" | "pro"'.
+tests/unit/admin-pages.test.tsx(100,33): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/admin-pages.test.tsx(103,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(111,25): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1415,13): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'null' is not assignable to type 'number'.
+      Type 'null' is not assignable to type 'number'.
+tests/unit/admin-pages.test.tsx(1432,13): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'null' is not assignable to type 'number'.
+      Type 'null' is not assignable to type 'number'.
+tests/unit/admin-pages.test.tsx(1619,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1620,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1621,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1652,69): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1654,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1654,34): error TS18046: 'input.props' is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1655,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1655,34): error TS18046: 'input.props' is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1658,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1659,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1660,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1692,61): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1694,5): error TS18046: 'searchInput.props' is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1695,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-pages.test.tsx(1696,5): error TS2571: Object is of type 'unknown'.
+tests/unit/admin-tenants-page-component.test.tsx(260,25): error TS2352: Conversion of type 'null' to type '{ onOpenChange: (open: boolean) => void; onSave: () => Promise<void>; onSuspend: () => Promise<void>; onReactivate: () => Promise<void>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+tests/unit/auth-guards.test.ts(141,12): error TS18048: 'unauthorized.response' is possibly 'undefined'.
+tests/unit/auth-guards.test.ts(154,12): error TS18048: 'missingProfile.response' is possibly 'undefined'.
+tests/unit/auth-guards.test.ts(175,12): error TS18048: 'forbidden.response' is possibly 'undefined'.
+tests/unit/auth-guards.test.ts(220,12): error TS18048: 'forbidden.response' is possibly 'undefined'.
+tests/unit/auth-guards.test.ts(266,12): error TS18048: 'forbidden.response' is possibly 'undefined'.
+tests/unit/auth-guards.test.ts(300,12): error TS18048: 'unauthorized.response' is possibly 'undefined'.
+tests/unit/auth-guards.test.ts(315,12): error TS18048: 'missingProfile.response' is possibly 'undefined'.
+tests/unit/auth-page-content.test.tsx(40,55): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ value: string; onChange: Mock<Procedure | Constructable>; }'.
+tests/unit/auth-page-content.test.tsx(63,35): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/auth-page-content.test.tsx(66,38): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/auth-page-content.test.tsx(75,11): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<LoginFormValues, any, LoginFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: false; }' is missing the following properties from type 'FormState<LoginFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(77,11): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<LoginFormValues, any, LoginFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: false; }' is missing the following properties from type 'FormState<LoginFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(96,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<LoginFormValues, any, LoginFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: true; }' is missing the following properties from type 'FormState<LoginFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(98,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<LoginFormValues, any, LoginFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: true; }' is missing the following properties from type 'FormState<LoginFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(112,50): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/auth-page-content.test.tsx(115,12): error TS18046: 'submitButton.props' is of type 'unknown'.
+tests/unit/auth-page-content.test.tsx(117,5): error TS18046: 'form.props' is of type 'unknown'.
+tests/unit/auth-page-content.test.tsx(128,11): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<RegisterFormValues, any, RegisterFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: true; }' is missing the following properties from type 'FormState<RegisterFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(130,11): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<RegisterFormValues, any, RegisterFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: true; }' is missing the following properties from type 'FormState<RegisterFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(153,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<RegisterFormValues, any, RegisterFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: false; }' is missing the following properties from type 'FormState<RegisterFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(155,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<RegisterFormValues, any, RegisterFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: false; }' is missing the following properties from type 'FormState<RegisterFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(163,5): error TS2571: Object is of type 'unknown'.
+tests/unit/auth-page-content.test.tsx(176,11): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<ForgotPasswordFormValues, any, ForgotPasswordFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: false; }' is missing the following properties from type 'FormState<ForgotPasswordFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(178,11): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<ForgotPasswordFormValues, any, ForgotPasswordFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: false; }' is missing the following properties from type 'FormState<ForgotPasswordFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(198,11): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<ResetPasswordFormValues, any, ResetPasswordFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: true; }' is missing the following properties from type 'FormState<ResetPasswordFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/auth-page-content.test.tsx(200,11): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{}' is missing the following properties from type 'Control<ResetPasswordFormValues, any, ResetPasswordFormValues>': _subjects, _removeUnmounted, _names, _state, and 25 more.
+      Type '{ isSubmitting: true; }' is missing the following properties from type 'FormState<ResetPasswordFormValues>': isDirty, isLoading, isSubmitted, isSubmitSuccessful, and 9 more.
+tests/unit/catalog-edit-page-component.test.tsx(231,25): error TS2352: Conversion of type 'null' to type '{ onNameFilterChange: (value: string) => void; onCategoryFilterChange: (value: "border" | "flavor" | "other" | "all") => void; onOpenChange: (open: boolean) => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+tests/unit/catalog-pages-component.test.tsx(465,18): error TS2349: This expression is not callable.
+  Type 'never' has no call signatures.
+tests/unit/extras-page.test.ts(47,31): error TS2345: Argument of type '{ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; }' is not assignable to parameter of type 'Extra | null'.
+  Property 'target_categories' is missing in type '{ id: string; name: string; price: number; category: "border"; active: boolean; }' but required in type 'Extra'.
+tests/unit/extras-page.test.ts(56,25): error TS2345: Argument of type '({ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; })[]' is not assignable to parameter of type 'Extra[]'.
+  Type '{ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; }' is not assignable to type 'Extra'.
+    Property 'target_categories' is missing in type '{ id: string; name: string; price: number; category: "border"; active: boolean; }' but required in type 'Extra'.
+tests/unit/extras-page.test.ts(57,25): error TS2345: Argument of type '({ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; })[]' is not assignable to parameter of type 'Extra[]'.
+  Type '{ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; }' is not assignable to type 'Extra'.
+    Property 'target_categories' is missing in type '{ id: string; name: string; price: number; category: "border"; active: boolean; }' but required in type 'Extra'.
+tests/unit/extras-page.test.ts(58,25): error TS2345: Argument of type '({ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; })[]' is not assignable to parameter of type 'Extra[]'.
+  Type '{ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; }' is not assignable to type 'Extra'.
+    Property 'target_categories' is missing in type '{ id: string; name: string; price: number; category: "border"; active: boolean; }' but required in type 'Extra'.
+tests/unit/extras-page.test.ts(59,25): error TS2345: Argument of type '({ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; })[]' is not assignable to parameter of type 'Extra[]'.
+  Type '{ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; }' is not assignable to type 'Extra'.
+    Property 'target_categories' is missing in type '{ id: string; name: string; price: number; category: "border"; active: boolean; }' but required in type 'Extra'.
+tests/unit/extras-page.test.ts(63,27): error TS2345: Argument of type '({ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; })[]' is not assignable to parameter of type 'Extra[]'.
+  Type '{ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; }' is not assignable to type 'Extra'.
+    Property 'target_categories' is missing in type '{ id: string; name: string; price: number; category: "border"; active: boolean; }' but required in type 'Extra'.
+tests/unit/extras-page.test.ts(64,27): error TS2345: Argument of type '({ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; })[]' is not assignable to parameter of type 'Extra[]'.
+  Type '{ id: string; name: string; price: number; category: "border"; active: boolean; } | { id: string; name: string; price: number; category: "other"; active: boolean; } | { id: string; name: string; price: number; category: "flavor"; active: boolean; }' is not assignable to type 'Extra'.
+    Property 'target_categories' is missing in type '{ id: string; name: string; price: number; category: "border"; active: boolean; }' but required in type 'Extra'.
+tests/unit/heavy-components-smoke.test.tsx(131,33): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/heavy-components-smoke.test.tsx(134,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(142,25): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(622,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(622,39): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(623,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(624,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(625,5): error TS18046: 'customerTextarea.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(627,5): error TS18046: 'pickerButton.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(653,5): error TS18046: 'tabInput.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(654,5): error TS18046: 'tabButton.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(674,56): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(677,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(678,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(679,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(680,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(681,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(763,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{ id: string; }' is missing the following properties from type 'MenuItem': tenant_id, product_id, category_id, name, and 6 more.
+      Type 'UseFormReturn<{ name: string; description: string; price: number; category_id: string; display_order: number; }, any, { name: string; description: string; price: number; category_id: string; display_order: number; }>' is not assignable to type 'UseFormReturn<MenuItemFormValues>'.
+        Types of property 'watch' are incompatible.
+          Type 'UseFormWatch<{ name: string; description: string; price: number; category_id: string; display_order: number; }>' is not assignable to type 'UseFormWatch<MenuItemFormValues>'.
+            Type 'string | undefined' is not assignable to type 'string'.
+              Type 'undefined' is not assignable to type 'string'.
+tests/unit/heavy-components-smoke.test.tsx(764,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{ id: string; }' is missing the following properties from type 'MenuItem': tenant_id, product_id, category_id, name, and 6 more.
+      Type 'UseFormReturn<{ name: string; description: string; price: number; category_id: string; display_order: number; }, any, { name: string; description: string; price: number; category_id: string; display_order: number; }>' is not assignable to type 'UseFormReturn<MenuItemFormValues>'.
+        Types of property 'watch' are incompatible.
+          Type 'UseFormWatch<{ name: string; description: string; price: number; category_id: string; display_order: number; }>' is not assignable to type 'UseFormWatch<MenuItemFormValues>'.
+            Type 'string | undefined' is not assignable to type 'string'.
+              Type 'undefined' is not assignable to type 'string'.
+tests/unit/heavy-components-smoke.test.tsx(811,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type 'UseFormReturn<{ name: string; description: string; price: number; category_id: string; display_order: number; }, any, { name: string; description: string; price: number; category_id: string; display_order: number; }>' is not assignable to type 'UseFormReturn<MenuItemFormValues>'.
+      Types of property 'watch' are incompatible.
+        Type 'UseFormWatch<{ name: string; description: string; price: number; category_id: string; display_order: number; }>' is not assignable to type 'UseFormWatch<MenuItemFormValues>'.
+          Type 'string | undefined' is not assignable to type 'string'.
+            Type 'undefined' is not assignable to type 'string'.
+tests/unit/heavy-components-smoke.test.tsx(837,56): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(841,9): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(842,9): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(843,16): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(845,82): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(847,48): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(847,83): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(853,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(854,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(855,5): error TS2571: Object is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(855,31): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(856,5): error TS18046: 'ingredientSelect.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(857,5): error TS18046: 'ingredientQuantityInput.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(858,5): error TS18046: 'ingredientQuantityInput.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(859,5): error TS18046: 'extraCheckbox.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(860,11): error TS18046: 'formElement.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(901,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{ id: string; }' is missing the following properties from type 'MenuItem': tenant_id, product_id, category_id, name, and 6 more.
+      Type '{ control: {}; formState: { isSubmitting: boolean; errors: { root: { message: string; }; }; }; handleSubmit: (callback: (values: Record<string, unknown>) => unknown) => () => unknown; }' is missing the following properties from type 'UseFormReturn<MenuItemFormValues>': watch, getValues, getFieldState, setError, and 9 more.
+tests/unit/heavy-components-smoke.test.tsx(902,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{ id: string; }' is missing the following properties from type 'MenuItem': tenant_id, product_id, category_id, name, and 6 more.
+      Type '{ control: {}; formState: { isSubmitting: boolean; errors: { root: { message: string; }; }; }; handleSubmit: (callback: (values: Record<string, unknown>) => unknown) => () => unknown; }' is missing the following properties from type 'UseFormReturn<MenuItemFormValues>': watch, getValues, getFieldState, setError, and 9 more.
+tests/unit/heavy-components-smoke.test.tsx(925,82): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(926,5): error TS18046: 'extraCheckbox.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(933,48): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(933,83): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(935,5): error TS18046: 'quantityInput.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(940,5): error TS18046: 'cancelButton.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(1035,11): error TS18046: 'formElement.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(1062,11): error TS18046: 'formElement.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(1089,11): error TS18046: 'formElement.props' is of type 'unknown'.
+tests/unit/heavy-components-smoke.test.tsx(1116,11): error TS18046: 'formElement.props' is of type 'unknown'.
+tests/unit/install-banner-component.test.tsx(32,33): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/install-banner-component.test.tsx(35,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/install-banner-component.test.tsx(43,25): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/install-banner-component.test.tsx(185,11): error TS18046: 'installButton.props' is of type 'unknown'.
+tests/unit/install-banner-component.test.tsx(231,5): error TS18046: 'dismissButton.props' is of type 'unknown'.
+tests/unit/install-banner-component.test.tsx(272,11): error TS18046: 'installButton.props' is of type 'unknown'.
+tests/unit/install-banner-component.test.tsx(427,18): error TS18046: 'installButton.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(52,33): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/integrations-page.test.tsx(55,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(63,25): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(84,34): error TS2345: Argument of type '{ tenant_id: string; delivery_enabled: true; flat_fee: number; }' is not assignable to parameter of type 'DeliverySettingsShape'.
+  Type '{ tenant_id: string; delivery_enabled: true; flat_fee: number; }' is missing the following properties from type 'DeliverySettingsShape': accepting_orders, schedule_enabled, opens_at, closes_at
+tests/unit/integrations-page.test.tsx(109,39): error TS2345: Argument of type '{ tenant_id: string; delivery_enabled: true; flat_fee: number; }' is not assignable to parameter of type 'DeliverySettingsShape'.
+  Type '{ tenant_id: string; delivery_enabled: true; flat_fee: number; }' is missing the following properties from type 'DeliverySettingsShape': accepting_orders, schedule_enabled, opens_at, closes_at
+tests/unit/integrations-page.test.tsx(376,56): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(379,48): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(383,5): error TS18046: 'deliveryInput.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(385,5): error TS2571: Object is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(385,52): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(386,5): error TS2571: Object is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(386,52): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(391,16): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(392,24): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(396,5): error TS2571: Object is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(397,5): error TS2571: Object is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(398,5): error TS2571: Object is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(399,5): error TS2571: Object is of type 'unknown'.
+tests/unit/integrations-page.test.tsx(646,52): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type '{ connected: true; accountLoading: false; accountData: { mercado_pago_user_id: string; live_mode: true; token_expires_at: string; }; disconnectPending: false; onDisconnect: Mock<Procedure>; ... 13 more ...; onToggleWhatsappOption: Mock<...>; }' is not assignable to parameter of type 'Attributes & Props'.
+      Type '{ connected: true; accountLoading: false; accountData: { mercado_pago_user_id: string; live_mode: true; token_expires_at: string; }; disconnectPending: false; onDisconnect: Mock<Procedure>; ... 13 more ...; onToggleWhatsappOption: Mock<...>; }' is missing the following properties from type 'Props': openingHourValue, closingHourValue, onDeliveryScheduleChange, onDeliveryHoursChange, onDeliveryHoursSave
+tests/unit/integrations-page.test.tsx(700,52): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type '{ connected: true; accountLoading: false; accountData: { mercado_pago_user_id: string; live_mode: true; token_expires_at: string; }; disconnectPending: false; onDisconnect: Mock<Procedure>; ... 13 more ...; onToggleWhatsappOption: Mock<...>; }' is not assignable to parameter of type 'Attributes & Props'.
+      Type '{ connected: true; accountLoading: false; accountData: { mercado_pago_user_id: string; live_mode: true; token_expires_at: string; }; disconnectPending: false; onDisconnect: Mock<Procedure>; ... 13 more ...; onToggleWhatsappOption: Mock<...>; }' is missing the following properties from type 'Props': openingHourValue, closingHourValue, onDeliveryScheduleChange, onDeliveryHoursChange, onDeliveryHoursSave
+tests/unit/kds-page.test.tsx(24,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/kds-page.test.tsx(32,25): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/kds-page.test.tsx(99,18): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{ id: string; order_number: number; status: string; created_at: string; table_number: number; notes: string; items: { id: string; name: string; quantity: number; notes: string; extras: { id: string; name: string; }[]; }[]; }' is missing the following properties from type 'Order': tenant_id, customer_name, customer_phone, customer_cpf, and 8 more.
+tests/unit/kds-page.test.tsx(112,18): error TS2740: Type '{ id: string; order_number: number; status: string; created_at: string; table_number: number; notes: string; items: { id: string; name: string; quantity: number; notes: string; extras: { id: string; name: string; }[]; }[]; }' is missing the following properties from type 'Order': tenant_id, customer_name, customer_phone, customer_cpf, and 8 more.
+tests/unit/kds-page.test.tsx(121,24): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/kds-page.test.tsx(125,5): error TS18046: 'advanceButton.props' is of type 'unknown'.
+tests/unit/kds-page.test.tsx(187,16): error TS2740: Type '{ id: string; order_number: number; status: string; created_at: string; table_number: null; notes: null; items: { id: string; name: string; quantity: number; notes: null; extras: never[]; }[]; }' is missing the following properties from type 'Order': tenant_id, customer_name, customer_phone, customer_cpf, and 8 more.
+tests/unit/kds-page.test.tsx(195,24): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/kds-page.test.tsx(198,27): error TS18046: 'advanceButton.props' is of type 'unknown'.
+tests/unit/kds-page.test.tsx(199,12): error TS18046: 'advanceButton.props' is of type 'unknown'.
+tests/unit/kds-page.test.tsx(217,18): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{ id: string; order_number: number; status: "delivered"; created_at: string; table_number: null; notes: null; items: never[]; }' is missing the following properties from type 'Order': tenant_id, customer_name, customer_phone, customer_cpf, and 8 more.
+tests/unit/menu-client-component.test.tsx(1532,5): error TS2349: This expression is not callable.
+  Type 'never' has no call signatures.
+tests/unit/mesas-page-component.test.tsx(146,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/mesas-page-component.test.tsx(151,10): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(57,33): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/plans-delivery-page-content.test.tsx(60,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(68,25): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(89,80): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type '{ currentPlan: string; currentSubscription: { status: string; plan: string; next_payment_date: string; cancel_at_period_end: boolean; }; loadingPlan: null; onSelectPlan: Mock<Procedure>; onCancelSubscription: Mock<...>; }' is not assignable to parameter of type 'Attributes & Props'.
+      Type '{ currentPlan: string; currentSubscription: { status: string; plan: string; next_payment_date: string; cancel_at_period_end: boolean; }; loadingPlan: null; onSelectPlan: Mock<Procedure>; onCancelSubscription: Mock<...>; }' is not assignable to type 'Props'.
+        Types of property 'currentPlan' are incompatible.
+          Type 'string' is not assignable to type 'Plan | undefined'.
+tests/unit/plans-delivery-page-content.test.tsx(96,77): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type '{ currentPlan: string; currentSubscription: { status: string; plan: string; next_payment_date: string; cancel_at_period_end: boolean; }; loadingPlan: null; onSelectPlan: Mock<Procedure>; onCancelSubscription: Mock<...>; }' is not assignable to parameter of type 'Attributes & Props'.
+      Type '{ currentPlan: string; currentSubscription: { status: string; plan: string; next_payment_date: string; cancel_at_period_end: boolean; }; loadingPlan: null; onSelectPlan: Mock<Procedure>; onCancelSubscription: Mock<...>; }' is not assignable to type 'Props'.
+        Types of property 'currentPlan' are incompatible.
+          Type 'string' is not assignable to type 'Plan | undefined'.
+tests/unit/plans-delivery-page-content.test.tsx(97,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(97,76): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(148,89): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type '{ canManage: boolean; activeDrivers: number; isLoading: boolean; drivers: { id: string; name: string; phone: string; vehicle_type: string; notes: string; active: boolean; }[]; openCreate: Mock<Procedure>; ... 16 more ...; submitDisabled: boolean; }' is not assignable to parameter of type 'Attributes & Props'.
+      Type '{ canManage: boolean; activeDrivers: number; isLoading: boolean; drivers: { id: string; name: string; phone: string; vehicle_type: string; notes: string; active: boolean; }[]; openCreate: Mock<Procedure>; ... 16 more ...; submitDisabled: boolean; }' is not assignable to type 'Props'.
+        Types of property 'drivers' are incompatible.
+          Type '{ id: string; name: string; phone: string; vehicle_type: string; notes: string; active: boolean; }[]' is not assignable to type 'DeliveryDriver[]'.
+            Type '{ id: string; name: string; phone: string; vehicle_type: string; notes: string; active: boolean; }' is missing the following properties from type 'DeliveryDriver': tenant_id, created_at, updated_at
+tests/unit/plans-delivery-page-content.test.tsx(155,86): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type '{ canManage: boolean; activeDrivers: number; isLoading: boolean; drivers: { id: string; name: string; phone: string; vehicle_type: string; notes: string; active: boolean; }[]; openCreate: Mock<Procedure>; ... 16 more ...; submitDisabled: boolean; }' is not assignable to parameter of type 'Attributes & Props'.
+      Type '{ canManage: boolean; activeDrivers: number; isLoading: boolean; drivers: { id: string; name: string; phone: string; vehicle_type: string; notes: string; active: boolean; }[]; openCreate: Mock<Procedure>; ... 16 more ...; submitDisabled: boolean; }' is not assignable to type 'Props'.
+        Types of property 'drivers' are incompatible.
+          Type '{ id: string; name: string; phone: string; vehicle_type: string; notes: string; active: boolean; }[]' is not assignable to type 'DeliveryDriver[]'.
+            Type '{ id: string; name: string; phone: string; vehicle_type: string; notes: string; active: boolean; }' is missing the following properties from type 'DeliveryDriver': tenant_id, created_at, updated_at
+tests/unit/plans-delivery-page-content.test.tsx(161,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(161,46): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(162,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(162,46): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(163,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(163,46): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(164,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(164,30): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(165,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(165,30): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(166,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(166,30): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(167,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(168,5): error TS18046: 'textarea.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(227,7): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{ id: string; name: string; phone: string; vehicle_type: "moto"; notes: string; active: true; }' is missing the following properties from type 'DeliveryDriver': tenant_id, created_at, updated_at
+tests/unit/plans-delivery-page-content.test.tsx(254,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(254,51): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(262,9): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Type '{ id: string; name: string; phone: string; vehicle_type: "carro"; notes: string; active: false; }' is missing the following properties from type 'DeliveryDriver': tenant_id, created_at, updated_at
+tests/unit/plans-delivery-page-content.test.tsx(299,44): error TS18046: 'element.props' is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(302,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(303,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-delivery-page-content.test.tsx(304,5): error TS18046: 'form.props' is of type 'unknown'.
+tests/unit/plans-page.test.tsx(275,63): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/plans-page.test.tsx(276,30): error TS18046: 'input.props' is of type 'unknown'.
+tests/unit/plans-page.test.tsx(279,5): error TS2571: Object is of type 'unknown'.
+tests/unit/plans-page.test.tsx(473,20): error TS2339: Property 'onSelectPlan' does not exist on type 'never'.
+tests/unit/plans-page.test.tsx(554,26): error TS2339: Property 'onSelectPlan' does not exist on type 'never'.
+tests/unit/plans-page.test.tsx(612,20): error TS2339: Property 'onSelectPlan' does not exist on type 'never'.
+tests/unit/plans-page.test.tsx(699,26): error TS2339: Property 'onCancelSubscription' does not exist on type 'never'.
+tests/unit/plans-page.test.tsx(700,20): error TS2339: Property 'onSelectPlan' does not exist on type 'never'.
+tests/unit/produtos-page-component.test.tsx(155,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/produtos-page-component.test.tsx(159,10): error TS2571: Object is of type 'unknown'.
+tests/unit/produtos-page-component.test.tsx(348,7): error TS18046: 'categorySelect.props' is of type 'unknown'.
+tests/unit/produtos-page-component.test.tsx(351,7): error TS18046: 'statusSelect.props' is of type 'unknown'.
+tests/unit/public-menu.test.tsx(382,27): error TS2345: Argument of type '{ readonly id: "item-1"; readonly tenant_id: "tenant-1"; readonly category_id: null; readonly name: "Suco"; readonly description: null; readonly price: 8; readonly available: true; readonly display_order: 1; readonly category: null; readonly extras: readonly []; }' is not assignable to parameter of type 'PublicMenuItem'.
+  Types of property 'extras' are incompatible.
+    The type 'readonly []' is 'readonly' and cannot be assigned to the mutable type '{ extra: MenuExtra | null; }[]'.
+tests/unit/public-menu.test.tsx(1513,58): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/unit/public-menu.test.tsx(1699,58): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/unit/public-menu.test.tsx(1756,58): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/unit/public-menu.test.tsx(1813,58): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/unit/public-menu.test.tsx(1880,58): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/unit/react-query-hooks.test.ts(42,18): error TS2352: Conversion of type 'UseQueryResult<DeliveryDriver[], Error>' to type '{ queryKey: unknown; queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<DeliveryDriver[], Error>' is missing the following properties from type '{ queryKey: unknown; queryFn: () => Promise<unknown>; }': queryKey, queryFn
+tests/unit/react-query-hooks.test.ts(51,20): error TS2352: Conversion of type 'UseMutationResult<DeliveryDriver, Error, DriverPayload, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<DeliveryDriver, Error, DriverPayload, unknown>, { mutate: UseMutateFunction<DeliveryDriver, Error, DriverPayload, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(60,20): error TS2352: Conversion of type 'UseMutationResult<DeliveryDriver, Error, DriverPayload & { id: string; }, unknown>' to type '{ mutationFn: (payload: { id: string; name: string; vehicle_type: string; }) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<DeliveryDriver, Error, DriverPayload & { id: string; }, unknown>, { mutate: UseMutateFunction<...>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: { id: string; name: string; vehicle_type: string; }) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(69,20): error TS2352: Conversion of type 'UseMutationResult<{ id: string; }, Error, string, unknown>' to type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<{ id: string; }, Error, string, unknown>, { mutate: UseMutateFunction<{ id: string; }, Error, string, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(104,27): error TS2352: Conversion of type 'UseQueryResult<DeliverySettings, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<DeliverySettings, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(108,30): error TS2352: Conversion of type 'UseMutationResult<DeliverySettings, Error, Omit<DeliverySettings, "tenant_id">, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<DeliverySettings, Error, Omit<DeliverySettings, "tenant_id">, unknown>, { ...; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(116,24): error TS2352: Conversion of type 'UseQueryResult<NotificationSettings, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<NotificationSettings, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(120,27): error TS2352: Conversion of type 'UseMutationResult<NotificationSettings, Error, Omit<NotificationSettings, "tenant_id">, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<NotificationSettings, Error, Omit<NotificationSettings, "tenant_id">, unknown>, { ...; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(152,32): error TS2352: Conversion of type 'UseQueryResult<NotificationSettings, Error>' to type '{ enabled: boolean; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'enabled' is missing in type 'QueryObserverPlaceholderResult<NotificationSettings, Error>' but required in type '{ enabled: boolean; }'.
+tests/unit/react-query-hooks.test.ts(159,29): error TS2352: Conversion of type 'UseQueryResult<OnboardingSteps, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<OnboardingSteps, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(163,26): error TS2352: Conversion of type 'UseMutationResult<OnboardingSteps, Error, Partial<Omit<OnboardingSteps, "id" | "tenant_id" | "completed_at">>, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: (data: unknown) => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<OnboardingSteps, Error, Partial<Omit<OnboardingSteps, "id" | "tenant_id" | "completed_at">>, unknown>, { ...; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: (data: unknown) => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(171,21): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(175,24): error TS2352: Conversion of type 'UseMutationResult<any, Error, void, unknown>' to type '{ mutationFn: () => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, void, unknown>, { mutate: UseMutateFunction<any, Error, void, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: () => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(207,20): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryKey: unknown; queryFn: () => Promise<unknown>; refetchInterval: number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<any, Error>' is missing the following properties from type '{ queryKey: unknown; queryFn: () => Promise<unknown>; refetchInterval: number; }': queryKey, queryFn, refetchInterval
+tests/unit/react-query-hooks.test.ts(223,33): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(227,37): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(233,26): error TS2352: Conversion of type 'UseMutationResult<any, Error, { id: string; status: OrderStatus; delivery_driver_id?: string | null | undefined; delivery_status?: DeliveryStatus | null | undefined; cancelled_reason?: string | undefined; }, unknown>' to type '{ mutationFn: (payload: { id: string; status: string; }) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, { id: string; status: OrderStatus; delivery_driver_id?: string | null | undefined; delivery_status?: DeliveryStatus | null | undefined; cancelled_reason?: string | undefined; }, unknown>, { ...; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: { id: string; status: string; }) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(241,25): error TS2352: Conversion of type 'UseMutationResult<any, Error, CreateOrderPayload, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, CreateOrderPayload, unknown>, { mutate: UseMutateFunction<any, Error, CreateOrderPayload, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(249,31): error TS2352: Conversion of type 'UseMutationResult<any, Error, CreateOrderPayload, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, CreateOrderPayload, unknown>, { mutate: UseMutateFunction<any, Error, CreateOrderPayload, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(260,23): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(264,28): error TS2352: Conversion of type 'UseMutationResult<any, Error, { name: string; description?: string | undefined; price: number; category_id?: string | undefined; available?: boolean | undefined; display_order?: number | undefined; }, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, { name: string; description?: string | undefined; price: number; category_id?: string | undefined; available?: boolean | undefined; display_order?: number | undefined; }, unknown>, { ...; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(272,21): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; refetchInterval: number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<any, Error>' is missing the following properties from type '{ queryFn: () => Promise<unknown>; refetchInterval: number; }': queryFn, refetchInterval
+tests/unit/react-query-hooks.test.ts(280,17): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; refetchInterval: number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<any, Error>' is missing the following properties from type '{ queryFn: () => Promise<unknown>; refetchInterval: number; }': queryFn, refetchInterval
+tests/unit/react-query-hooks.test.ts(331,23): error TS2352: Conversion of type 'UseQueryResult<TenantPlan, Error>' to type '{ queryKey: unknown; queryFn: () => Promise<unknown>; staleTime: number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<TenantPlan, Error>' is missing the following properties from type '{ queryKey: unknown; queryFn: () => Promise<unknown>; staleTime: number; }': queryKey, queryFn, staleTime
+tests/unit/react-query-hooks.test.ts(444,23): error TS2352: Conversion of type 'UseQueryResult<TenantPlan, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<TenantPlan, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(459,22): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(465,35): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(469,39): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(475,27): error TS2352: Conversion of type 'UseMutationResult<any, Error, CreateProductPayload, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, CreateProductPayload, unknown>, { mutate: UseMutateFunction<any, Error, CreateProductPayload, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(480,27): error TS2352: Conversion of type 'UseMutationResult<any, Error, Partial<CreateProductPayload> & { active?: boolean | undefined; } & { id: string; }, unknown>' to type '{ mutationFn: (payload: { id: string; }) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, Partial<CreateProductPayload> & { active?: boolean | undefined; } & { id: string; }, unknown>, { ...; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: { id: string; }) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(485,24): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(489,21): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(493,34): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(497,38): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(501,20): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(505,23): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(509,36): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<any, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(513,28): error TS2352: Conversion of type 'UseMutationResult<any, Error, CreateMovementPayload, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, CreateMovementPayload, unknown>, { mutate: UseMutateFunction<any, Error, CreateMovementPayload, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(518,22): error TS2352: Conversion of type 'UseMutationResult<any, Error, void, unknown>' to type '{ mutationFn: () => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, void, unknown>, { mutate: UseMutateFunction<any, Error, void, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: () => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(572,20): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; refetchInterval: number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<any, Error>' is missing the following properties from type '{ queryFn: () => Promise<unknown>; refetchInterval: number; }': queryFn, refetchInterval
+tests/unit/react-query-hooks.test.ts(577,25): error TS2352: Conversion of type 'UseMutationResult<any, Error, { id: string; number?: string | undefined; capacity?: number | undefined; }, unknown>' to type '{ mutationFn: (payload: { id: string; }) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, { id: string; number?: string | undefined; capacity?: number | undefined; }, unknown>, { mutate: UseMutateFunction<...>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: { id: string; }) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(582,25): error TS2352: Conversion of type 'UseMutationResult<any, Error, string, unknown>' to type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, string, unknown>, { mutate: UseMutateFunction<any, Error, string, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(587,25): error TS2352: Conversion of type 'UseMutationResult<any, Error, CreateTablePayload, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, CreateTablePayload, unknown>, { mutate: UseMutateFunction<any, Error, CreateTablePayload, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(592,25): error TS2352: Conversion of type 'UseMutationResult<any, Error, OpenSessionPayload, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, OpenSessionPayload, unknown>, { mutate: UseMutateFunction<any, Error, OpenSessionPayload, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(597,26): error TS2352: Conversion of type 'UseMutationResult<any, Error, string, unknown>' to type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, string, unknown>, { mutate: UseMutateFunction<any, Error, string, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(602,21): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; enabled: boolean; refetchInterval: number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<any, Error>' is missing the following properties from type '{ queryFn: () => Promise<unknown>; enabled: boolean; refetchInterval: number; }': queryFn, enabled, refetchInterval
+tests/unit/react-query-hooks.test.ts(608,18): error TS2352: Conversion of type 'UseQueryResult<any, Error>' to type '{ queryFn: () => Promise<unknown>; refetchInterval: number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<any, Error>' is missing the following properties from type '{ queryFn: () => Promise<unknown>; refetchInterval: number; }': queryFn, refetchInterval
+tests/unit/react-query-hooks.test.ts(613,23): error TS2352: Conversion of type 'UseMutationResult<any, Error, CreateTabPayload, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, CreateTabPayload, unknown>, { mutate: UseMutateFunction<any, Error, CreateTabPayload, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(618,22): error TS2352: Conversion of type 'UseMutationResult<any, Error, string, unknown>' to type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, string, unknown>, { mutate: UseMutateFunction<any, Error, string, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(623,19): error TS2352: Conversion of type 'UseQueryResult<UsersResponse, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<UsersResponse, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(627,23): error TS2352: Conversion of type 'UseQueryResult<Customer[], Error>' to type '{ queryKey: unknown; queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'QueryObserverPlaceholderResult<Customer[], Error>' is missing the following properties from type '{ queryKey: unknown; queryFn: () => Promise<unknown>; }': queryKey, queryFn
+tests/unit/react-query-hooks.test.ts(632,24): error TS2352: Conversion of type 'UseMutationResult<any, Error, { full_name: string; email: string; password: string; role: EstablishmentRole; }, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, { full_name: string; email: string; password: string; role: EstablishmentRole; }, unknown>, { ...; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: unknown) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(637,24): error TS2352: Conversion of type 'UseMutationResult<any, Error, { id: string; role: EstablishmentRole; }, unknown>' to type '{ mutationFn: (payload: { id: string; role: string; }) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, { id: string; role: EstablishmentRole; }, unknown>, { mutate: UseMutateFunction<any, Error, { ...; }, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (payload: { id: string; role: string; }) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(642,24): error TS2352: Conversion of type 'UseMutationResult<any, Error, string, unknown>' to type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'Override<MutationObserverSuccessResult<any, Error, string, unknown>, { mutate: UseMutateFunction<any, Error, string, unknown>; }> & { ...; }' is missing the following properties from type '{ mutationFn: (id: string) => Promise<unknown>; onSuccess: () => void; }': mutationFn, onSuccess
+tests/unit/react-query-hooks.test.ts(703,19): error TS2352: Conversion of type 'UseQueryResult<DeliveryDriver[], Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<DeliveryDriver[], Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(709,19): error TS2352: Conversion of type 'UseQueryResult<UsersResponse, Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<UsersResponse, Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(710,23): error TS2352: Conversion of type 'UseQueryResult<Customer[], Error>' to type '{ queryFn: () => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'queryFn' is missing in type 'QueryObserverPlaceholderResult<Customer[], Error>' but required in type '{ queryFn: () => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(711,24): error TS2352: Conversion of type 'UseMutationResult<any, Error, { full_name: string; email: string; password: string; role: EstablishmentRole; }, unknown>' to type '{ mutationFn: (payload: unknown) => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'mutationFn' is missing in type 'Override<MutationObserverSuccessResult<any, Error, { full_name: string; email: string; password: string; role: EstablishmentRole; }, unknown>, { ...; }> & { ...; }' but required in type '{ mutationFn: (payload: unknown) => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(714,24): error TS2352: Conversion of type 'UseMutationResult<any, Error, { id: string; role: EstablishmentRole; }, unknown>' to type '{ mutationFn: (payload: { id: string; role: string; }) => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'mutationFn' is missing in type 'Override<MutationObserverSuccessResult<any, Error, { id: string; role: EstablishmentRole; }, unknown>, { mutate: UseMutateFunction<any, Error, { ...; }, unknown>; }> & { ...; }' but required in type '{ mutationFn: (payload: { id: string; role: string; }) => Promise<unknown>; }'.
+tests/unit/react-query-hooks.test.ts(717,24): error TS2352: Conversion of type 'UseMutationResult<any, Error, string, unknown>' to type '{ mutationFn: (id: string) => Promise<unknown>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Property 'mutationFn' is missing in type 'Override<MutationObserverSuccessResult<any, Error, string, unknown>, { mutate: UseMutateFunction<any, Error, string, unknown>; }> & { ...; }' but required in type '{ mutationFn: (id: string) => Promise<unknown>; }'.
+tests/unit/sidebar-component.test.tsx(51,68): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/sidebar-component.test.tsx(53,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/sidebar-component.test.tsx(61,25): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/sidebar-component.test.tsx(100,11): error TS18046: 'logoutButton.props' is of type 'unknown'.
+tests/unit/sidebar-component.test.tsx(135,11): error TS18046: 'logoutButton.props' is of type 'unknown'.
+tests/unit/sidebar-component.test.tsx(192,11): error TS18046: 'logoutButton.props' is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(82,33): error TS2349: This expression is not callable.
+  Not all constituents of type 'JSXElementConstructor<any>' are callable.
+    Type 'new (props: any, context: any) => Component<any, any, any>' has no call signatures.
+tests/unit/stock-page-content.test.tsx(85,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(389,16): error TS18046: 'entry.props' is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(390,58): error TS18046: 'entry.props' is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(393,5): error TS2571: Object is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(394,5): error TS2571: Object is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(395,5): error TS2571: Object is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(396,5): error TS2571: Object is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(397,5): error TS2571: Object is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(398,5): error TS18046: 'form.props' is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(454,5): error TS18046: 'movementSelect.props' is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(458,52): error TS18046: 'entry.props' is of type 'unknown'.
+tests/unit/stock-page-content.test.tsx(460,5): error TS18046: 'cancelButton.props' is of type 'unknown'.
+tests/unit/supabase-clients.test.ts(67,60): error TS2493: Tuple type '[]' of length '0' has no element at index '2'.
+tests/unit/supabase-clients.test.ts(68,12): error TS18048: 'options' is possibly 'undefined'.
+tests/unit/supabase-clients.test.ts(69,5): error TS18048: 'options' is possibly 'undefined'.
+tests/unit/ui-primitives.test.tsx(9,82): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'.
+tests/unit/ui-primitives.test.tsx(17,37): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'.
+tests/unit/ui-primitives.test.tsx(25,45): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Object literal may only specify known properties, and 'ref' does not exist in type 'Partial<unknown> & Attributes'.
+tests/unit/ui-primitives.test.tsx(27,59): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'.
+tests/unit/ui-primitives.test.tsx(33,84): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'.
+tests/unit/ui-primitives.test.tsx(40,45): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Object literal may only specify known properties, and 'ref' does not exist in type 'Partial<unknown> & Attributes'.
+tests/unit/ui-primitives.test.tsx(42,59): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'.
+tests/unit/ui-primitives.test.tsx(125,69): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'.
+tests/unit/ui-primitives.test.tsx(262,17): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Object literal may only specify known properties, and ''data-state'' does not exist in type 'Attributes & ClassAttributes<HTMLTableRowElement> & HTMLAttributes<HTMLTableRowElement>'.
+tests/unit/vendas-page-component.test.tsx(59,36): error TS18046: 'node.props' is of type 'unknown'.
+tests/unit/vendas-page-component.test.tsx(102,50): error TS18046: 'button.props' is of type 'unknown'.
+tests/unit/vendas-page-component.test.tsx(116,7): error TS18046: 'monthButton.props' is of type 'unknown'.


### PR DESCRIPTION

# Descrição
Este PR remove a funcionalidade de vincular manualmente "Itens Adicionais" a itens individuais do cardápio dentro do diálogo de edição. Esta mudança foi solicitada para evitar duplicidade e conflitos, uma vez que o sistema agora utiliza uma gestão centralizada e automática de extras (vinculada via categorias ou regras globais).

## Mudanças Realizadas
- **Frontend (Dashboard)**:
Remoção da seção "Itens adicionais" no componente MenuItemDialog.
Limpeza de props, estados e chamadas de API (GET e PUT de extras) no CardapioPage que eram exclusivas para essa funcionalidade.
- **Refatoração de Código**:
Remoção de diversos helpers e tipos em dashboard-menu-page.ts que se tornaram obsoletos (ex: getSelectableMenuExtras, toggleMenuExtraSelection, groupMenuExtrasByCategory).
- **Testes**:
Atualização dos testes de fumaça em heavy-components-smoke.test.tsx para remover validações de interface e comportamento de extras no diálogo de itens do cardápio.

## Impacto
Simplificação do processo de cadastro de produtos no cardápio.
Redução de complexidade no código do dashboard.
Garantia de que a configuração de adicionais siga o novo padrão centralizado da plataforma.